### PR TITLE
Add Juan to README contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ For the Step Pulse Challenge, you should take the existing `3_gates_challenge.py
 For help or advice email: 
 neo.y.cai.25@dartmouth.edu 
 mattias.w.fitzpatrick@dartmouth.edu
-
+juan.sebastian.salcedo-gallo.th@dartmouth.edu


### PR DESCRIPTION
## Summary

Add Juan Sebastián Salcedo-Gallo's Dartmouth email address to the README contact section:

`juan.sebastian.salcedo-gallo.th@dartmouth.edu`
