### PR TITLE
[codex] Group Dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    # Keep routine version bumps quiet while grouping real security fixes.
+    open-pull-requests-limit: 0
+    groups:
+      python-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ This app provides interactive tools to explore exceptional points and transmissi
 
 ## Installation 
 
+Use Python 3.10 or newer. The current PyArrow security release no longer supports Python 3.9.
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements.txt
+```
+
 ### Libraries
 Qublitz is hosted as a Streamlit app. The relevant libraries for installation are as follows:
 - `streamlit`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 streamlit==1.39.0
 plotly==5.24.1
-pyarrow==16.1.0
+pyarrow==23.0.1
 numpy==1.26.4
 scipy==1.12.0
 pandas==2.2.3


### PR DESCRIPTION
## Summary

- Bump `pyarrow` from `16.1.0` to the first patched release, `23.0.1`.
- Add `.github/dependabot.yml` so pip security fixes are grouped into one PR while routine version-bump PRs remain disabled.
- Document the Python 3.10+ runtime requirement and a clean virtual-environment setup.

## Why

GitHub Dependabot alert [#66](https://github.com/mvwf/qublitz/security/dependabot/66) flags the repository's explicit PyArrow pin for CVE-2026-25087. Apache notes that the affected C++ pre-buffering path is not exposed through the Python bindings, but keeping a package in the affected range still leaves the repository flagged and creates recurring alert noise.

This change removes the flagged version and makes future security update traffic actionable without disabling vulnerability detection.

## Validation

- Installed the complete `requirements.txt` dependency set with Python 3.11.
- Imported Streamlit, PyArrow, QuTiP, the scientific stack, and `quantum_simulator` successfully.
- Verified Arrow IPC round-tripping and Streamlit DataFrame-to-Arrow marshalling.
- Parsed and checked the Dependabot YAML configuration.
