### PR TITLE
Add QuBlitz Arena: a gate-level quantum battle game with a real Lindblad physics engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main, "feature/**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # qutip 4.7.6 has no cp312 wheel, so it builds from source and needs a
+      # BLAS/LAPACK development library available on the runner.
+      - name: Install BLAS for the qutip source build
+        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Lint (ruff)
+        run: ruff check .
+
+      - name: Smoke tests (pytest)
+        run: pytest -q
+
+      # The embedded game (C02-T4) vendors quantum_chess.html + its physics
+      # regression test under pages/_assets/. Run it when present.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Game physics regression test
+        if: ${{ hashFiles('pages/_assets/tests/qphysics.test.js') != '' }}
+        run: node pages/_assets/tests/qphysics.test.js pages/_assets/quantum_chess.html

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ generate_qubits.py
 user_parameters.json
 venv_st/
 venv_qublitz/
+.venv/
 utils/__pycache__/*
 __pycache__/*
 ### Streamlit secrets

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/*
 __pycache__/
 ### Streamlit secrets
 *.toml
+!ruff.toml
 .streamlit/secrets.toml
 
 # Never commit roster / secrets / local server

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ venv_qublitz/
 .venv/
 utils/__pycache__/*
 __pycache__/*
+__pycache__/
 ### Streamlit secrets
 *.toml
 .streamlit/secrets.toml
@@ -19,3 +20,4 @@ net_IDs.csv
 .secrets.toml
 to_recycle/
 .DS_Store
+.pytest_cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to Qublitz
+
+Thanks for contributing! This guide covers the local development setup and the
+**verification gate** every change must pass before it is pushed or opened as a PR.
+
+## Local setup
+
+Qutip 4.7.6 has no wheel for Python 3.13, so use **Python 3.12**:
+
+```bash
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-dev.txt    # app deps + pytest + ruff
+```
+
+On macOS, the qutip source build needs BLAS: `brew install openblas`.
+On Debian/Ubuntu: `sudo apt-get install -y libopenblas-dev`.
+
+Run the app with `streamlit run home.py`.
+
+## The verification gate — run it GREEN before every push / PR
+
+```bash
+bash scripts/verify.sh
+```
+
+This runs exactly what CI runs:
+
+1. **ruff** — correctness lint (pyflakes + syntax).
+2. **pytest** — smoke tests: every page must load without raising
+   (`tests/test_pages_smoke.py`), plus the QuBlitz Arena page test.
+3. **node** — the game's physics regression test, once the game is vendored.
+
+It prints a single `VERIFY: PASS ✓` / `FAIL ✗` and exits non-zero on any failure.
+CI (`.github/workflows/ci.yml`) enforces the same checks on push and PR.
+
+## Pull-request checklist
+
+- `bash scripts/verify.sh` is green.
+- Branch named for the feature (e.g. `feature/qublitz-arena`).
+- Commit messages follow `scope: imperative description` (e.g.
+  `perf: cache mesolve in quantum_simulator`).
+- PR description says **what** changed, **why**, and **how to test**, with a
+  screenshot for any UI change.
+- New/changed functions have docstrings.

--- a/docs/PR_REVIEW_GUIDE.md
+++ b/docs/PR_REVIEW_GUIDE.md
@@ -1,0 +1,301 @@
+# PR Review Guide: `quantum_chess.html`
+
+This repo vendors `pages/_assets/quantum_chess.html` — the QuBlitz Arena game — as a
+single ~4,000-line HTML/CSS/JS file. It is realistically unreviewable cold: there is
+no build step and no module boundaries to lean on, so a reviewer scanning a diff has
+no map of what region of the file they're looking at or why it matters. This doc is
+that map. Read it once (~10 minutes), then jump to whichever anchors your PR touches
+(~another ~10 minutes) — that should get you from clone to an informed
+approve/request-changes in about 20 minutes total.
+
+**Line-number caveat:** every line number below was read from the *canonical*
+upstream source at `QuBlitz Project/quantum_chess.html` (4,322 lines as of this
+writing), not from this repo's vendored copy at `pages/_assets/quantum_chess.html`
+(currently 4,058 lines — it predates some canonical changes and will be refreshed in
+a follow-up PR). Numbers will drift once that refresh lands. Anchor on the function
+and variable **names** below (`QPhysics`, `lindbladStep`, `guardCritProb`, etc.) — all
+of them are `grep`-stable — and treat line numbers as "was roughly here," not exact
+addresses.
+
+## 1. Orientation
+
+QuBlitz Arena is a gate-level tactics game that teaches quantum mechanics by making
+its game mechanics *be* the physics: every unit on the board is a qubit, every
+action button is a quantum gate, and combat is resolved by literally measuring a
+unit's state. A player charges a unit toward `|1⟩` (excited, "ready to strike") or
+into superposition, closes to melee range before T1/T2 decoherence bleeds the charge
+away, and attacks — which performs a Born-rule projective measurement on the
+attacker. The GUARD stance measures a defender in the X-basis instead of the Z-basis,
+which makes relative phase (Z/S/T gates) mechanically consequential rather than
+cosmetic, and CNOT produces a real two-qubit Bell pair with correlated,
+no-communication-respecting collapse.
+
+It's one file by design, not by neglect: the game must stay a single self-contained
+file that opens standalone in Chrome with no build step and no CDN dependencies (the
+one external reference is a Google Fonts `@import` for display type — everything that
+touches game logic is inline). That constraint is why you'll find CSS, markup, and
+all of the JS — physics engine, bot AI, renderer, UI glue — concatenated into one
+`<html>` document instead of split into modules.
+
+It's embedded in this repo by `pages/QuBlitz_Arena.py`, which is a thin Streamlit
+wrapper: `_load_game_html()` reads `pages/_assets/quantum_chess.html` as a raw string
+(cached via `@st.cache_data`), and `_render_embed()` passes it to
+`st.components.v1.html(..., height=920, scrolling=True)`, which renders it inside an
+iframe. The Python side does exactly one piece of injection before handing the HTML
+off: if a `QB_SAGE_PROXY_URL` is configured (env var or Streamlit secrets), it
+prepends `<script>window.QB_SAGE_PROXY=...</script>` so the game can find its AI-Sage
+proxy endpoint (see anchor 7 below). With no proxy configured, the script tag is
+simply omitted and the game falls back to its offline heuristic Sage — no error, no
+missing feature, just a different advice source.
+
+## 2. The 10 anchor points
+
+All line numbers below are from the canonical file at
+`/Users/davidmukuruva/Desktop/Academics/Projects/QuBlitz Project/quantum_chess.html`.
+
+### 2.1 The physics engine object — `QPhysics`
+**`const QPhysics = (() => {...})();`, opens at line 1081, closes ~1282 (returns
+at 1278-1280, IIFE closes 1281, self-test auto-runs 1282-1285).**
+
+This is the whole quantum-state math layer: Bloch-vector conversions
+(`blochFromPure`/`pureFromBloch`), `charge`, `guardCritProb`, the Lindblad
+decoherence step, the density-matrix gate-application layer (`rhoFromBloch`,
+`gateBloch`, `gateMatrix`), the `Bell` entanglement sub-object, Z-basis `measure`,
+and the `diagnose`/`selfTest` regression harness. It is written with **no DOM
+dependency** — it never touches `document` or `GAME` — specifically so it can be
+extracted verbatim into a Node test file (see anchor 3 and section 3). **Check on
+change:** does the diff preserve that DOM-independence? Any new function here that
+reaches for `document.*` or a global game-state object breaks the extraction trick
+`tests/qphysics.test.js` relies on, and silently stops the physics regression suite
+from testing the real code.
+
+### 2.2 Born-rule measurement / combat resolution
+**Three sites, by design (see anchor 6 for why there are two attack-resolution
+paths):**
+- Line 1204: `QPhysics.measure` — "Born-rule projective measurement in the Z basis,"
+  `Math.random() < charge(r)`, collapses to `{x:0,y:0,z:±1}`.
+- Line 1420-1439: `BotAI.resolveAttack(attacker, target, rng)` — the pure,
+  headlessly-testable port of the in-browser `attack()` function's combat math: a
+  Born-rule "fire roll" (`rng() < pAtt`), then the GUARD X-basis measurement
+  (`GATES.H(target.state)` then a Z-basis draw), crit detection, and damage.
+- The live in-browser call site is `attack()` around line 2010-2043, which as of the
+  "GD-1" comment there now delegates to `BotAI.resolveAttack` for the actual math
+  rather than re-implementing it, so the browser and the test harness provably run
+  the same formula.
+
+**Check on change:** if someone edits the fire-roll or crit formula in one of these
+three places, did they edit (or at least re-verify) the other two? A drift between
+`BotAI.resolveAttack` and the in-browser caller would mean the tests are no longer
+testing what players actually experience.
+
+### 2.3 The Lindblad decoherence step — `lindbladStep`
+**`function lindbladStep(r, { T1, T2, dt = 1 })`, line 1113-1118.**
+
+This is the exact analytical solution to the open-quantum-system (Lindblad
+master-equation) decay for amplitude damping (T1) and dephasing (T2) applied to a
+Bloch vector: `x,y` decay by `e^(-dt/T2)`, `z` relaxes toward `+1` (ground state) by
+`e^(-dt/T1)`, with `T2` clamped to `≤ 2·T1` (the physical constraint). This is the
+single most physics-correctness-critical function in the file — it is what the
+falsifiability harness (`diagnose`, anchor 3 / section 3) exists to validate, and
+it's the function every "charge bleeds away over time" mechanic in the game
+ultimately calls. **Check on change:** any edit here should come with an updated
+`node tests/qphysics.test.js` run showing R²(exponential) still > 0.99 and the fitted
+T1 still recovering the input T1 — a hand-wavy "decay felt better this way" edit
+here would break the game's core physics claim.
+
+### 2.4 The GUARD crit rule — `guardCritProb`
+**`const guardCritProb = pureOrBloch => {...}`, line 1104-1107.**
+
+`guardCritProb = (1 − x) / 2`, where `x` is the Bloch x-component. The comment above
+it (lines 1099-1103) explains the reasoning: a GUARDing unit is measured in the
+X-basis rather than the Z-basis, so its chance of being caught in the "excited"
+outcome of *that* basis is `P(|−⟩)`. This makes relative phase — otherwise invisible
+to the Z-basis `charge` a player watches all game — mechanically real: `|+⟩` (x=+1)
+is crit-immune under GUARD, `|−⟩` (x=−1) is fully exposed, and `|0⟩`/`|1⟩` (x=0, no
+defined phase) are a coin flip. This is called out in the project's own docs as a
+genuine pedagogical invention (not a textbook mechanic) precisely because it's the
+one place phase management has a stakes-bearing payoff — a reviewer should understand
+*why* the formula is `(1-x)/2` and not just accept that it is, since it's the
+justification for GUARD existing as a mechanic at all. **Check on change:** does an
+edit preserve the property that pure `|+⟩`/`|−⟩` states hit the 0%/100% extremes, and
+does the in-game copy (Physics Lab tooltip text, GUARD button explainer text) stay in
+sync with the formula if it changes?
+
+### 2.5 The Bell-pair / entanglement state — `Bell`
+**`const Bell = (() => {...})();`, line 1133-1181, nested inside `QPhysics`.**
+
+Models a shared 4-amplitude two-qubit state `[c00,c01,c10,c11]`. `phiPlus()`
+constructs `|Φ+⟩ = (|00⟩+|11⟩)/√2` (what CNOT produces from `|+⟩⊗|0⟩`);
+`marginalP1(a, which)` computes a single qubit's marginal `P(|1⟩)` by summing over
+the partner; `applyLocal(a, which, U)` applies a 2×2 unitary to *only one* qubit's
+half of the joint state (tensored with identity on the other); `measure(a, which,
+rand)` performs a correlated projective measurement and returns the renormalized
+post-collapse state plus both outcomes. The comment at lines 1130-1132 flags that
+this replaces older code that applied a gate directly to the entangled partner — "the
+#1 entanglement misconception" — so this correctness is a deliberate fix, not
+incidental. Use-sites reach it via `bell.amps` (the stored joint-state array on an
+entangled unit pair) and `Bell.applyLocal`/`Bell.measure`. **Check on change:** does a
+local gate on one half of a pair still leave the partner's `marginalP1` provably
+unchanged (no-communication)? Does measuring one half still force a fully correlated
+outcome on the other? `tests/qphysics.test.js` asserts both — re-run it after any
+`Bell` edit.
+
+### 2.6 The bot AI module — `BotAI`
+**`const BotAI = (() => {...})();`, opens line 1297, closes 1441-1442.**
+
+A newer, pure/DOM-free module (`scoreMoveSpots`, `pickTarget`, `chooseAction`,
+`resolveAttack`) extracted from the logic that used to live only inline inside the
+browser's `doBotMove()`/`attack()` functions — specifically so the bot's decision
+policy and combat math can be exercised headlessly in a test harness
+(`tests/bot_guard_harness.test.js`, see section 4) instead of only being verifiable
+by clicking through games in a browser. This is the same extraction pattern
+`QPhysics` itself already used (anchor 1): keep the logic that needs to be correct
+free of `document`/DOM reads so it can be lifted out of the HTML file verbatim by a
+Node test via source-text extraction (`findBlock()` regex matching, not a copy —
+so the test always runs the *actual* shipped code). `chooseAction` in particular
+encodes a fairly detailed decision cascade (numbered priority: kill shot → scheduled
+guard → defensive measure → CNOT setup → guard-preferred → charge-up → take-the-shot)
+with inline comments explaining each branch's rationale (e.g. "GD-1" comments
+throughout, about making the bot actually use GUARD against X-only opponents).
+**Check on change:** does a change to bot behavior stay inside this pure module
+(testable) or leak DOM/`GAME`-global reads back into it (untestable, and liable to
+silently diverge from what `attack()`'s live call site does — see anchor 2)?
+
+### 2.7 The Sage proxy boundary — `SAGE_PROXY_URL`
+**`const SAGE_PROXY_URL = ...`, line 3955-3957; used at the `fetch()` call ~line
+3994.**
+
+Security model: the client HTML never holds an API key. It only ever holds a proxy
+*URL*, read from `window.QB_SAGE_PROXY` (a global the embedding page — see
+`pages/QuBlitz_Arena.py`'s `_render_embed()` — injects via a `<script>` tag only when
+a proxy is actually configured). If that global isn't set, `SAGE_PROXY_URL` is `''`,
+`_sageEnabled()` returns `false`, and the game silently falls back to its offline
+heuristic Sage — no key prompt, no broken feature, no exfiltration risk. The actual
+Anthropic API key lives server-side in `sage_proxy.py`, which holds the key and
+issues the real Claude calls behind a rate limiter. That file is **not** part of this
+fork — it lives in the canonical game repo at
+`/Users/davidmukuruva/Desktop/Academics/Projects/QuBlitz Project/sage_proxy.py` — so
+if a PR touches Sage behavior, the proxy-side code that actually needs a security
+review isn't in this diff at all; go read it there. **Check on change:** does any
+new code path in this file read, log, or forward anything that looks like a
+credential? The invariant to hold is "this file only ever sees a URL."
+
+### 2.8 Board / turn state — `GAME`
+**`const GAME = {...};`, line 1696 (through ~1728, initial literal; mutated
+throughout the file after).**
+
+The central mutable game-state object: `pieces` (the qubit units), `turn`/`phase`
+(whose move, and whether the UI is mid-menu), `selected`/`reachable` (current
+selection + cached legal moves), `turnCount`/`turnCap` (the 60-turn cap that decides
+the game if no one is eliminated), `mode`/`botColor`/`difficulty`, `decoRate` (feeds
+`QPhysics.timesFromRate`), `cnotMode`/`attackMode` (two-step target-picking UI
+state), plus a grab-bag of presentation state (`particles`, `deaths`, `fx`, `shake`,
+`floats`, `beamFlash`) and campaign/vote-mode fields. **Check on change:** this
+object is read and mutated from a lot of places in the file — a new field added here
+should have a comment explaining what owns it, and a reviewer should check whether
+`resetGame()` (just below it) was updated to reset the new field between games.
+
+### 2.9 The renderer — canvas draw functions
+**`grep -n "^function draw" quantum_chess.html`** turns up the main entry points:
+`drawSprite` (1468), `drawCharFrame` (1677), `drawSageNPC` (2260), `drawBoard`
+(2301), `drawHighlights` (2372), `drawEntanglementBeams` (2428), `drawPiece` (2467),
+`drawDeaths` (2572), `drawFx` (2575), `drawParticles` (2585), `drawGateMenu` (2659),
+`drawTurnBanner` (2786), `drawOverlay` (2820), `drawBloch` (2873, the live
+Bloch-sphere panel), `drawFloats` (3331, floating damage/crit numbers), and
+`drawDecoherenceDiagram` (4132, the Physics Lab's decay-curve visualization). **Check
+on change:** canvas drawing is inherently hard to review from a text diff — a
+one-character coordinate or color change can silently break layout. This is exactly
+what the screenshot set (section 5) exists to catch; if a PR touches any `draw*`
+function, expect (and ask for) a fresh screenshot, not just code review.
+
+### 2.10 UI panels / DOM rendering
+**Side-panel population, keyed on the DOM ids `sel-eq` (line 323 CSS, 772 markup,
+populated ~2953-2975) and `sel-xbasis` (778 markup, populated ~2957-2975).** These
+elements show the selected unit's live `|ψ⟩` equation and its X-basis readout; the
+populating code sits in the same function that also computes and displays
+`guardCritProb` for the current selection (anchor 4) — so a phase-formula change and
+its UI readout are adjacent and should be reviewed together. The Sage panel's own
+rendering (advice text, badge state via `_updateClaudeBadge()`) lives near the Sage
+proxy code (anchor 7, ~3960-3980). **Check on change:** does the displayed equation
+text / X-basis readout actually match the underlying Bloch vector after a physics
+change, or is it reading stale/mismatched state?
+
+## 3. The console self-tests
+
+`QPhysics` ships two verification entry points, both exposed on `window` at the
+bottom of the IIFE (line ~1282-1285) and auto-run once at load (`QPhysics.selfTest()`
+is called immediately, logging to console):
+
+- **`QPhysics.selfTest()`** (defined 1253-1276) — a fast, synchronous set of 8 exact
+  analytic-value checks: `H|0⟩ → |+⟩`, `X|0⟩ → |1⟩` (z=-1), `Z` preserves z, `charge(|1⟩)=1`,
+  `charge(|+⟩)=0.5`, one Lindblad step matches `e^(-1/T1)`/`e^(-1/T2)` exactly, and
+  `T2` clamps to `≤2·T1`. Returns `{ pass: boolean, tests: [[name, bool], ...] }` and
+  also logs a one-line summary (`console.log`/`console.error`) — `"QPhysics
+  self-test: 8/8 passed ✓"` on success, or lists failing test names.
+- **`window.runDecoherenceDiagnostic(opts)`** — a thin wrapper (line 1284) around
+  **`QPhysics.diagnose({ decoRate, turns })`** (defined 1229-1252): starts a unit
+  fully excited (`z=-1`), steps it through `lindbladStep` for `turns` steps, fits the
+  resulting charge-vs-turn curve to both an exponential and a straight line, and
+  reports R² for each plus the recovered T1. A passing/healthy result is
+  R²(exponential) close to 1.000 and clearly greater than R²(linear), with the
+  recovered T1 close to the input T1 — this is the falsifiability check that a real
+  physical decay model, not an arbitrary curve, is driving the game.
+
+**How a reviewer runs them:** open `quantum_chess.html` directly in Chrome (or the
+Streamlit-embedded version), open devtools, and in the console run
+`QPhysics.selfTest()` and `runDecoherenceDiagnostic()`. The in-game Physics Lab panel
+also surfaces this — it calls `QPhysics.diagnose({decoRate, turns:24})` (line 4135)
+and renders it as `drawDecoherenceDiagram`, and the panel's own footer text (lines
+4123, 4275) tells the player to run the same two console calls themselves.
+
+## 4. How to run the verification gates
+
+**In this repo:** `bash scripts/verify.sh`. Reading it (`scripts/verify.sh`, 40
+lines), it runs three checks in sequence and prints a single PASS/FAIL:
+1. `ruff check .` — lint.
+2. `pytest -q` — the Python smoke test suite.
+3. **Conditionally**, `node pages/_assets/tests/qphysics.test.js
+   pages/_assets/quantum_chess.html` — but only if
+   `pages/_assets/tests/qphysics.test.js` exists (i.e. the game's test file has been
+   vendored alongside the HTML) **and** `node` is on `PATH`; otherwise it prints
+   "SKIPPED: node not installed" and doesn't fail the gate. As of this writing that
+   vendored test file does exist in this repo (`pages/_assets/tests/qphysics.test.js`,
+   byte-identical to the canonical copy) and is exercised by `verify.sh` whenever
+   Node is available.
+
+**In the canonical game repo**, there are two Node test files worth knowing about
+(found by listing its `tests/` directory directly — don't assume just one exists):
+- `node tests/qphysics.test.js` — the physics regression suite described in section
+  3; this is the one currently vendored into this fork.
+- `node tests/bot_guard_harness.test.js` — a newer, **not yet vendored** headless
+  bot-vs-bot harness for the "GD-1" bot-guard behavior work (anchor 6). It uses the
+  same source-extraction technique (regex-matched block extraction straight out of
+  `quantum_chess.html`, no copy-paste) to pull out `C`, `GATES`, `QPhysics`, and now
+  `BotAI` as well, then drives a headless simulated game around
+  `BotAI.chooseAction`/`BotAI.resolveAttack` to check that a Medium-difficulty bot
+  actually uses GUARD to punish an "X-only" opponent. Since it isn't vendored into
+  `pages/_assets/tests/` yet, `scripts/verify.sh` does not currently run it — a
+  reviewer who wants to check `BotAI` changes against it needs to run it directly
+  against the canonical file, or wait for a follow-up PR that vendors it the same way
+  `qphysics.test.js` was vendored.
+
+## 5. The screenshot set
+
+Visual regression reference lives outside both repos, at
+`/Users/davidmukuruva/Desktop/Academics/Projects/_arena_screenshots/`. As of this
+writing it contains: `00_arena_streamlit_full.png`, `01_menu.png`, `02_board_play.png`,
+`03_selected_plus.png`, `04_guard_minus.png`, `05_bell_pair.png`,
+`06_sage_expanded.png`, `07_physics_lab.png`, plus a second pass (`v2_10_arena_top.png`,
+`v2_11_arena_full.png`, `v2_12_game_menu.png`, `v2_13_game_fit_768.png` — the last
+being a 768px tablet-width capture) and a third-pass pair
+(`v3_arena_top.png`, `v3_concept_map.png`).
+
+These should be re-captured after any UI-affecting change (anything touching a
+`draw*` function, panel layout, or CSS) and eyeballed against the existing set —
+not just diffed as text. A prior LLM-council review of this project found five
+defects in these screenshots that a code-only review would not have caught (layout
+clipping, contrast/legibility issues, and similar visual-only problems). Treat the
+screenshot set the way you'd treat a snapshot test: regenerate, look at it, and
+specifically check the tablet-width (768px) capture and the Sage/Physics-Lab panels,
+since those are the ones with the most dynamic content and the most history of
+clipping.

--- a/home.py
+++ b/home.py
@@ -1,9 +1,9 @@
 import streamlit as st
-from PIL import Image
+from utils.branding import load_logo
 def main():
     # Display main image and logo side by side
-    main_img = Image.open("images/qublitz.png")
-    logo_img = Image.open("images/logo.png")
+    main_img = load_logo("images/qublitz.png")
+    logo_img = load_logo("images/logo.png")
     col1, col2 = st.columns([1,1])
     with col1:
         st.image(main_img, width=345)

--- a/home.py
+++ b/home.py
@@ -13,6 +13,7 @@ def main():
     st.write("Welcome to Qublitz!")
 
     st.page_link("home.py", label="Home", icon="🏠")
+    st.page_link("pages/QuBlitz_Arena.py", label="QuBlitz Arena", icon="⚔️")
     st.page_link("pages/Sonify.py", label="Sonify Images", icon="🎵")
     st.page_link("pages/Qubit_Simulator.py", label="Qubit Simulator", icon="⚛")
     st.page_link("pages/Quantum_Measurement_Tutorial.py", label="Quantum Measurement Tutorial", icon="🎮")

--- a/pages/Custom_Qubit_Query.py
+++ b/pages/Custom_Qubit_Query.py
@@ -21,8 +21,8 @@ from typing import Dict, Any, Optional
 import numpy as np
 import pandas as pd
 import streamlit as st
+from utils.branding import load_logo
 import requests
-from PIL import Image
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
@@ -798,11 +798,11 @@ def page():
     user_data = st.session_state["user_data"]
 
     try:
-        st.sidebar.image(Image.open("images/qublitz.png"))
+        st.sidebar.image(load_logo("images/qublitz.png"))
     except Exception:
         pass
     try:
-        st.sidebar.image(Image.open("images/logo.png"))
+        st.sidebar.image(load_logo("images/logo.png"))
     except Exception:
         pass
 

--- a/pages/Custom_Qubit_Query.py
+++ b/pages/Custom_Qubit_Query.py
@@ -963,16 +963,11 @@ def page():
         st.markdown("### Time-domain results")
         st.caption("Use this tab mainly to extract T₁ from the post-pulse decay. The Rabi-rate fit is now taken from the peak-frequency time trace in the Frequency Domain tab.")
 
-        if st.session_state.get("td_out") is None:
-            try:
-                st.session_state["td_out"] = run_time_domain(
-                    omega_q, omega_rabi, T1_ns, float(omega_d),
-                    float(t_final), sx_sched, sy_sched, int(shots),
-                )
-            except Exception:
-                st.session_state["td_out"] = None
-
-        if st.button("Re-run simulation with current settings", key="td_run"):
+        # Gate the (expensive) mesolve behind an explicit button instead of
+        # auto-solving on every fresh page load / refresh (C02-T12).
+        _td_has_result = st.session_state.get("td_out") is not None
+        _td_run_label = "Re-run simulation with current settings" if _td_has_result else "Run simulation"
+        if st.button(_td_run_label, key="td_run"):
             try:
                 st.session_state["td_out"] = run_time_domain(
                     omega_q, omega_rabi, T1_ns, float(omega_d),
@@ -983,6 +978,9 @@ def page():
                 st.exception(e)
 
         out_td = st.session_state.get("td_out")
+
+        if out_td is None:
+            st.info("Set your parameters above and click **Run simulation** to solve the time-domain dynamics.")
 
         if out_td is not None:
             fit_summary = _analyze_time_domain_fits(out_td["tlist"], out_td["p1_meas"], sx_sched, sy_sched)

--- a/pages/EP_TPD_exploration.py
+++ b/pages/EP_TPD_exploration.py
@@ -21,6 +21,39 @@ color_marker_dict = {
     "ROGUE_TPD": ("gray", "diamond-open")
 }
 
+
+@st.cache_data(show_spinner=False)
+def _compute_ep_tpd_fields(phi, kappa_tilde_c):
+    """Cached 500x500 Petermann-factor field computation.
+
+    A pure function of (phi, kappa_tilde_c) — the only slider-driven inputs — so
+    moving an unrelated widget no longer rebuilds the 250k-element complex grids
+    on every rerun. Returns (K_color, K_gray, instability, min_petermann, disc, tilde_q).
+    """
+    x1 = np.linspace(-4, 4, 500)
+    y1 = np.linspace(-4, 4, 500)
+    X, Y = np.meshgrid(x1, y1)
+
+    Delta_tilde_lambda = np.sqrt(-Y ** 2 + 2j * Y * X + X ** 2 - 4 * np.exp(1j * phi))
+    Delta_tilde_lambda_mod_squared = abs(Delta_tilde_lambda) ** 2
+    K_2_tilde = (Y ** 2 + X ** 2 + Delta_tilde_lambda_mod_squared + 4) / (2 * Delta_tilde_lambda_mod_squared)
+
+    tilde_q = ((kappa_tilde_c - X) * (Delta_tilde_lambda ** 2).imag) / 8
+    tilde_p = (((kappa_tilde_c - X) ** 2) + (Delta_tilde_lambda ** 2).real) / 4
+    disc = -4 * (tilde_p ** 3) - 27 * (tilde_q ** 2)
+    instability = (Delta_tilde_lambda.real) - (kappa_tilde_c - X)
+    if phi == 0 or phi == 2 * np.pi:
+        min_petermann = X
+    elif phi == np.pi:
+        min_petermann = Y
+    else:
+        min_petermann = (-1 / np.tan(phi / 2)) * X - Y
+
+    K_color = np.where(instability <= 0, K_2_tilde, np.nan)  # plasma region
+    K_gray = np.where(instability > 0, K_2_tilde, np.nan)    # grayscale region
+    return K_color, K_gray, instability, min_petermann, disc, tilde_q
+
+
 # function: plots contours
 def plot_contours(fig, contour, x, y, color, linestyle, linewidth, label):
     fig.add_trace(go.Contour(
@@ -137,37 +170,17 @@ def main():
     phi = phi_labels[phi_label]
     # phi = st.sidebar.slider("Φ - Coupling Phase (rad)", 0.0, (2 * np.pi), 0.0, step=0.01) # Option for if we want a continuous slider
 
-    # define x and y axis for the plot (x is Delta_tilde_kappa and y is Delta_tilde_f)
+    # x/y axes for the plots (x is Delta_tilde_kappa, y is Delta_tilde_f); the
+    # heavy 500x500 field math is cached on (phi, kappa_tilde_c) — see _compute_ep_tpd_fields.
     x1 = np.linspace(-4, 4, 500)
     y1 = np.linspace(-4, 4, 500)
-    X, Y = np.meshgrid(x1, y1)
-
-    # define modulus squared of Delta_tilde_lambda in terms of X and Y
-    Delta_tilde_lambda = np.sqrt(-Y ** 2 + 2j * Y * X + X ** 2 - 4 * np.exp(1j * phi))
-    Delta_tilde_lambda_mod_squared = abs(Delta_tilde_lambda) ** 2
-
-    # petermann Factor
-    K_2_tilde = (Y ** 2 + X ** 2 + Delta_tilde_lambda_mod_squared + 4) / (2 * Delta_tilde_lambda_mod_squared)
-
-    # contour values
-    tilde_q = ((kappa_tilde_c - X) * (Delta_tilde_lambda ** 2).imag) / 8
-    tilde_p = (((kappa_tilde_c - X) ** 2) + (Delta_tilde_lambda ** 2).real) / 4
-    disc = -4 * (tilde_p ** 3) - 27 * (tilde_q ** 2)
-    instability = (Delta_tilde_lambda.real) - (kappa_tilde_c - X)
-    if phi == 0 or phi == 2 * np.pi:
-        min_petermann = X
-    elif phi == np.pi:
-            min_petermann = Y
-    else:
-            min_petermann = (-1 / np.tan(phi / 2)) * X - Y
+    K_color, K_gray, instability, min_petermann, disc, tilde_q = _compute_ep_tpd_fields(
+        float(phi), float(kappa_tilde_c)
+    )
 
     # compute degeneracy locations
     eps = ep_location(phi)
     tpds = tpd_location(phi, kappa_tilde_c)
-
-    # mask the petermann factor into two regions
-    K_color = np.where(instability <= 0, K_2_tilde, np.nan)  # plasma region
-    K_gray = np.where(instability > 0, K_2_tilde, np.nan)   # grayscale region
 
     # plot petermann factor color map
     fig1 = go.Figure()

--- a/pages/EP_TPD_exploration.py
+++ b/pages/EP_TPD_exploration.py
@@ -7,11 +7,11 @@ Release Date:
 """
 
 import streamlit as st
+from utils.branding import load_logo
 import numpy as np
 import plotly.graph_objects as go
 from utils.tpd_locations_nd import ep_location, tpd_location
 from utils.pt_peaks_MODEL import peak_location, eigenvalues
-from PIL import Image
 # map degeneracy type to color and marker
 color_marker_dict = {
     "PRIMARY_EP": ("red", "x-thin"),
@@ -83,9 +83,9 @@ def main():
     # create a title for the page
     st.title("Exceptional Point and Transmission Peak Degeneracy Locations")
 
-    qublitz_logo = Image.open("images/qublitz.png")
+    qublitz_logo = load_logo("images/qublitz.png")
     st.sidebar.image(qublitz_logo)
-    logo = Image.open("images/logo.png") 
+    logo = load_logo("images/logo.png") 
     st.sidebar.image(logo) # display logo on the side 
     st.sidebar.markdown('<div style="text-align:center;"><a href="https://sites.google.com/view/fitzlab/home" target="_blank" style="font-size:1.2rem; font-weight:bold;">FitzLab Website</a></div>', unsafe_allow_html=True)
     

--- a/pages/EP_TPD_exploration.py
+++ b/pages/EP_TPD_exploration.py
@@ -350,7 +350,7 @@ def main():
     plot_trace(fig2, [instability_val, instability_val], [ymin, ymax], 'Instability', None, (instability_val != None), dict(width=4, color='chartreuse'))
 
     fig2.update_layout(
-        title=f"Primary EP and TPD Peak Splitting",
+        title="Primary EP and TPD Peak Splitting",
         title_font = dict(size=25),
         xaxis_title = x2_label,
         yaxis_title = "Frequency [arb.]",

--- a/pages/IQ_mixer.py
+++ b/pages/IQ_mixer.py
@@ -20,13 +20,13 @@ from scipy.fft import fftshift, fft
 import plotly.graph_objects as go
 import plotly.subplots as sp
 import streamlit as st
-from PIL import Image
+from utils.branding import load_logo
 
 def main():
     st.title("IQ Mixing Demo")
-    qublitz_logo = Image.open("images/qublitz.png")
+    qublitz_logo = load_logo("images/qublitz.png")
     st.sidebar.image(qublitz_logo)
-    logo = Image.open("images/logo.png") 
+    logo = load_logo("images/logo.png") 
     st.sidebar.image(logo) # display logo on the side 
     
     st.sidebar.markdown('<div style="text-align:center;"><a href="https://sites.google.com/view/fitzlab/home" target="_blank" style="font-size:1.2rem; font-weight:bold;">FitzLab Website</a></div>', unsafe_allow_html=True)

--- a/pages/IQ_mixer.py
+++ b/pages/IQ_mixer.py
@@ -15,14 +15,8 @@ Release Date:
 # Date: 07/27/2025
 
 
-from qutip import basis, sigmaz, sigmax, sigmay, mesolve, sigmam, Options
 import numpy as np
-import matplotlib.pyplot as plt
-from matplotlib import use
-from matplotlib.colors import Normalize
-from qutip import *
-from scipy.fft import fftshift, fft, ifft
-from matplotlib.widgets import Slider
+from scipy.fft import fftshift, fft
 import plotly.graph_objects as go
 import plotly.subplots as sp
 import streamlit as st

--- a/pages/QuBlitz_Arena.py
+++ b/pages/QuBlitz_Arena.py
@@ -1,21 +1,129 @@
+"""QuBlitz Arena — David Mukuruva's contribution to the Fitzpatrick Lab platform.
+
+Embeds the QuBlitz battle game (a self-contained quantum_chess.html) and frames
+it as an academic learning tool: every game action maps to a real quantum
+concept, and the in-engine physics is the same unit-tested open-quantum-system
+model the simulator pages use.
+
+Sage AI: the embedded game's Sage runs on a smart offline heuristic out of the
+box (no key, nothing to configure). If a server-side proxy URL is provided via
+``st.secrets["QB_SAGE_PROXY_URL"]`` (or the env var of the same name), the live
+Claude Sage is enabled by injecting it as ``window.QB_SAGE_PROXY`` — the API key
+itself lives only on that proxy, never in this page or the client HTML.
+"""
+import json
+import os
+from pathlib import Path
+
 import streamlit as st
+
+from utils.branding import load_logo
+
+_GAME_HTML = Path(__file__).parent / "_assets" / "quantum_chess.html"
+
+
+@st.cache_data(show_spinner=False)
+def _load_game_html() -> str:
+    return _GAME_HTML.read_text(encoding="utf-8")
+
+
+def _sage_proxy_url() -> str:
+    """Server-side Sage proxy URL, or '' for the offline heuristic Sage.
+
+    Read from the QB_SAGE_PROXY_URL env var, falling back to st.secrets. The
+    Anthropic key is never read here — only the proxy URL — so no key can leak
+    into the client HTML.
+    """
+    url = os.environ.get("QB_SAGE_PROXY_URL", "")
+    if not url:
+        try:
+            url = st.secrets.get("QB_SAGE_PROXY_URL", "")  # type: ignore[attr-defined]
+        except Exception:
+            url = ""
+    return str(url or "")
+
+
+def _render_academic_framing():
+    st.markdown(
+        "**QuBlitz** is a quantum tactics game where every unit on the board is a **qubit**, "
+        "every action is a **quantum gate**, and combat resolves via the **Born rule**. It is "
+        "the interactive companion to this simulator: the same T₁/T₂ physics you explore on the "
+        "other pages drive the game's decoherence — so playing builds intuition for the math."
+    )
+
+    with st.expander("🎯 Learning objectives — what you'll reason about", expanded=True):
+        st.markdown(
+            "- **Superposition & state preparation** — drive a qubit between |0⟩, |1⟩, and |+⟩.\n"
+            "- **The Born rule** — measurement outcomes are probabilistic in the qubit's amplitudes.\n"
+            "- **Bloch-sphere state** — read a live qubit as a vector (the panel shows it each turn).\n"
+            "- **T₁/T₂ decoherence** — watch charge relax exponentially when a unit sits idle.\n"
+            "- **Relative phase** — discover why Z/S/T gates matter only through interference.\n"
+            "- **Entanglement & the no-communication theorem** — Bell pairs that collapse together."
+        )
+
+    with st.expander("🧭 Concept map — every action maps to real quantum mechanics"):
+        st.markdown(
+            "| In-game action | Quantum concept | In-engine rule |\n"
+            "|---|---|---|\n"
+            "| Charge with **X** / **H** | State preparation, superposition | X → |1⟩ (100%); H → |+⟩ (P(1)=50%) |\n"
+            "| **Attack** | Born rule | P(hit) = charge = P(|1⟩); a target in |1⟩ takes a CRITICAL |\n"
+            "| **Idle** a turn | T₁/T₂ relaxation (Lindblad) | charge ∝ e^(−t/T₁), coherence ∝ e^(−t/T₂) |\n"
+            "| **GUARD** | X-basis measurement, relative phase | crit risk = (1−x)/2; |+⟩ safe, |−⟩ exposed |\n"
+            "| **Z / S / T** | relative-phase rotation | invisible to charge — matters only via the GUARD's X-basis |\n"
+            "| **CNOT** | entanglement (Bell pair) | |Φ⁺⟩; measuring one collapses both; no faster-than-light signalling |\n"
+            "| **MEASURE** | projective collapse | |ψ⟩ → |0⟩ or |1⟩, then stabilizes the unit |\n"
+        )
+
+    with st.expander("🔬 The physics is real — and unit-tested"):
+        st.markdown(
+            "QuBlitz is not hand-waving flavor. Each unit evolves under the **exact Lindblad "
+            "master-equation solution** for amplitude damping (T₁) plus dephasing (T₂), the same "
+            "open-quantum-system model behind the simulator. Open the in-game **Physics Lab** to "
+            "inspect a live density matrix ρ. The engine ships with a regression suite that asserts:\n\n"
+            "- decoherence is **exponential** (R² > 0.99) and the fit recovers the input T₁ to within 1%,\n"
+            "- a CNOT makes a true Bell pair with **perfectly correlated** collapse, and\n"
+            "- a local gate on one half **never** changes the partner's marginal (no-communication)."
+        )
+
+    with st.expander("🎓 Research context"):
+        st.markdown(
+            "Built by **David Mukuruva** within the **Fitzpatrick Lab, Dartmouth College** "
+            "(PI: Prof. Mattias Fitzpatrick), as the game companion to the lab's qubit simulator. "
+            "The roadmap calibrates the game's decoherence to **real measured T₁/T₂**, connecting "
+            "the proposal's research questions — mapping BCTDS parameters to T₂ degradation, and "
+            "characterizing non-Markovian (HEOM) memory effects — to an interactive learning tool."
+        )
 
 
 def main():
     st.set_page_config(page_title="QuBlitz Arena", layout="wide")
 
-    st.title("⚔️ QuBlitz Arena")
-
-    st.markdown(
-        "**QuBlitz** is a quantum tactics game where every unit on the board is a qubit, "
-        "every action is a quantum gate, and combat resolves via the Born rule. Charge a "
-        "qubit (H/X), close in, and strike — a target caught in |1⟩ takes a critical hit, "
-        "while decoherence bleeds your charge away each turn. It is the game companion to "
-        "this simulator: the same T₁/T₂ physics you explore here drive the game's "
-        "decoherence model."
+    st.sidebar.image(load_logo("images/qublitz.png"))
+    st.sidebar.image(load_logo("images/logo.png"))
+    st.sidebar.markdown(
+        '<div style="text-align:center;"><a href="https://sites.google.com/view/fitzlab/home" '
+        'target="_blank" style="font-size:1.2rem; font-weight:bold;">FitzLab Website</a></div>',
+        unsafe_allow_html=True,
     )
 
-    st.info("🎮 Game loading coming in C02 — the playable board will embed here next cycle.")
+    st.title("⚔️ QuBlitz Arena")
+    _render_academic_framing()
+
+    st.markdown("### ▶ Play")
+    st.caption("Click the board, then: A=attack · H/X/Y/Z=charge · M=measure · C=CNOT · Space=end turn. Press ? for the Sage.")
+
+    proxy = _sage_proxy_url()
+    inject = f"<script>window.QB_SAGE_PROXY={json.dumps(proxy)};</script>" if proxy else ""
+    # Height covers the title bar + 800px board + side panels + event log.
+    st.components.v1.html(inject + _load_game_html(), height=1100, scrolling=True)
+
+    if proxy:
+        st.caption("✦ Live Claude Sage connected via a server-side proxy (the API key stays on the proxy).")
+    else:
+        st.caption(
+            "The offline heuristic Sage is active — it gives concept-linked, per-unit advice with no "
+            "API key. To enable the live Claude Sage, set `QB_SAGE_PROXY_URL` in the app secrets."
+        )
 
 
 if __name__ == "__main__":

--- a/pages/QuBlitz_Arena.py
+++ b/pages/QuBlitz_Arena.py
@@ -1,9 +1,13 @@
 """QuBlitz Arena — David Mukuruva's contribution to the Fitzpatrick Lab platform.
 
 Embeds the QuBlitz battle game (a self-contained quantum_chess.html) and frames
-it as an academic learning tool: every game action maps to a real quantum
+it as an academic learning companion: every game action maps to a real quantum
 concept, and the in-engine physics is the same unit-tested open-quantum-system
-model the simulator pages use.
+model the simulator pages use. The game ties decoherence and relative phase to
+real tactical stakes and motivates engagement with the concepts; the formal
+teaching happens on the Physics Lab screen and the concept map/cross-links
+below. Whether play transfers to durable understanding is a design goal this
+project intends to measure later, not a claim this page asserts as proven.
 
 Sage AI: the embedded game's Sage runs on a smart offline heuristic out of the
 box (no key, nothing to configure). If a server-side proxy URL is provided via
@@ -103,7 +107,9 @@ def _render_academic_framing():
         "**QuBlitz** is a quantum tactics game where every unit on the board is a **qubit**, "
         "every action is a **quantum gate**, and combat resolves via the **Born rule**. It is "
         "the interactive companion to this simulator: the same T₁/T₂ physics you explore on the "
-        "other pages drive the game's decoherence — so playing builds intuition for the math."
+        "other pages drive the game's decoherence — so decoherence and relative phase carry real "
+        "tactical stakes here, not just flavor text. Building intuition for the math is the goal; "
+        "the Physics Lab and concept map below do the formal teaching."
     )
 
     with st.expander(":material/track_changes: Learning objectives — what you'll reason about", expanded=True):
@@ -193,7 +199,7 @@ def main():
 
     st.title("QuBlitz Arena")
     st.caption(
-        "Learn quantum mechanics by playing it — every unit is a qubit, every move is a gate.  "
+        "Quantum mechanics with real stakes — every unit is a qubit, every move is a gate.  "
         "Click the board, then **A** attack · **H/X/Y/Z** charge · **M** measure · **C** entangle · "
         "**G** guard · **E** explain · **?** Sage."
     )

--- a/pages/QuBlitz_Arena.py
+++ b/pages/QuBlitz_Arena.py
@@ -20,6 +20,10 @@ import streamlit as st
 from utils.branding import load_logo
 
 _GAME_HTML = Path(__file__).parent / "_assets" / "quantum_chess.html"
+# Frame height tuned so the board + side panels + event log sit on one screen
+# without inner scroll on a typical laptop; the game caps the board by viewport
+# height (CSS min(...,100vh-…)) so it scales to fit this frame.
+_EMBED_HEIGHT = 860
 
 
 @st.cache_data(show_spinner=False)
@@ -27,20 +31,62 @@ def _load_game_html() -> str:
     return _GAME_HTML.read_text(encoding="utf-8")
 
 
+def _has_secrets_file() -> bool:
+    """True only if a Streamlit secrets.toml actually exists.
+
+    Accessing ``st.secrets`` with no secrets file makes Streamlit render a red
+    'No secrets found' error in the app, so we check first and skip it when none
+    is configured (the heuristic Sage is the no-secret default).
+    """
+    candidates = [
+        Path.cwd() / ".streamlit" / "secrets.toml",
+        Path.home() / ".streamlit" / "secrets.toml",
+    ]
+    return any(c.exists() for c in candidates)
+
+
 def _sage_proxy_url() -> str:
     """Server-side Sage proxy URL, or '' for the offline heuristic Sage.
 
-    Read from the QB_SAGE_PROXY_URL env var, falling back to st.secrets. The
-    Anthropic key is never read here — only the proxy URL — so no key can leak
-    into the client HTML.
+    Read from the QB_SAGE_PROXY_URL env var, falling back to st.secrets only when
+    a secrets file exists. The Anthropic key is never read here — only the proxy
+    URL — so no key can leak into the client HTML.
     """
     url = os.environ.get("QB_SAGE_PROXY_URL", "")
-    if not url:
+    if not url and _has_secrets_file():
         try:
             url = st.secrets.get("QB_SAGE_PROXY_URL", "")  # type: ignore[attr-defined]
         except Exception:
             url = ""
     return str(url or "")
+
+
+def _render_sidebar():
+    st.sidebar.image(load_logo("images/qublitz.png"))
+    st.sidebar.image(load_logo("images/logo.png"))
+    st.sidebar.markdown(
+        '<div style="text-align:center;"><a href="https://sites.google.com/view/fitzlab/home" '
+        'target="_blank" style="font-size:1.2rem; font-weight:bold;">FitzLab Website</a></div>',
+        unsafe_allow_html=True,
+    )
+
+
+def _render_embed():
+    proxy = _sage_proxy_url()
+    inject = f"<script>window.QB_SAGE_PROXY={json.dumps(proxy)};</script>" if proxy else ""
+    st.components.v1.html(inject + _load_game_html(), height=_EMBED_HEIGHT, scrolling=True)
+    if proxy:
+        st.success(
+            "Live Claude Sage connected via a server-side proxy — the API key stays on the "
+            "proxy, never in this page.",
+            icon=":material/verified:",
+        )
+    else:
+        st.info(
+            "The offline heuristic Sage is active — concept-linked, per-unit advice with no API "
+            "key. To enable the live Claude Sage, set `QB_SAGE_PROXY_URL` in the app secrets.",
+            icon=":material/auto_awesome:",
+        )
 
 
 def _render_academic_framing():
@@ -51,7 +97,7 @@ def _render_academic_framing():
         "other pages drive the game's decoherence — so playing builds intuition for the math."
     )
 
-    with st.expander("🎯 Learning objectives — what you'll reason about", expanded=True):
+    with st.expander(":material/track_changes: Learning objectives — what you'll reason about", expanded=True):
         st.markdown(
             "- **Superposition & state preparation** — drive a qubit between |0⟩, |1⟩, and |+⟩.\n"
             "- **The Born rule** — measurement outcomes are probabilistic in the qubit's amplitudes.\n"
@@ -61,20 +107,21 @@ def _render_academic_framing():
             "- **Entanglement & the no-communication theorem** — Bell pairs that collapse together."
         )
 
-    with st.expander("🧭 Concept map — every action maps to real quantum mechanics"):
+    with st.expander(":material/schema: Concept map — every action maps to real quantum mechanics"):
+        # Kets contain '|', the markdown table delimiter, so each is escaped as \| .
         st.markdown(
             "| In-game action | Quantum concept | In-engine rule |\n"
             "|---|---|---|\n"
-            "| Charge with **X** / **H** | State preparation, superposition | X → |1⟩ (100%); H → |+⟩ (P(1)=50%) |\n"
-            "| **Attack** | Born rule | P(hit) = charge = P(|1⟩); a target in |1⟩ takes a CRITICAL |\n"
+            "| Charge with **X** / **H** | State preparation, superposition | X → \\|1⟩ (100%); H → \\|+⟩ (≈50%) |\n"
+            "| **Attack** | Born rule | P(hit) = charge = P(\\|1⟩); a target in \\|1⟩ takes a CRITICAL |\n"
             "| **Idle** a turn | T₁/T₂ relaxation (Lindblad) | charge ∝ e^(−t/T₁), coherence ∝ e^(−t/T₂) |\n"
-            "| **GUARD** | X-basis measurement, relative phase | crit risk = (1−x)/2; |+⟩ safe, |−⟩ exposed |\n"
+            "| **GUARD** | X-basis measurement, relative phase | crit risk = (1−x)/2; \\|+⟩ safe, \\|−⟩ exposed |\n"
             "| **Z / S / T** | relative-phase rotation | invisible to charge — matters only via the GUARD's X-basis |\n"
-            "| **CNOT** | entanglement (Bell pair) | |Φ⁺⟩; measuring one collapses both; no faster-than-light signalling |\n"
-            "| **MEASURE** | projective collapse | |ψ⟩ → |0⟩ or |1⟩, then stabilizes the unit |\n"
+            "| **CNOT** | entanglement (Bell pair) | \\|Φ⁺⟩; measuring one collapses both; no signalling |\n"
+            "| **MEASURE** | projective collapse | \\|ψ⟩ → \\|0⟩ or \\|1⟩, then stabilizes the unit |\n"
         )
 
-    with st.expander("🔬 The physics is real — and unit-tested"):
+    with st.expander(":material/science: The physics is real — and unit-tested"):
         st.markdown(
             "QuBlitz is not hand-waving flavor. Each unit evolves under the **exact Lindblad "
             "master-equation solution** for amplitude damping (T₁) plus dephasing (T₂), the same "
@@ -85,7 +132,7 @@ def _render_academic_framing():
             "- a local gate on one half **never** changes the partner's marginal (no-communication)."
         )
 
-    with st.expander("🎓 Research context"):
+    with st.expander(":material/school: Research context"):
         st.markdown(
             "Built by **David Mukuruva** within the **Fitzpatrick Lab, Dartmouth College** "
             "(PI: Prof. Mattias Fitzpatrick), as the game companion to the lab's qubit simulator. "
@@ -99,18 +146,14 @@ def _render_quickstart():
     st.markdown("#### How to play in 30 seconds")
     c1, c2, c3 = st.columns(3)
     with c1:
-        st.markdown("**1 · Charge** ⚡")
+        st.markdown("**1 · Charge**")
         st.caption("Apply **X** (→ |1⟩, 100%) or **H** (→ |+⟩, 50%). A unit's charge *is* its P(|1⟩).")
     with c2:
-        st.markdown("**2 · Close in** 🏃")
+        st.markdown("**2 · Close in**")
         st.caption("Move adjacent to a foe — but hurry: idle charge relaxes as e^(−t/T₁) every turn.")
     with c3:
-        st.markdown("**3 · Collapse** 💥")
+        st.markdown("**3 · Collapse**")
         st.caption("**Attack** fires with probability = charge; a target caught in |1⟩ takes a CRITICAL.")
-    st.caption(
-        "Controls: click the board, then **A**=attack · **H/X/Y/Z**=charge · **M**=measure · "
-        "**C**=CNOT · **G**=guard · **Space**=end turn. Press **?** for the Sage."
-    )
 
 
 def _render_related_links():
@@ -122,50 +165,36 @@ def _render_related_links():
     try:
         with col1:
             st.page_link("pages/Quantum_Measurement_Tutorial.py",
-                         label="🆕 New to qubits? Start with the Measurement Tutorial", icon="🎮")
+                         label="New to qubits? Start with the Measurement Tutorial",
+                         icon=":material/school:")
         with col2:
             st.page_link("pages/Qubit_Simulator.py",
-                         label="⚛ See the real physics in the Qubit Simulator", icon="🔬")
+                         label="See the real physics in the Qubit Simulator",
+                         icon=":material/science:")
     except Exception:
         with col1:
-            st.markdown("🆕 **New to qubits?** Open the *Quantum Measurement Tutorial* page.")
+            st.markdown("**New to qubits?** Open the *Quantum Measurement Tutorial* page.")
         with col2:
-            st.markdown("⚛ **Want the real physics?** Open the *Qubit Simulator* page.")
+            st.markdown("**Want the real physics?** Open the *Qubit Simulator* page.")
 
 
 def main():
     st.set_page_config(page_title="QuBlitz Arena", layout="wide")
+    _render_sidebar()
 
-    st.sidebar.image(load_logo("images/qublitz.png"))
-    st.sidebar.image(load_logo("images/logo.png"))
-    st.sidebar.markdown(
-        '<div style="text-align:center;"><a href="https://sites.google.com/view/fitzlab/home" '
-        'target="_blank" style="font-size:1.2rem; font-weight:bold;">FitzLab Website</a></div>',
-        unsafe_allow_html=True,
+    st.title("QuBlitz Arena")
+    st.caption(
+        "Learn quantum mechanics by playing it — every unit is a qubit, every move is a gate.  "
+        "Click the board, then **A** attack · **H/X/Y/Z** charge · **M** measure · **C** entangle · "
+        "**G** guard · **E** explain · **?** Sage."
     )
 
-    st.title("⚔️ QuBlitz Arena")
-    st.markdown("*Learn quantum mechanics by playing it — every unit is a qubit, every move is a gate.*")
-
-    _render_academic_framing()
-    _render_quickstart()
+    # Game first, so it sits within the screen; the academic depth follows below.
+    _render_embed()
 
     st.divider()
-    proxy = _sage_proxy_url()
-    inject = f"<script>window.QB_SAGE_PROXY={json.dumps(proxy)};</script>" if proxy else ""
-    # Fixed iframe height covers the title bar + 800px board + side panels + event log;
-    # the game itself is responsive (CSS grid) and scrolls within this frame on small screens.
-    st.components.v1.html(inject + _load_game_html(), height=1180, scrolling=True)
-
-    if proxy:
-        st.success("✦ Live Claude Sage connected via a server-side proxy — the API key stays on the proxy, never in this page.", icon="✅")
-    else:
-        st.info(
-            "The offline heuristic Sage is active — concept-linked, per-unit advice with no API key. "
-            "To enable the live Claude Sage, set `QB_SAGE_PROXY_URL` in the app secrets.",
-            icon="🔮",
-        )
-
+    _render_academic_framing()
+    _render_quickstart()
     st.divider()
     _render_related_links()
 

--- a/pages/QuBlitz_Arena.py
+++ b/pages/QuBlitz_Arena.py
@@ -95,6 +95,44 @@ def _render_academic_framing():
         )
 
 
+def _render_quickstart():
+    st.markdown("#### How to play in 30 seconds")
+    c1, c2, c3 = st.columns(3)
+    with c1:
+        st.markdown("**1 · Charge** ⚡")
+        st.caption("Apply **X** (→ |1⟩, 100%) or **H** (→ |+⟩, 50%). A unit's charge *is* its P(|1⟩).")
+    with c2:
+        st.markdown("**2 · Close in** 🏃")
+        st.caption("Move adjacent to a foe — but hurry: idle charge relaxes as e^(−t/T₁) every turn.")
+    with c3:
+        st.markdown("**3 · Collapse** 💥")
+        st.caption("**Attack** fires with probability = charge; a target caught in |1⟩ takes a CRITICAL.")
+    st.caption(
+        "Controls: click the board, then **A**=attack · **H/X/Y/Z**=charge · **M**=measure · "
+        "**C**=CNOT · **G**=guard · **Space**=end turn. Press **?** for the Sage."
+    )
+
+
+def _render_related_links():
+    st.markdown("**Keep exploring the platform**")
+    col1, col2 = st.columns(2)
+    # st.page_link resolves relative to the app entrypoint (home.py). Guard it so
+    # the page still renders if loaded in isolation (e.g. under AppTest, where the
+    # sibling pages aren't on the entrypoint's page list).
+    try:
+        with col1:
+            st.page_link("pages/Quantum_Measurement_Tutorial.py",
+                         label="🆕 New to qubits? Start with the Measurement Tutorial", icon="🎮")
+        with col2:
+            st.page_link("pages/Qubit_Simulator.py",
+                         label="⚛ See the real physics in the Qubit Simulator", icon="🔬")
+    except Exception:
+        with col1:
+            st.markdown("🆕 **New to qubits?** Open the *Quantum Measurement Tutorial* page.")
+        with col2:
+            st.markdown("⚛ **Want the real physics?** Open the *Qubit Simulator* page.")
+
+
 def main():
     st.set_page_config(page_title="QuBlitz Arena", layout="wide")
 
@@ -107,23 +145,29 @@ def main():
     )
 
     st.title("⚔️ QuBlitz Arena")
+    st.markdown("*Learn quantum mechanics by playing it — every unit is a qubit, every move is a gate.*")
+
     _render_academic_framing()
+    _render_quickstart()
 
-    st.markdown("### ▶ Play")
-    st.caption("Click the board, then: A=attack · H/X/Y/Z=charge · M=measure · C=CNOT · Space=end turn. Press ? for the Sage.")
-
+    st.divider()
     proxy = _sage_proxy_url()
     inject = f"<script>window.QB_SAGE_PROXY={json.dumps(proxy)};</script>" if proxy else ""
-    # Height covers the title bar + 800px board + side panels + event log.
-    st.components.v1.html(inject + _load_game_html(), height=1100, scrolling=True)
+    # Fixed iframe height covers the title bar + 800px board + side panels + event log;
+    # the game itself is responsive (CSS grid) and scrolls within this frame on small screens.
+    st.components.v1.html(inject + _load_game_html(), height=1180, scrolling=True)
 
     if proxy:
-        st.caption("✦ Live Claude Sage connected via a server-side proxy (the API key stays on the proxy).")
+        st.success("✦ Live Claude Sage connected via a server-side proxy — the API key stays on the proxy, never in this page.", icon="✅")
     else:
-        st.caption(
-            "The offline heuristic Sage is active — it gives concept-linked, per-unit advice with no "
-            "API key. To enable the live Claude Sage, set `QB_SAGE_PROXY_URL` in the app secrets."
+        st.info(
+            "The offline heuristic Sage is active — concept-linked, per-unit advice with no API key. "
+            "To enable the live Claude Sage, set `QB_SAGE_PROXY_URL` in the app secrets.",
+            icon="🔮",
         )
+
+    st.divider()
+    _render_related_links()
 
 
 if __name__ == "__main__":

--- a/pages/QuBlitz_Arena.py
+++ b/pages/QuBlitz_Arena.py
@@ -1,0 +1,22 @@
+import streamlit as st
+
+
+def main():
+    st.set_page_config(page_title="QuBlitz Arena", layout="wide")
+
+    st.title("⚔️ QuBlitz Arena")
+
+    st.markdown(
+        "**QuBlitz** is a quantum tactics game where every unit on the board is a qubit, "
+        "every action is a quantum gate, and combat resolves via the Born rule. Charge a "
+        "qubit (H/X), close in, and strike — a target caught in |1⟩ takes a critical hit, "
+        "while decoherence bleeds your charge away each turn. It is the game companion to "
+        "this simulator: the same T₁/T₂ physics you explore here drive the game's "
+        "decoherence model."
+    )
+
+    st.info("🎮 Game loading coming in C02 — the playable board will embed here next cycle.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pages/QuBlitz_Arena.py
+++ b/pages/QuBlitz_Arena.py
@@ -23,7 +23,16 @@ _GAME_HTML = Path(__file__).parent / "_assets" / "quantum_chess.html"
 # Frame height tuned so the board + side panels + event log sit on one screen
 # without inner scroll on a typical laptop; the game caps the board by viewport
 # height (CSS min(...,100vh-…)) so it scales to fit this frame.
-_EMBED_HEIGHT = 860
+#
+# Was 860 — an LLM-council review found the Sage panel/event log clipped at the
+# bottom at that height. The game side responded by trimming vertical chrome
+# and adding a Sage-panel collapse toggle, which should reduce (not eliminate)
+# the pressure on this fixed frame. Bumped to 920 as a modest, judgment-call
+# increase: a slightly taller default with a collapse option to fall back on
+# beats a cramped fixed height with no give. This wasn't visually verified
+# against the trimmed layout (no Streamlit run in this pass) — re-check on a
+# typical laptop viewport and adjust if it still clips or now over-scrolls.
+_EMBED_HEIGHT = 920
 
 
 @st.cache_data(show_spinner=False)

--- a/pages/Quantum_Measurement_Tutorial.py
+++ b/pages/Quantum_Measurement_Tutorial.py
@@ -8,14 +8,14 @@ Release Date:
 import numpy as np
 from streamlit import columns, header, image, latex, markdown, plotly_chart, slider, title
 import streamlit as st
-from PIL import Image
+from utils.branding import load_logo
 import plotly.graph_objects as go
 
 def main():
     title('Quantum Measurement Tutorial')
-    qublitz_logo = Image.open("images/qublitz.png")
+    qublitz_logo = load_logo("images/qublitz.png")
     st.sidebar.image(qublitz_logo)
-    logo = Image.open("images/logo.png") 
+    logo = load_logo("images/logo.png") 
     st.sidebar.image(logo) # display logo on the side 
     st.sidebar.markdown('<div style="text-align:center;"><a href="https://sites.google.com/view/fitzlab/home" target="_blank" style="font-size:1.2rem; font-weight:bold;">FitzLab Website</a></div>', unsafe_allow_html=True)
     

--- a/pages/Quantum_Measurement_Tutorial.py
+++ b/pages/Quantum_Measurement_Tutorial.py
@@ -6,9 +6,8 @@ Release Date:
 
 '''
 import numpy as np
-from streamlit import *
+from streamlit import columns, header, image, latex, markdown, plotly_chart, slider, title
 import streamlit as st
-from streamlit.components.v1 import html
 from PIL import Image
 import plotly.graph_objects as go
 

--- a/pages/Qubit_Simulator.py
+++ b/pages/Qubit_Simulator.py
@@ -910,16 +910,11 @@ def page():
         st.markdown("### Time-domain results")
         st.caption("Use this tab mainly to extract T₁ from the post-pulse decay. The Rabi-rate fit is now taken from the peak-frequency time trace in the Frequency Domain tab.")
 
-        if st.session_state.get("td_out") is None:
-            try:
-                st.session_state["td_out"] = run_time_domain(
-                    omega_q, omega_rabi, T1_ns, float(omega_d),
-                    float(t_final), sx_sched, sy_sched, int(shots),
-                )
-            except Exception:
-                st.session_state["td_out"] = None
-
-        if st.button("Re-run simulation with current settings", key="td_run"):
+        # Gate the (expensive) mesolve behind an explicit button instead of
+        # auto-solving on every fresh page load / refresh (C02-T12).
+        _td_has_result = st.session_state.get("td_out") is not None
+        _td_run_label = "Re-run simulation with current settings" if _td_has_result else "Run simulation"
+        if st.button(_td_run_label, key="td_run"):
             try:
                 st.session_state["td_out"] = run_time_domain(
                     omega_q, omega_rabi, T1_ns, float(omega_d),
@@ -930,6 +925,9 @@ def page():
                 st.exception(e)
 
         out_td = st.session_state.get("td_out")
+
+        if out_td is None:
+            st.info("Set your parameters above and click **Run simulation** to solve the time-domain dynamics.")
 
         if out_td is not None:
             fit_summary = _analyze_time_domain_fits(out_td["tlist"], out_td["p1_meas"], sx_sched, sy_sched)

--- a/pages/Qubit_Simulator.py
+++ b/pages/Qubit_Simulator.py
@@ -16,7 +16,7 @@ from typing import Dict, Any, Optional
 import numpy as np
 import pandas as pd
 import streamlit as st
-from PIL import Image
+from utils.branding import load_logo
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
@@ -755,11 +755,11 @@ def page():
     user_data = st.session_state["user_data"]
 
     try:
-        st.sidebar.image(Image.open("images/qublitz.png"))
+        st.sidebar.image(load_logo("images/qublitz.png"))
     except Exception:
         pass
     try:
-        st.sidebar.image(Image.open("images/logo.png"))
+        st.sidebar.image(load_logo("images/logo.png"))
     except Exception:
         pass
 

--- a/pages/Sonify.py
+++ b/pages/Sonify.py
@@ -1,9 +1,8 @@
 import streamlit as st
+from utils.branding import load_logo
 import numpy as np
 from PIL import Image
 import plotly.graph_objects as go
-import soundfile as sf
-import tempfile
 import json
 import os
 
@@ -44,10 +43,10 @@ def generate_audio(env, t_env, row_idx, carrier_freq, duration, sr=DEFAULT_SR):
     ramp[-ramp_len:] = np.linspace(1, 0, ramp_len)
     audio *= ramp
     audio /= (np.max(np.abs(audio)) + 1e-12)
-    # write WAV
-    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
-        sf.write(tmp.name, audio.astype(np.float32), sr)
-        return tmp.name, audio
+    # Return the waveform + sample rate; st.audio plays a numpy array directly,
+    # so we no longer write a NamedTemporaryFile(delete=False) on every rerun
+    # (that leaked an unbounded pile of .wav files on the server).
+    return audio.astype(np.float32), sr
 
 # ——— Streamlit app ——————————————————————————————————
 
@@ -56,9 +55,9 @@ st.set_page_config(layout="wide")
 def main():
     min_x = 0.0
     st.title("Image Sonification, Turn Images into Sound!")
-    qublitz_logo = Image.open("images/qublitz.png")
+    qublitz_logo = load_logo("images/qublitz.png")
     st.sidebar.image(qublitz_logo)
-    logo = Image.open("images/logo.png") 
+    logo = load_logo("images/logo.png") 
     st.sidebar.image(logo) # display logo on the side 
     st.sidebar.markdown('<div style="text-align:center;"><a href="https://sites.google.com/view/fitzlab/home" target="_blank" style="font-size:1.2rem; font-weight:bold;">FitzLab Website</a></div>', unsafe_allow_html=True)
     # --- Load image list for premade option (not shown in sidebar) ---
@@ -227,11 +226,11 @@ def main():
 
     # 6) Audio Playback for that row
     st.markdown(f"### Audio for Row {sel_row}")
-    wav_path, _ = generate_audio(env, t_lowres, sel_row,
-                                 mod_freq,
-                                 duration=max_x - min_x,
-                                 sr=DEFAULT_SR)
-    st.audio(wav_path, format="audio/wav")
+    audio_wave, audio_sr = generate_audio(env, t_lowres, sel_row,
+                                           mod_freq,
+                                           duration=max_x - min_x,
+                                           sr=DEFAULT_SR)
+    st.audio(audio_wave, sample_rate=audio_sr)
 
 if __name__ == "__main__":
     main()

--- a/pages/Sonify.py
+++ b/pages/Sonify.py
@@ -28,7 +28,6 @@ def compute_fft_map(mat, sample_spacing):
     return mag, freqs
 
 def generate_audio(env, t_env, row_idx, carrier_freq, duration, sr=DEFAULT_SR):
-    cols = env.shape[1]
     # audio time axis
     N = int(np.ceil(duration * sr))
     t_audio = np.linspace(0, duration, N, endpoint=False)
@@ -175,7 +174,6 @@ def main():
 
     # Set same modulation frequency for all rows
     y_freqs = np.full(rows, mod_freq)
-    y_axis = np.arange(rows)  # For plotting
 
     sample_spacing = (max_x - min_x) / cols
 

--- a/pages/_assets/quantum_chess.html
+++ b/pages/_assets/quantum_chess.html
@@ -1,0 +1,3999 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>QuBlitz — Qubit Battle Arena</title>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Space+Grotesk:wght@400;500;600;700&display=swap');
+
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+:root {
+  /* Oravec-inspired dark, living pixel-world palette — vibrant neon on deep night */
+  --bg:        #070a16;
+  --bg-2:      #0b1024;
+  --bg-3:      #11183a;
+  --panel:     rgba(18,24,52,0.60);
+  --panel-2:   rgba(30,40,80,0.42);
+  --glass-brd: rgba(124,140,230,0.22);
+  --border:    rgba(124,140,230,0.22);
+  --border-hi: rgba(124,140,230,0.46);
+  --ink:       #eaf0ff;   /* primary high-contrast text */
+  --ink-2:     #aeb8e6;   /* secondary text */
+  --ink-3:     #9aa3cf;   /* muted text — lightened to meet WCAG AA 4.5:1 on dark bg (QB-8) */
+  --gold:      #f5b73c;
+  --teal:      #2fe0d0;   /* WHITE controller neon (cyan) */
+  --indigo:    #8b7dff;
+  --green:     #3fe08a;
+  --red:       #ff5a72;
+  --amber:     #ffa83c;
+  --rose:      #ff4d9d;   /* BLACK controller neon (magenta) */
+  --warm:      #eaf0ff;   /* legacy alias → light ink */
+  --parchment: #aeb8e6;
+  --dim:       #9aa3cf;   /* QB-8 — AA-contrast muted text on dark bg */
+  --wood:      #9aa3cf;   /* QB-8 — AA-contrast muted text on dark bg */
+  --pixel:     'Press Start 2P', monospace;
+  --body:      'Space Grotesk', system-ui, -apple-system, sans-serif;
+  --ease:      cubic-bezier(.22,.61,.36,1);
+}
+
+/* QB-8 — calm board for users who ask for reduced motion: drop CSS animations
+   and transitions (particles, shake and flashes are gated in JS via
+   REDUCE_MOTION). */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+html, body {
+  background:
+    radial-gradient(1200px 800px at 15% -10%, #16203f 0%, transparent 55%),
+    radial-gradient(1100px 900px at 110% 8%, #1c1448 0%, transparent 55%),
+    linear-gradient(160deg, #070a16 0%, #0b1024 55%, #070a16 100%);
+  background-attachment: fixed;
+  color: var(--ink);
+  font-family: var(--body);
+  width: 100%;
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+::selection { background: var(--indigo); color:#fff; }
+::-webkit-scrollbar { width: 9px; height: 9px; }
+::-webkit-scrollbar-thumb { background: var(--border-hi); border-radius: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+
+/* ── Boot Screen ───────────────────────────────────── */
+#boot {
+  position: fixed; inset: 0; z-index: 9000;
+  background:
+    radial-gradient(900px 600px at 30% 20%, #16203f 0%, transparent 60%),
+    radial-gradient(700px 500px at 80% 90%, #1c1448 0%, transparent 60%),
+    linear-gradient(160deg, #070a16, #0b1024);
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  gap: 22px;
+  transition: opacity 0.8s var(--ease);
+}
+#boot.fade-out { opacity: 0; pointer-events: none; }
+#boot-logo {
+  font-family: var(--pixel); font-size: 38px;
+  background: linear-gradient(135deg, var(--indigo), var(--teal) 60%, var(--gold));
+  -webkit-background-clip: text; background-clip: text; color: transparent;
+  filter: drop-shadow(0 6px 18px rgba(91,84,230,0.28));
+  letter-spacing: 10px;
+  min-height: 48px;
+  animation: floaty 4s var(--ease) infinite;
+}
+#boot-sub {
+  font-family: var(--body); font-weight: 500;
+  font-size: 16px; font-style: normal;
+  color: var(--ink-2); letter-spacing: 3px;
+  min-height: 22px;
+}
+#boot-lines {
+  font-family: var(--pixel); font-size:11px;
+  color: var(--ink-3); text-align: left; width: 360px;
+  line-height: 2.2; white-space: pre;
+  min-height: 100px;
+}
+#boot-start {
+  font-family: var(--pixel); font-size: 11px;
+  color: var(--indigo); letter-spacing: 1px;
+  animation: blink 0.9s step-end infinite;
+  min-height: 16px;
+}
+@keyframes blink { 0%,49%{opacity:1} 50%,100%{opacity:0} }
+@keyframes floaty { 0%,100%{transform:translateY(0)} 50%{transform:translateY(-6px)} }
+
+/* ── Background canvas ─────────────────────────────── */
+#bg-canvas {
+  position: fixed; inset: 0; z-index: 0;
+  pointer-events: none;
+  opacity: 0.95;
+  image-rendering: pixelated; image-rendering: crisp-edges;
+}
+
+/* ── Root container ────────────────────────────────── */
+#root {
+  position: relative; z-index: 1;
+  width: 100%;
+  display: flex; flex-direction: column;
+  align-items: center;
+}
+
+/* ── Title bar ─────────────────────────────────────── */
+#title-bar {
+  width: 100%; max-width: 1350px;
+  margin-top: 8px;
+  padding: 10px 18px;
+  display: flex; align-items: center; justify-content: space-between;
+  border-radius: 4px;
+  border: 2px solid rgba(90,80,204,0.55);
+  background: rgba(4,6,20,0.97);
+  box-shadow: 0 4px 20px rgba(0,0,0,0.55), inset 0 1px 0 rgba(139,125,255,0.08);
+}
+#title-bar h1 {
+  font-family: var(--pixel); font-size: 17px;
+  background: linear-gradient(120deg, var(--indigo), var(--teal));
+  -webkit-background-clip: text; background-clip: text; color: transparent;
+  filter: drop-shadow(0 2px 6px rgba(91,84,230,0.25));
+  letter-spacing: 4px;
+}
+#title-bar .sub { font-size: 11px; font-family: var(--body); font-weight: 600; color: var(--ink-2); letter-spacing: 1px; }
+#attract-badge {
+  font-family: var(--pixel); font-size:11px;
+  color: var(--indigo); letter-spacing: 1px;
+  display: none;
+}
+
+/* ── Layout ────────────────────────────────────────── */
+#ui {
+  width: 100%; max-width: 1350px;
+  display: flex; gap: 12px; padding: 10px 10px 0;
+  align-items: flex-start;
+}
+
+/* Canvas wrapper — relative container for sage-bar overlay */
+#canvas-wrap {
+  position: relative;
+  flex-shrink: 0;
+  line-height: 0;
+  border: 2px solid rgba(90,80,204,0.45);
+  border-radius: 4px;
+  box-shadow: 0 0 32px rgba(90,80,204,0.14), 0 8px 32px rgba(0,0,0,0.60);
+  /* Push sage bar and timer elements into the padding zone below the canvas
+     so they never overlap pieces. 90px clears the 82px sage bar + 5px timer bar. */
+  padding-bottom: 90px;
+}
+
+canvas { display: block; cursor: pointer; }
+
+/* QB-4 — responsive layout. Below a wide laptop the board + side panels stack
+   instead of demanding ~1200px of width; the canvas stays square and fluid. */
+@media (max-width: 1100px) {
+  #ui { flex-direction: column; align-items: center; max-width: 820px; }
+  #canvas-wrap { flex-shrink: 1; min-width: 0; width: 100%; max-width: 800px; }
+  .panel { max-width: 800px; width: 100%; order: 2; }
+  #canvas-wrap { order: 1; }
+}
+@media (max-width: 560px) {
+  #ui { padding: 6px 6px 0; gap: 8px; }
+  #canvas-wrap { padding-bottom: 72px; }
+  .panel { min-width: 0; padding: 8px; }
+}
+
+#game-canvas {
+  border-radius: 2px;
+  border: none;
+  filter: contrast(1.10) saturate(1.12);
+  display: block;
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
+  /* QB-4 — display-scale to the viewport without touching the internal 800px
+     resolution (kept crisp). The click handler scales via getBoundingClientRect,
+     so input math still lands on the right cells at any size. */
+  width: 100%;
+  height: auto;
+  max-width: 800px;
+  aspect-ratio: 1 / 1;
+}
+
+/* Animated DOM overlay used to smoothly move a sprite on top of the canvas */
+.piece-fly {
+  position: absolute; width: var(--cell, 80px); height: var(--cell, 80px);
+  pointer-events: none; image-rendering: pixelated; image-rendering: crisp-edges;
+  background-size: contain; background-repeat: no-repeat; z-index: 50;
+  transform: translate3d(0,0,0); transition: transform linear;
+}
+
+@keyframes walk {
+  0% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+  100% { transform: translateY(0); }
+}
+
+/* Biome backgrounds (single-biome by default, toggleable via JS) */
+body.biome-grass {
+  --bg: #071018; /* keep dark base but warmer for grass */
+  background: linear-gradient(160deg, #071018 0%, #0b1628 60%, #071018 100%);
+}
+body.biome-snow {
+  --bg: #0a1220;
+  background: linear-gradient(160deg, #08121e 0%, #0b2030 60%, #08121e 100%);
+}
+
+
+/* ── Glass Panels — defined below with game-HUD styling ─── */
+.psec {
+  border: 1px solid rgba(90,80,204,0.28);
+  border-radius: 4px;
+  padding: 10px 10px 12px;
+  background: rgba(8,12,30,0.65);
+}
+.srow {
+  display: flex; justify-content: space-between; align-items: center;
+  font-size: 12px; color: var(--ink-2); margin-bottom: 5px;
+  font-family: var(--body); font-weight: 600;
+}
+.srow .val { font-family: var(--pixel); font-size:11px; color: var(--green); }
+
+/* Coherence bar */
+.cbar {
+  height: 9px; margin: 5px 0 7px;
+  background: rgba(36,48,90,0.10);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 1px;
+  overflow: hidden;
+}
+.cbar-fill { height: 100%; border-radius: 999px; transition: width .4s var(--ease), background .4s; }
+
+.gcnt {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 6px 10px;
+  font-size: 12px; color: var(--ink-2); font-family: var(--body); font-weight: 600;
+}
+.gcnt span { color: var(--gold); font-family: var(--pixel); font-size:11px; }
+
+.btn {
+  display: block; width: 100%;
+  background: rgba(14,18,48,0.85);
+  border: 1px solid rgba(90,80,204,0.45);
+  border-radius: 4px;
+  color: var(--ink-2);
+  font-family: var(--pixel); font-size:11px;
+  padding: 10px 6px; cursor: pointer;
+  text-align: center; letter-spacing: 1px;
+  transition: background .15s, border-color .15s, color .15s, box-shadow .15s;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.40);
+}
+.btn:hover {
+  color: #fff;
+  background: rgba(90,80,204,0.30);
+  border-color: var(--indigo);
+  box-shadow: 0 0 12px rgba(139,125,255,0.35);
+}
+.btn:active { background: rgba(90,80,204,0.50); }
+.btn-sage {
+  background: linear-gradient(180deg, rgba(139,125,255,0.28), rgba(90,76,214,0.22));
+  border-color: var(--indigo);
+  color: #d7d0ff;
+}
+.btn-sage:hover {
+  color: #fff;
+  background: linear-gradient(180deg, var(--indigo), #5a4cd6);
+  border-color: var(--indigo);
+  box-shadow: 0 12px 30px rgba(139,125,255,0.50);
+}
+
+#sel-eq {
+  font-size:11px; color: var(--teal);
+  word-break: break-all; min-height: 16px; margin-bottom: 4px;
+  font-family: var(--pixel); line-height: 1.7;
+}
+#sel-hint {
+  font-size: 12px; color: var(--ink-2);
+  min-height: 26px; line-height: 1.65;
+  font-family: var(--body); font-weight: 500;
+}
+
+/* ── Retro Sage Dialogue Bar ──────────────────────── */
+/* Portrait canvas inside the dialogue bar */
+#sage-portrait { image-rendering: pixelated; image-rendering: crisp-edges; }
+
+#sage-bar {
+  /* Absolute overlay on the bottom of #canvas-wrap — RPG dialogue box */
+  position: absolute; bottom: 0; left: 0; right: 0;
+  display: flex; align-items: stretch;
+  background: rgba(3,4,14,0.96);
+  border-top: 2px solid #5a50cc;
+  border-bottom: none; border-left: none; border-right: none;
+  min-height: 82px; max-height: 82px;
+  cursor: pointer;
+  transition: border-color .3s;
+  overflow: hidden;
+  z-index: 10;
+}
+#sage-bar.urgent { border-top-color: var(--red); }
+/* Retro inner line */
+#sage-bar::after {
+  content: ''; position: absolute; top: 3px; left: 3px; right: 3px;
+  border-top: 1px solid rgba(139,125,255,0.16);
+  pointer-events: none;
+}
+#sage-portrait {
+  width: 100px; min-width: 100px; height: 82px; flex-shrink: 0;
+  border-right: 2px solid #5a50cc;
+  background: rgba(6,9,28,0.9);
+}
+#sage-bar-body {
+  flex: 1; padding: 8px 14px 6px;
+  display: flex; flex-direction: column; justify-content: space-between;
+  min-width: 0;
+}
+#sage-bar-name {
+  font-family: var(--pixel); font-size:11px;
+  color: #8b7dff; letter-spacing: 2px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid rgba(139,125,255,0.18);
+  margin-bottom: 3px;
+}
+#sage-bar-text {
+  font-family: var(--pixel); font-size:11px;
+  color: #eaf0ff; line-height: 1.9;
+  flex: 1; overflow: hidden;
+}
+#sage-bar-footer {
+  display: flex; align-items: center; justify-content: space-between;
+  padding-top: 2px;
+}
+#sage-bar-hotkey {
+  font-family: var(--pixel); font-size:11px;
+  color: rgba(139,125,255,0.55); letter-spacing: 1px;
+}
+#sage-bar-more {
+  font-family: var(--pixel); font-size:11px;
+  color: #8b7dff; animation: blink 0.7s step-end infinite;
+  display: none;
+}
+#sage-bar-more.show { display: block; }
+
+/* Expanded tips panel — sits directly above the sage bar in the padding zone.
+   max-height keeps it from ever reaching the canvas area. */
+#sage-tips {
+  position: absolute; bottom: 82px; left: 0; right: 0;
+  max-height: calc(100% - 800px - 90px); /* can't grow above the canvas bottom */
+  display: none; flex-direction: column;
+  background: rgba(3,4,14,0.96);
+  border-top: 1px solid rgba(90,80,204,0.50);
+  border-bottom: 1px solid rgba(90,80,204,0.50);
+  overflow-y: auto;
+  z-index: 10;
+  animation: tipPanelIn .22s var(--ease);
+}
+#sage-tips.show { display: flex; }
+@keyframes tipPanelIn { from{opacity:0;transform:translateY(4px)} to{opacity:1;transform:none} }
+.sage-tip-row {
+  display: flex; gap: 10px; align-items: flex-start;
+  padding: 8px 16px 8px 14px;
+  border-bottom: 1px solid rgba(139,125,255,0.10);
+  animation: tipIn .35s var(--ease);
+}
+.sage-tip-row:last-child { border-bottom: none; }
+.sage-tip-ic {
+  font-family: var(--pixel); font-size:11px;
+  width: 20px; flex-shrink: 0; text-align: center; padding-top: 1px;
+}
+.sage-tip-ic.danger  { color: var(--red);    }
+.sage-tip-ic.warn    { color: var(--amber);  }
+.sage-tip-ic.quantum { color: var(--teal);   }
+.sage-tip-ic.gate    { color: var(--indigo); }
+.sage-tip-ic.info    { color: var(--ink-3);  }
+.sage-tip-tx {
+  font-family: var(--pixel); font-size: 7.5px;
+  color: var(--ink-2); line-height: 1.85;
+}
+
+/* ── Log ───────────────────────────────────────────── */
+#log {
+  width: 100%; max-width: 1350px;
+  margin-top: 6px;
+  background: rgba(4,6,20,0.95);
+  border: 1px solid rgba(90,80,204,0.40);
+  border-radius: 4px;
+  padding: 7px 14px;
+  font-size: 11px; color: var(--ink-2);
+  height: 62px; overflow-y: auto;
+  font-family: var(--body); font-weight: 500; line-height: 1.75;
+}
+#log span { display: block; animation: logIn .35s var(--ease); }
+@keyframes logIn { from{opacity:0; transform:translateX(-6px)} to{opacity:1; transform:none} }
+#log .ev-gate     { color: var(--green);  }
+#log .ev-decohere { color: var(--red);    }
+#log .ev-measure  { color: var(--gold);   }
+#log .ev-capture  { color: var(--rose);   }
+#log .ev-info     { color: var(--ink-3);  }
+#log .ev-quantum  { color: var(--teal); font-style: italic; }
+#log .ev-check    { color: var(--amber);  }
+#log .ev-system   { color: var(--ink-3); }
+
+#kb-hint {
+  display: none;
+}
+
+/* ── RPG Modal ─────────────────────────────────────── */
+#modal-overlay {
+  display: none; position: fixed; inset: 0;
+  background: rgba(5,8,20,0.62); z-index: 100;
+  align-items: center; justify-content: center;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+#modal-overlay.show { display: flex; animation: fadeIn .3s var(--ease); }
+@keyframes fadeIn { from{opacity:0} to{opacity:1} }
+#modal {
+  background: linear-gradient(165deg, rgba(20,27,58,0.96), rgba(12,17,38,0.97));
+  border: 1px solid var(--glass-brd);
+  border-radius: 22px;
+  box-shadow: 0 30px 90px rgba(0,0,0,0.65), 0 0 0 1px rgba(139,125,255,0.12), inset 0 1px 0 rgba(255,255,255,0.08);
+  padding: 30px 32px; max-width: 760px; width: 95%;
+  max-height: 88vh; overflow-y: auto;
+  font-size: 13px; line-height: 1.7; font-family: var(--body); font-weight: 500;
+  color: var(--ink);
+  position: relative;
+  animation: modalIn .42s var(--ease);
+}
+@keyframes modalIn { from{opacity:0; transform:translateY(18px) scale(.97)} to{opacity:1; transform:none} }
+#modal::before, #modal::after {
+  content: '✦'; position: absolute;
+  color: var(--indigo); font-size: 14px;
+  opacity: 0.55;
+}
+#modal::before { top: 14px; left: 16px; }
+#modal::after  { top: 14px; right: 16px; }
+#modal h2 {
+  font-family: var(--pixel); font-size: 16px;
+  background: linear-gradient(120deg, var(--indigo), var(--teal));
+  -webkit-background-clip: text; background-clip: text; color: transparent;
+  margin-bottom: 20px; text-align: center; letter-spacing: 2px;
+}
+#modal h3 {
+  font-family: var(--pixel); color: var(--teal); font-size: 11px;
+  margin: 18px 0 8px; letter-spacing: 1px;
+}
+#modal p  { color: var(--ink-2); margin-bottom: 10px; font-size: 13px; }
+#modal table { width:100%; border-collapse:collapse; margin:12px 0; font-size:12px; }
+#modal td, #modal th { border:1px solid var(--border); padding:8px 10px; color:var(--ink); }
+#modal th { color:#fff; background:var(--indigo); font-family:var(--pixel); font-size:11px; }
+#modal .close-btn {
+  display:block; margin:22px auto 0;
+  background:linear-gradient(180deg, rgba(40,52,104,0.6), rgba(22,30,64,0.6)); border:1px solid var(--border);
+  border-radius:12px;
+  color:var(--ink); font-family:var(--pixel); font-size:11px;
+  padding:12px 30px; cursor:pointer; letter-spacing:1px;
+  transition:transform .2s var(--ease), box-shadow .25s var(--ease), color .2s, border-color .2s;
+  box-shadow: 0 4px 14px rgba(0,0,0,0.4);
+}
+#modal .close-btn:hover { transform:translateY(-2px); color:#fff; border-color:var(--indigo); box-shadow:0 10px 26px rgba(139,125,255,0.4); }
+
+/* ── Soft ambient vignette ─────────────────────────── */
+body::before {
+  content:''; position:fixed; inset:0; pointer-events:none; z-index:998;
+  background: radial-gradient(ellipse at center, transparent 55%, rgba(2,4,12,0.55) 100%);
+}
+
+/* ── Panel headers — game-HUD look ─────────────────── */
+.panel {
+  background: rgba(4,6,20,0.97);
+  border: 2px solid rgba(90,80,204,0.45);
+  border-radius: 4px;
+  padding: 10px 10px;
+  flex: 1; min-width: 188px; max-width: 230px;
+  display: flex; flex-direction: column; gap: 8px;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.55);
+}
+.panel h3 {
+  font-family: var(--pixel); font-size:11px;
+  color: var(--teal); letter-spacing: 1px;
+  margin-bottom: 6px; padding-bottom: 5px;
+  border-bottom: 1px solid rgba(47,224,208,0.25);
+  text-shadow: 0 0 6px rgba(47,224,208,0.30);
+}
+
+/* Gate count colors — each gate gets its signature color */
+#cnt-H    { color: var(--teal);   }
+#cnt-X    { color: var(--rose);   }
+#cnt-Y    { color: var(--amber);  }
+#cnt-Z    { color: var(--indigo); }
+#cnt-S    { color: var(--green);  }
+#cnt-T    { color: var(--gold);   }
+#cnt-Rx   { color: var(--teal);   }
+#cnt-Ry   { color: var(--green);  }
+#cnt-CNOT { color: #c97bff;       }
+#cnt-MEASURE { color: var(--gold); }
+
+/* urgent pulse on any sage-related button */
+@keyframes tipIn { from{opacity:0; transform:translateX(8px)} to{opacity:1; transform:none} }
+.btn-sage.urgent {
+  animation: sagePulse 1.1s var(--ease) infinite;
+  border-color: var(--red);
+}
+@keyframes sagePulse {
+  0%,100% { box-shadow: 0 4px 12px rgba(224,65,60,0.20); }
+  50%     { box-shadow: 0 6px 20px rgba(224,65,60,0.55); }
+}
+
+/* ── Turn Timer bar (sits in padding zone, never over the canvas) ── */
+#timer-bar {
+  position: absolute; bottom: 85px; left: 0; right: 0;
+  height: 5px; background: rgba(139,125,255,0.12);
+  z-index: 9; pointer-events: none; overflow: hidden;
+  display: none;
+}
+#timer-bar.active { display: block; }
+#timer-fill {
+  height: 100%; width: 100%;
+  background: linear-gradient(90deg, var(--teal), var(--indigo));
+  transform-origin: left; transition: background 0.5s;
+}
+#timer-fill.urgent { background: linear-gradient(90deg, var(--red), var(--amber)); animation: timerPulse 0.4s ease infinite; }
+@keyframes timerPulse { 0%,100%{opacity:1} 50%{opacity:0.55} }
+
+/* ── Timer countdown chip ─────────────────────────────── */
+#timer-chip {
+  display: none; position: absolute; bottom: 86px; right: 6px;
+  font-family: var(--pixel); font-size:11px;
+  color: var(--teal); z-index: 11; pointer-events: none;
+  background: rgba(4,6,20,0.85); padding: 2px 7px;
+  border: 1px solid rgba(47,224,208,0.35); border-radius: 4px;
+}
+#timer-chip.active { display: block; }
+#timer-chip.urgent { color: var(--red); border-color: rgba(255,90,114,0.5); }
+
+/* ── Crowd / Audience vote overlay ───────────────────── */
+#vote-overlay {
+  display: none; position: fixed; inset: 0; z-index: 300;
+  background: rgba(5,8,20,0.88);
+  backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
+  align-items: center; justify-content: center;
+  flex-direction: column; gap: 18px;
+}
+#vote-overlay.show { display: flex; animation: fadeIn .3s var(--ease); }
+#vote-title {
+  font-family: var(--pixel); font-size: 13px;
+  color: var(--gold); letter-spacing: 3px;
+  text-shadow: 0 0 24px rgba(245,183,60,0.7);
+}
+#vote-subtitle { font-family: var(--body); font-size: 13px; color: var(--ink-2); }
+#vote-timer {
+  font-family: var(--pixel); font-size: 34px;
+  color: var(--teal); letter-spacing: 2px;
+  text-shadow: 0 0 18px rgba(47,224,208,0.6);
+  transition: color 0.3s;
+}
+#vote-timer.urgent { color: var(--red); text-shadow: 0 0 18px rgba(255,90,114,0.7); }
+#vote-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
+  max-width: 580px; width: 94%;
+}
+.vote-btn {
+  background: rgba(14,18,48,0.92);
+  border: 2px solid rgba(90,80,204,0.45);
+  border-radius: 8px; padding: 14px 10px;
+  color: var(--ink); font-family: var(--pixel); font-size:11px;
+  cursor: pointer; text-align: center; letter-spacing: 1px;
+  transition: all .15s var(--ease);
+  box-shadow: 0 2px 10px rgba(0,0,0,0.4);
+}
+.vote-btn:hover { background: rgba(90,80,204,0.32); border-color: var(--indigo);
+  box-shadow: 0 0 18px rgba(139,125,255,0.4); }
+.vote-count { font-size: 20px; margin-top: 6px; display: block; color: var(--gold); }
+#vote-status { font-family: var(--pixel); font-size:11px; color: var(--ink-3); }
+
+/* ── Leaderboard ─────────────────────────────────────── */
+.lb-wrap { margin: 10px 0; border: 1px solid var(--border); border-radius: 6px; overflow: hidden; }
+.lb-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 7px 12px; border-bottom: 1px solid rgba(90,80,204,0.15);
+  font-family: var(--pixel); font-size:11px; color: var(--ink-2);
+}
+.lb-row:last-child { border-bottom: none; }
+.lb-icon { font-size: 14px; flex-shrink: 0; }
+.lb-val { color: var(--gold); margin-left: auto; }
+
+/* ── Guardian role badge ──────────────────────────────── */
+/* (painted on canvas, no DOM needed) */
+
+/* ── Campaign mission cards ──────────────────────────── */
+.mission-card {
+  margin:8px 0; padding:12px 14px;
+  border:1px solid rgba(90,80,204,0.30); border-radius:8px;
+  background:rgba(8,12,30,0.65);
+}
+.mission-card h4 {
+  font-family:var(--pixel); font-size:11px; color:var(--teal);
+  margin-bottom:6px; letter-spacing:1px;
+}
+.mission-card p { font-size:11px; color:var(--ink-2); margin-bottom:8px; }
+.mission-done { font-family:var(--pixel); font-size:11px; color:var(--green); margin-top:4px; }
+</style>
+</head>
+<body>
+
+<!-- Boot screen -->
+<div id="boot">
+  <div id="boot-logo"></div>
+  <div id="boot-sub"></div>
+  <div id="boot-lines"></div>
+  <div id="boot-start"></div>
+</div>
+
+<!-- Background particle canvas -->
+<canvas id="bg-canvas"></canvas>
+
+<div id="root">
+  <!-- Title bar -->
+  <div id="title-bar">
+    <h1>◈ QUBLITZ</h1>
+    <div id="attract-badge">★ DEMO — CLICK TO PLAY ★</div>
+    <span class="sub">QUBIT BATTLE ARENA · CHARGE · STRIKE · COLLAPSE</span>
+  </div>
+
+  <div id="ui">
+    <!-- LEFT PANEL -->
+    <div class="panel">
+      <div class="psec">
+        <h3>▸ ELITE KNIGHTS</h3>
+        <div class="srow">Total HP <span class="val" id="p1-coh">0 HP</span></div>
+        <div class="cbar"><div class="cbar-fill" id="p1-cbar" style="width:100%;background:var(--teal)"></div></div>
+        <div class="srow">Entangled <span class="val" id="p1-ent">0</span></div>
+        <div class="srow">Units <span class="val" id="p1-cnt">0</span></div>
+      </div>
+      <div class="psec">
+        <h3>▸ GATE LOG</h3>
+        <div class="gcnt">
+          <div>H: <span id="cnt-H">0</span></div>
+          <div>X: <span id="cnt-X">0</span></div>
+          <div>Y: <span id="cnt-Y">0</span></div>
+          <div>Z: <span id="cnt-Z">0</span></div>
+          <div>S: <span id="cnt-S">0</span></div>
+          <div>T: <span id="cnt-T">0</span></div>
+          <div>Rx: <span id="cnt-Rx">0</span></div>
+          <div>Ry: <span id="cnt-Ry">0</span></div>
+          <div>CNOT: <span id="cnt-CNOT">0</span></div>
+          <div>M: <span id="cnt-MEASURE">0</span></div>
+        </div>
+      </div>
+      <button class="btn" onclick="openTutorial()">📜 TOME</button>
+      <button class="btn" onclick="openMenu()">⚙ MENU</button>
+    </div>
+
+    <!-- CANVAS + RPG DIALOGUE BAR (overlaid at bottom of canvas) -->
+    <div id="canvas-wrap">
+      <canvas id="game-canvas" width="800" height="800"
+              role="application"
+              aria-label="QuBlitz quantum battle board. Click a unit to select it, click again to open its action menu."
+              tabindex="0"></canvas>
+      <!-- Screen-reader announcements: turn, selection, winner (QB-8) -->
+      <div id="a11y-status" aria-live="polite" role="status"
+           style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap"></div>
+
+      <!-- Sage dialogue bar — overlays bottom of canvas like a JRPG dialogue box -->
+      <div id="timer-bar"><div id="timer-fill"></div></div>
+      <div id="timer-chip">30s</div>
+      <div id="sage-bar" onclick="toggleAdvisor()" title="Click or press ? for more advice">
+        <canvas id="sage-portrait" width="100" height="82"></canvas>
+        <div id="sage-bar-body">
+          <div id="sage-bar-name">⬟ THE SAGE · QUANTUM ADVISOR<span id="claude-badge" style="display:none;float:right;font-size:11px;color:rgba(255,107,53,0.9);background:rgba(255,107,53,0.10);border:1px solid rgba(255,107,53,0.28);border-radius:3px;padding:1px 6px;font-family:var(--body);letter-spacing:0.3px;transition:opacity 0.3s">✦ Claude AI</span></div>
+          <div id="sage-bar-text">Greetings, controller. Charge a qubit, close in, and strike.</div>
+          <div id="sage-bar-footer">
+            <span id="sage-bar-hotkey">[?] · A=ATK H/X/Y/Z=CHARGE M=MEASURE C=CNOT SPC=END</span>
+            <span id="sage-bar-more">▼ MORE</span>
+          </div>
+        </div>
+      </div>
+      <!-- Expanded advice panel (slides upward from sage bar) -->
+      <div id="sage-tips"></div>
+    </div>
+
+    <!-- RIGHT PANEL -->
+    <div class="panel">
+      <div class="psec">
+        <h3>▸ ELITE MAGES</h3>
+        <div class="srow">Total HP <span class="val" id="p2-coh">0 HP</span></div>
+        <div class="cbar"><div class="cbar-fill" id="p2-cbar" style="width:100%;background:var(--rose)"></div></div>
+        <div class="srow">Entangled <span class="val" id="p2-ent">0</span></div>
+        <div class="srow">Units <span class="val" id="p2-cnt">0</span></div>
+      </div>
+      <div class="psec">
+        <h3>▸ SELECTED QUBIT</h3>
+        <div class="srow" style="color:var(--teal)" id="sel-name">—</div>
+        <div id="sel-eq">|ψ⟩ = —</div>
+        <div class="srow">HP <span class="val" id="sel-theta">—</span></div>
+        <div class="srow">Charge <span class="val" id="sel-phi">—</span></div>
+        <div class="srow">Coherence <span class="val" id="sel-coh">—</span></div>
+        <canvas id="bloch-canvas" width="100" height="100"
+          style="display:block;margin:7px auto;border:1px solid rgba(90,80,204,0.40);border-radius:50%;background:radial-gradient(circle at 40% 35%, #1c2440, #0a0f22);box-shadow:0 4px 16px rgba(0,0,0,0.50);"></canvas>
+        <div id="sel-hint"></div>
+      </div>
+      <div class="psec">
+        <h3>▸ TURN</h3>
+        <div class="srow" id="turn-info" style="color:var(--gold)">WHITE to move</div>
+        <div class="srow" id="phase-info" style="color:var(--indigo)">MOVE phase</div>
+        <div class="srow">Turn <span class="val" id="turn-cnt">1</span></div>
+      </div>
+      <button class="btn btn-sage" onclick="toggleAdvisor()">💬 ASK SAGE</button>
+    </div>
+  </div>
+
+  <div id="log"></div>
+  <div id="kb-hint"></div>
+</div>
+
+<!-- Modal overlay -->
+<div id="modal-overlay">
+  <div id="modal">
+    <div id="modal-content"></div>
+    <button class="close-btn" onclick="closeModal()">[ CLOSE ]</button>
+  </div>
+</div>
+
+<script>
+'use strict';
+
+const QB_VERSION = 'v1.1';   // physics-engine release: exact Lindblad T₁/T₂ decoherence
+
+// ═══════════════════════════════════════════════════════
+// AUDIO ENGINE  (Web Audio API, lazy-init on first click)
+// ═══════════════════════════════════════════════════════
+let _ac = null;
+function ac() {
+  if (!_ac) {
+    try { _ac = new (window.AudioContext || window.webkitAudioContext)(); }
+    catch(e) { return null; }
+  }
+  if (_ac.state === 'suspended') _ac.resume();
+  return _ac;
+}
+
+function beep(freq, type='square', dur=0.09, vol=0.18) {
+  const c = ac(); if (!c) return;
+  const o = c.createOscillator(), g = c.createGain();
+  o.connect(g); g.connect(c.destination);
+  o.type = type; o.frequency.value = freq;
+  g.gain.setValueAtTime(vol, c.currentTime);
+  g.gain.exponentialRampToValueAtTime(0.0001, c.currentTime + dur);
+  o.start(); o.stop(c.currentTime + dur);
+}
+
+function sfxMove()    { beep(294, 'triangle', 0.08, 0.13); }
+function sfxSelect()  { beep(440, 'triangle', 0.05, 0.10); }
+function sfxCapture() {
+  beep(196, 'sawtooth', 0.09, 0.20);
+  setTimeout(()=>beep(147,'sawtooth',0.11,0.16), 60);
+}
+function sfxDecohere() {
+  const c = ac(); if (!c) return;
+  const buf = c.createBuffer(1, c.sampleRate * 0.22, c.sampleRate);
+  const d = buf.getChannelData(0);
+  for (let i = 0; i < d.length; i++) d[i] = (Math.random()*2-1)*0.35;
+  const s = c.createBufferSource(), g = c.createGain();
+  s.buffer = buf; s.connect(g); g.connect(c.destination);
+  g.gain.setValueAtTime(0.10, c.currentTime);
+  g.gain.exponentialRampToValueAtTime(0.0001, c.currentTime + 0.22);
+  s.start(); s.stop(c.currentTime + 0.22);
+}
+function sfxGate(name) {
+  const f = {H:523,X:392,Y:440,Z:349,S:494,T:587,Rx:330,Ry:370,CNOT:659,MEASURE:262};
+  beep(f[name]||440,'triangle',0.11,0.18);
+  if (name==='X')    setTimeout(()=>beep(588,'triangle',0.07,0.13),38);
+  if (name==='H')    setTimeout(()=>beep(659,'triangle',0.05,0.12),52);
+  if (name==='CNOT') { setTimeout(()=>beep(784,'triangle',0.08,0.14),55); setTimeout(()=>beep(988,'triangle',0.05,0.10),110); }
+  if (name==='MEASURE'){ setTimeout(()=>beep(196,'triangle',0.06,0.20),0); }
+  if (name==='Z')    setTimeout(()=>beep(262,'square',0.05,0.14),45);
+}
+function sfxCrit() {
+  beep(988,'square',0.10,0.08);
+  setTimeout(()=>beep(1175,'square',0.08,0.10),55);
+  setTimeout(()=>beep(1319,'square',0.07,0.12),110);
+}
+function sfxWin() {
+  [392,494,587,784,988].forEach((f,i)=>setTimeout(()=>beep(f,'triangle',0.17,0.30),i*120));
+}
+function sfxBootBeep(f) { beep(f,'triangle',0.04,0.07); }
+
+// ═══════════════════════════════════════════════════════
+// CONSTANTS
+// ═══════════════════════════════════════════════════════
+const π          = Math.PI;
+const BOARD       = 800;   // canvas size px — bigger for visibility
+let   GRID        = 8;
+let   CELL        = BOARD / GRID;
+const ANIM_FPS    = 16;    // ms per advanceAnims tick (≈60fps)
+const ANIM_FRAME_MS = 75;  // ms per one-shot animation frame
+// Walk-tween lerp factor: lower = slower walk (0.12 ≈ 0.7s cross-board).
+const MOVE_LERP   = 0.14;
+const TURN_DELAY  = 800;   // ms the bot pauses before acting
+const MAX_HP     = 3;        // hit points per qubit unit
+const MOVE_RANGE = 3;        // tiles a unit may move (Manhattan, BFS)
+
+// Selectable board / army presets (chosen in the menu).
+const BOARD_PRESETS = [
+  { key:'8x8-6', label:'8×8 · 6 units', grid:8, units:6 },
+  { key:'6x6-4', label:'6×6 · 4 units', grid:6, units:4 },
+  { key:'8x8-8', label:'8×8 · 8 units', grid:8, units:8 },
+];
+function applyPreset(idx) {
+  const p = BOARD_PRESETS[idx] || BOARD_PRESETS[0];
+  GRID = p.grid;
+  CELL = BOARD / GRID;
+  return p;
+}
+
+// Expose cell size as a CSS variable so overlay DOM sprites match canvas pixels.
+function syncCellCSS() {
+  document.documentElement.style.setProperty('--cell', `${CELL}px`);
+}
+syncCellCSS();
+
+
+// Biome toggle: stores preference in localStorage and toggles body class.
+function initBiomeToggle() {
+  const key = 'qublitz_biome';
+  const current = localStorage.getItem(key) || 'biome-grass';
+  document.body.classList.add(current);
+  const tb = document.getElementById('title-bar');
+  if (!tb) return;
+  const btn = document.createElement('button');
+  btn.id = 'biome-toggle';
+  btn.className = 'btn';
+  btn.style.cssText = 'width:auto;padding:6px 10px;font-size:11px;';
+  btn.textContent = current === 'biome-grass' ? '🌿 Grass' : '❄ Snow';
+  btn.addEventListener('click', () => {
+    const next = document.body.classList.contains('biome-grass') ? 'biome-snow' : 'biome-grass';
+    document.body.classList.remove('biome-grass', 'biome-snow');
+    document.body.classList.add(next);
+    localStorage.setItem(key, next);
+    btn.textContent = next === 'biome-grass' ? '🌿 Grass' : '❄ Snow';
+  });
+  tb.appendChild(btn);
+}
+// Biome toggle retired — the board is now a procedural quantum lattice, so the
+// grass/snow art toggle no longer applies. (initBiomeToggle kept for reference.)
+void initBiomeToggle;
+
+// ═══════════════════════════════════════════════════════
+// PIXEL-ART BIOME ART  (embedded tileset visualizations)
+// Grassland = battlefield ground · Snow = living background scene.
+// ═══════════════════════════════════════════════════════
+const ASSET_GRASS = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAogAAAKICAIAAAB8K5ztAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwwAADsMBx2+oZAAA/7JJREFUeF7s/Wusddl1ngfafxtBkB8NBLDV3bB/CHLECBSiBizfZJsywLbbkinFASXbRUoqykIcFxl+vLjoiLFjRpRE3ahLWzYpqBFbQBR8diew0Q0DBqGQNK0oUkKxWMWLoh802jDTLVhtNNwKGg2o5x7PqFHvGmPNeda+rHP2Pt9ceICaGHPMd40111zzrW+dvc/5Hb89j3nMYx7zmMc8ruaYxjyPecxjHvOYxxUd05jnMY95zGMe87iiYxrzPOYxj3nMYx5XdCyM+Sve+rUPjpdixwv/9MXGk//5+xsvfPrFA58/8N5XDrzw3xmfMD5jkPOLxscMU/A2/JJB+0j9P/jjb2p89bu/IaDm3/dX39CobY183U9+S+M7/9EHE8R11H/0H/61xg/+6E81aJNJjmbWtka+6o2/t/H6N7+uQeV7z8/Un/pn6f+qQRyFf3LgP/u737PKP/kv3pH45//0bzZo/4tf/puN33zpNYhoXCNKDEk56AORXmaNKDEk5Ux9iCEp53Hru+3ZMY35CP1pzA87/1P/ketPY576RgxJOY9b323Pjus2ZnssX/gfDB5UNoX//sB3/Iu/ErzwP7544FMG+b9s8JDr9kHkF4wz9P/sz3x7Q+0ZI1RrDPcNPvCpnw2IqDHDn/jGb21gybQ1X+EswFhqACqELfPzB558bXD+/Ow9/1P/EeqT/ysCasRFv9ozW5taciV2wAYR3Shrr0aAeI+aOfWVmjn1Fbc9O6Yxn6iP4U1j7s3P3vM/9R+hPvnTmDvUzKmv1Mzb0nfbs+O6jZlHkQf7kwZbgD20iwebTHp5LcbDzIu1zxro8LpMX7idoa/mhx1yFeGyDawXKw1XTkarmWNjJifEGzF1ja//rtc3tKpa/8KAbR5o/8lP/Z7G13zbVzYuNT+us9v8T/2H1f9DH/3djd968xsCIqqvOd7b06dmKqSNMb9s2KhqyQobnLbZNGkrsZ9G72/9T68RaavoJqsKSohH79RXQrzB/UJZ792WNgq0lRCP3ii+EWmrPNT8uO3ZMY35LH21wGnM3nuP8z/1H1ZfTXdhvaKvOd7b06dmKqQ9jfkZ0Od+oaz3bksbBdpKiEdvFN+ItFUean7c9uy4bmPmAyNsHPZYehvYJtgCXjHYXIiwffCKjAj5xuIDKaidoY8FUn947VFgsbSrMUfaAM7+pz74pxvU06sfG/7DP/87G2rJbJoY82XnxyPkG1P/1vVZLRCuHNb7DR/6YwHxf/0bf6NBu6uvZow9W1Vqxj3YrHXL7rUrulEqxHu9im6vlZ5CiK/2Ko9Jv94XFLbHa/s+66/0FEJ8tVdB323PjmnMr6qdoT+NeTw/HiHfmPq3rs9qAewWiExjVnoKIb7aqzwm/XpfUNger+37rL/SUwjx1V4Ffbc9O67bmD/+4gEeYz42wisvNh0eaT5mIg+2j33pxcbidRmZuilcSF+NGYvlhXPyzoTmMJY2lly/LlVBgTOisDDmTv1bjPmy8wOeidrU303f83fWx2IB01XrhWrPtO/Q538RzJgX9f+3Lx4oVs0GXWHL0zZbJJG6XbI5VjSnjlLo5WVmzUyygebUUQq9t6Wv808b/Ro/Fh1Lm7MTqZWksgPNqaMUei87Pwo7A8c05gvoT2Mezw94JmpTfzd9z99ZP9y3MY0Z6N1v46b3tvR1/mmjX+PHomNpc3YitZJUdqA5dZRC72XnR2Fn4LiFD3/xUsu+nvHkiwf80WUr4SsctPmQCw+wjV15sNFkY7qQPl+aSq45QA2VCNdO+7RX2YCOG/OwfgwYY8aSaS+M+ULzAxqf+oy9Xf1w3waW/PJnP97QOCsqvDlAn1W30OdDXsP61ZIrbMoKW14vQpvtUhnH64bb26whhgfj+O3qM6vo6wzT1pyK3sG4oYNIDz0j7SgvGMf3mx/iPX23PTumMV9Afxpz1df5AY1Pfcberr4a8DTm+9m4NUeJ4cE4vp8+s4q+zjBtzanoHYwbOoj00DPSjvKCcXy/+SHe03fbs+O6jZnHle3DPsbyjpcO+Ms34vZg+4dZeC1mL+je86UDvNDzfD7qgiaZF9LHmNVoFWy4tslPl9+oxtxTUIhTiRvzsH62SGxY8a2TzAvNj+fvNv9T//71WSegZqxrCWPu2TP52LPrY8mG12//06CbMniafUwsdTVijx7A5kibzVHbbKNf/tInAyJ1SwV6aZPTywTyH5M+s8dV60zSruidihsXcH9TMKijiCi9Smhf5/y77dkxjfkC+tOYx/Pj+bvN/9S/f33WCYQrN3QtTWOOhAT5j0mf2WOUziTtit6puHEB9zcFgzqKiNKrhHatnwijyFHopU1OLxPIP1bfbc+OWzBmvqRhr9p8c+FVm2wc3tYXdLbR+FbCh00+Z9hHTnwjOFsfC8QOk1MGatjVjIlgq1CNmZyqVqGS7fWnvbJx2fnZe/6n/sPqs2bClRvVkhVfY6aPJS/0+fAXbWrAgHnZzotuM2Pq162ZfI0A23GNANtir123UTZQoLfmbKeOvUX9OnuVOv8aqf/75etT/serd39BNWmDVlXb9dr3mB+NjPXd9uyYxnyW/jTmsf7e8z/1H1afNTONWXO2U8feon6dvUqdf41MY6bXbc+O6zZmNgJerNmGwtcq3vVrBzyuD7bhN5Veu7X80nx/rYcOyWfr8+cU1SzVYomnC2zwyzvpBR2FJevXpchXdFS4cuONP/+Whv+Rxw317z0/U/+x6mOrGC0kDw6wajVv8sf6bMReP2DPtC2TjVgziWyHbVph06Qd+2mD+PhDQFB79WVm7QXit6Wvs0RbSVM9wO+p2LMvBvsftUWO/c+ZR4ZWDamkBvXTpnIg/rDz77ZnxzTms/SnMU99z3zG9Kcxa69Sey+1cUPtfSh9nSXaSprqAX5PpzHLcd3GbNuEv5TjpRZbDLCt8GCXx9t7wfIXX73g9d3Z+ligWiNmqVfEL/1Q+FMTWCw5arT1VTb5Sjh0g7Fagxvzhvqdk+ZHN9899H1sFD/1r0MfS1aLrbAqsOSeMUPVd3itDbYpL+rXLRtjtvo9YvnelkyPmL5GIPbu2LJps40q9OqryNpbIz00E4hfs36dJUhTukqd/979xYb1/tY7CyF1iN/s/XXbs2Ma81n605hhD30fG8VP/evQn8bc21i1t0Z6aCYQv2b9OkuQpnSVOv+9+zuN2Y/wkgfES7HjhU+8eIBXcGwWdhve9+sH3v7SAT6u8uQLB/gih3+MhW2Fh9xyFjeeD8WcrY8FqjVyFXwobAwWy1joGXPy9QT2zNlRoKpLzU+4b4P5oc0v8mTbPUf/mu/v1O/pY8/oq9ECK0TNmF9CAhpf6LP5shFbJV6/veRc1E8m6CtQqd8j1lv16a3E3t1gA9V2hS11yytQ3YhT14Br068zA2kaA707HpH765EN9xdL1vvrccN1yL/Z++u2Z8c05rP0pzFPY3429acxg26stFNCcP7GfQ36dWYgTWOgd8cjcn89suH+TmN+YLwUO/yxZMvgoyJE2HR4BWe9/oER6337Fw54Do83XwthLF8aoQ1n6GOBmCJfVVLrdbWirznYKsbMDFRj1vweas9Udan5YZMd/9GLc/Tr/PjYC9U/9ffWZyVgtGrP4b4NLLn+2s6q/8LnDSoHNmV6eb1JG+hluydio9iI6a363iv6RCD27tiyabOBAlsqkMOmXONARMf2ejUHyLke/Zichs7beP49cqH76xHR996bvb9ue3ZMYz5LfxrzNOapP42ZnL037uvRj8lp6LyN598jF7q/HhF9773Z++u2Z8ctGDNf5LCNYPG6gw+wsKHw4RHabCjcfm6qvS7zfG488bP1sUDAILfrk//6N7+uoTpYsn5dalw/OqA6W+p3naH+FmM+R/+c+Z/616CPxWK9tFkb2DNt4toLC322WtD6eWPJJlvrp229i/rJR03bUPR7GzfU7ZVIhe1bIzpqPPb69XU2aOu8nTP/nvMM31+3PTumMZ+lr0aINW7XJ38a8znzP/WvQR+7ncYM+23c8LD6Ohu0dd7OmX/PeYbvr9ueHddtzDy03B575bW4MfwROm4JmcaTzx54/8sH3vnpA64A3DY+9nI1+mqo9VX2a+KNB6ofA8aY2VJpuzGfrb93/VPf2UGf9aCmq/rau8ip+lbbu18+gP5//KsHXiu+Qf3yMR+P2xa8qJ8tHn0yjaqvW7aiW7a269as0Au9jZg4aBwYm4JBiDdQuB/9OhtpuoJj5/+1m9sg7Zm8v257dkxjfjX+oPrTmPeuf+o7O+izHhamK/rau8ip+lbb3LgZm4JBiDdQuB/9OhtpuoJj5/+1m9sgbRqz/9eO5JEPgpdih7/gAh51XrvFXWzwwRZuj32R452fOcAXQvxDAbyUI8faHr9K/RVjvqj+afXzWhIbVoifr793/VP/YfUxY7fknr5trL5Z29bsOvQKK3G2ctu+F/pEyNmgXzdu3bK1XTff2K8D7WX7hhgYkKPU3iTe0N799LlqlGkDs+RTd6H5h5X4hfTj5jb0WpgBbcfkNIikyWlob0x+IwYG5Ci1123PjmnMV6c/jXmP+qf+w+pPYz5/407iDe3dT5+rRpk2MEs+dReaf1iJX0g/bm5Dr4UZ0HZMToNImpyG9sbkN2JgQI5Se9327LhuY2Yzso+l+G34tMHDrL22TXivbR8OvzyBTF6XsbXxGk0VrkZ/xZjJvIL6sWHlsvqusFv9U/+q9dt+2rDt1SHCpkyEjZjXmMTZc9EnnxztpU1viDeIWK9u2Urs3Q3dRpXYYU/oVXo5MfyEXqWXE8MHvToPaYoa58+/Rxj7TN5ftz07pjFfnf405v3qn/pXrT/cWD3yDG/cp/UqvZwYPujVeUhT1Dh//j3C2GnM/l87kkc+CF6KHTy0/jqCR9o+BP/eVw747eHx/oyhjz03UjcFYOOgfZX6WPLi61Ih3rj6+qf+1Pf2temzTRNHwbb1tFMHumUDLzBp65YKsc9GXCNKDEk58Y60QaSXWSNKDEk5x+rrldKGNFENn1ubfz5+5fOslgky/697/y8Gfkekl7vj95exR+rf1v1127NjGvPV6U9jnvrenvqX1b/xjTvSIq4RJYaknGP19UppQ5qohs+tzf805hiScmLyG0Q0023Pjus2ZptWf0XGRPPQ1q928EsP+BgL+bxq4ybp402EV2dXqb/yKvum6p/6p+nz9TO4xfpvQJ98fdWJGnHRr9s3W6du2ZXYYRtEdCOuvRoB4j1q5v3o1xkA5sdnUmYPFvNPjsw/ZvyVn/3t4Hd9+/c1fDh2K/nH6jskExeFuLkNrkWvLiYkQQ4Qiclv1F6NAPEebnt2TGO+Ov1pzM+m/jTm3fXJv9mNu2bej36dAWB+fCZl9mAx/+TI/E9jrrjt2XHdxsxU8uDxlRIeUZv0xY0hk15eW3EzePHFR1HQ4XWHvhC7Mv0VY76p+qf+WH9hwKZDm190ypfQztG/9fnZUR9NFGizcb9s2Ki6ZStsoNpmU6atxH7dIJ8v0ujYLW0UaCsh3iB/D/06CnSWKuP5x5Lhd3z0ywGRhT0zytTq2J7+7d5ftz07pjFfnf405setH67cQIf2NObd9dFEgfZNbdxKiDfI30O/jgKdpcp4/tVcpzGjQNttz47rNmY+0MGDx+2hDTyEPKKvGDycRHi8eYVFhHxj8YER1K5Gf8WYL6rvkZudH4/crD42PP6jINdcv0duUV83a7ZvG6WbdQ82U91St7d5jbk9Xtu6fdecS+n3emkrOjM+85VijRgqL64x43/5r14JiCxea8s90rGLHNG/9fvrtmfHNOZX1a5Gfxqz80j1pzE7969/4xt3jdO+lH6vl7aiM+MzX9HZnsY81GH+3fbsuGpj/uNf/dWBf6yDVxY8tDxyfAyEj41wY3gs7VcfLF53kKkP7ccNIlejjyXr16Uuq+/5Nzs/nr+z/jf//Tc1LqYvxrDFmM/R9/zLzs9j0sc2bONe6POBo7KVs4FW6vZKu/dK81h0rLb301cj0baiM6O4HTL/mCIRZrUYM20s+eXPfryhvW66NpY4YN5AjmeqMd/s/XXbs2Ma86uRq9GfxnwN+tOYH63+zW7ctPfTn8as1Pmhvd/8u+3ZcdXG/HPv+54Ae37yxRcbvo3yKFqbbdTj3ABbIis3hqXDg63LyL6ecQ369VX2ZfVVJ4qf+gd9PmRkOn/vQ29uqL7nbNFnaxB9b4s+BowxY8m0F8Z8hj5jtX6NP6P6bN9Dfd2yK7GrBrq99swMVCEEB5HK3vqgV6SoglugzD/xJ194seHzjzGTSdvmHyvFgNVoiagNg2Zi5KCjFvZ8s/fXbc+OacxrD/aD6k9jdp371xdjmMb8CPWnMUukh16RogrTmCuqEIKDSMVtz46FMV/bocYM2LNvkTxyBtuox+0F13u+dMAjvOzioyI8orzgos3yso+ZvOOlAz7qgfSrMd9W/berD+h7216oelv0XaGj7/UQN33/sBJVmT5/AgQbVvxPgwzr36LP/FC/52+en0erz5ZtuL6YiuJpZiepq5H201U0MwYG6KdgUEcRUTQeacH5+qC9kRy43TLPZsb+JxcxZuJmzDr/mKjaKqgN1whtLHn86htu8f667dkxjfnVBSQPto96IP1pzD7q3vUBfW+bMXhb9F2ho+/1EDd935ioyvSnMT+A/qu7dsP1pzFLpKK9kRwwPz7P05gF9FMwqKOIuO3ZcQPG/Ll/8DONF7756xsYMxulb5f24NUID6pH+DDI5w6wpfpCsQfbN1l7FcbDH1KHsfeuv2LMN1X/rev3QJ+PFHnE9P1LPqK/2Jiolra+gLX6sWEFfa3/HH03MJmfZ1qf16rMFXPIBm3bt78Itc2a+detk3yNQG+T1Ui1B/TVGHr6oJr76auythXVVNCnEm8zzzrn0sZKAYsFDBs0BwPW3oUl13NRw03dX7c9O6YxX50xTGMOqcPYe9fvgT7G6RHTP8c4kys30Nf6z9GfxrzQv/GNu7bhUvqqrG1FNRX0qcTbdc6lHY7bmMaMptueHQtj/r+988823v+Xv7WBBX7z7/93GrQ1gk26Zf7cmxpv/YFvatBWE0WTjUzbPDC0VVP563/hGxvYMxE0GQVb9D1ir8W8zc2zjSASDnH7WoVG7l8fS9avS9F7K/XTvkX9MarvZm/6/uLUDAP9d/3aAY9bnV6P4Q8tvfbo8kcX0Hcdqd8zp/5l9dm40Qe2b9qWyaapmbGTHoVryvbtxZiRLHLMPDwy3MqVvfUV1xF9dFR/8REwcsg3+JENXxHEjNV0eVkN1YBpA70LYzZu9/66DdsxjXmZYw+2Ru5ffxqzRu5Tf4zqT2P23tvVv8GNu8fe+orriD46qj+N2Ys5cv7dhu1YMWbfeswssVvAJrHGP/rnv64RDtromSiaCvpAhEy1Z22jTEQ1VUEJ8ejViMJjnIINHUVbibTo1Yhymn59lR0DE9dZf6RFr0aU29X316emj0lr78K2MYZiD94LZjyLr3aIvr/U5aUcFmXw9SrYQ9/HRvGPTB/DANs0F/q6pbJxm75HLN/bkukR019EOvps06pflSGkDvEH0l9EhvqO6INaMl8RVGOmjSX3Pt6loOY/AOIU3FmQ81JPnR+/FqnfI5bvbcn0SGd+qv6x8+82bMc05qszhmnMOoq2EmnRqxFlP301hmnM5N+YvmyLvY3VN9Cr2bg9/kD6i8hQ3xF9mMZclYGI27AdK8YMbo32appX1mq69GLPnjk00R5P/+LXN/Tl+Zjv/XPf2GBUklqFTN00a4RM2vRCiAwgM6RCQSNk0qYXQiQxNmbGaoRRtEO8EYIDyAypUNAImbTphRAZQGZIhYJGyKRNL4TIADJDKhQ0QiZteiFE7iSkBrgZ2GP2vl8/8PaXDvBxJH+5Z18E8o8pYRtsIpazeLD50NMnDiwM2PRps8GxPZ2j76+Id6v/ivTZHNkoLdP17SXkQp9M0FeUou8R60XfI6KvOWN9tmzV97iBjqs9qL5HjtRnflirWLLaM0aLAfOCGtSS6yjai/VPPVL/bd1ft2E7pjFfnTFMY4YQGUBmSIWCRsikTS+EyJ2E1ID9jCdcuYE+7ZWNaW9ju3V9Nsqb3bhd7UH1PXKkPvPDWq0WO40ZHbdhO7rGjBFitz3THfP9b/v2xsf/k7c16lZIXCFfwYYVdNLAxhb9CqMqKa1B/H70qzGn5CAEEymtQTyKb6SEVUIwkdIaxB+HvrZ7rFgyHzViI8BUeMVqvf6BFOt9+xcOeA7bB1/7YSxfCqJtYMPjP3pxjv7e9V+b/gufN1AGNk16ef1IG+hlOyZio3xTtl70PXIhfY88qL5HRN8j6MBmfdZqBetVMwYi1Zh1/dNGx89+ofnRa+/Nj3OSvkdE323YjmnMK6S0BvH70Z/GnNIaxO9HX9s9pjHfrv7tbtz3r+8R0fcIOrBZn7VamcaMvtuwHQtj1q0Ka0xeGyS/DMJTG6r2Sz/+vQEbn/YCvSmY6I3tQT6bKe0xaXgQxTd6mfSmYGJ8FsCS9etSt1W/Qv5jql8tucLHvvx1Fh9QwjD48BFtDIPHm4fWXrd6Pg82cXuMtxjzOfr+RSMzs3gXd8H6r0ifrRBUnzeKbJdVn7b1LvR1e9U2TH3VtPZzP/L8a/zEAVYvKxkDrpCjkL/yFETxjRucH7dhO6YxL0jDgyi+0cukNwUT47PANOZKFN/oZdKbgonxWSrka/3JiRPTmK9aP3bVhurfyMb9mnjjBvWnMY/13Ybt6BozqNEmD06wbTEq9tA7iRM1vvz3P9TQyGWhwjFkpiIHhHjjUvX3XmWnUlchMxU5gHyY8z8mldpQS+aV6eLB448Y8vhhD8aTzx54/8sH3vnpA/4AAw8qH2tiiMXZejBmNiPaviWdrb93/Vehb2Pf/fIB9P2PLoR4A30+tkObuG2vC322YPTJNKZ+Tx9L/s4fP/Ddxlt/7ABreMxzP/R8480f+a5G6mr4l6bsLLc7P27DdkxjXkBmKnJAiDcuVf805lTkgBBv3H/905hvTN/G3u7GDberP415rO82bMcdxgxpN7wgehY21pSQ4KWijtpCErkgepZL1V+NOYlcED3vnP8eSaSxsGRek2IVvFaNp7TBB5d4/OyLQO/8zAG+8MOHPvylKznW9jjKBltP2o8aviWdrb93/Vehb9ufb6a2dboOvcJKnK3WtteFPhFypv4Gfcz4ue8/8B0f/UuN537w+eCr/szvb/C/nqxw77J87Pm57xMsovq3Oz9uw3ZMYz4LPcul6p/GvB09y33WP435JvUfhbHduv405p6+27AdC2Nma+vBpvb+/+Pvu5M0cCNb9NOQo7iV+qsxE7+V+ntcf/3JfRPo915lAx/+cjPAKuxDSdiMf4jJ7Mfhl2OQyetWrIXXsKpgjzE2rFxW3xV2q/+B9dt+2rDt1SHCpkmEjZLXjMTZWNEnnxztpU1viDeI0Etk6of4r7z4XHPoV02aF90YrVsycYwZGyYfM96g7xF6iVy0fo/QS+QMfbdhO6Yxr5AGbuRS9U9jTgM3cn79yYkT6E9jvmF9tsXYVRtE2CKJnLGxem+IN4jQS2Tqh/g05ui1ttuwHQtjZuuBn/i2rw00nna6RG9Uj5qZBBMhnkZVeplJMNEb1aNmvus/+KbgjX/ga4Pt+v+Xv/d/SmhvlLrKFn2lZibBRIinUZVeZhJM9Eb1qJlJMBHiaRSQw+trNeCU1kh+HPAlive+csAfP+zhM4baBg+qmgpgPLSt11+LMXbqT/2p/0j13YbtmMa8oDeqR82cxgy9zCSY6I3qUTOTYCLE0yggZxrz1Pf21J/696jvNmzHijHr5qXQG3tc49v/9/+7BPE0cCOqv12TUUpKCOhFDfQsQDwN3Ahm/Lf/03etgj2nIY0ou4EN/39++/8b/P9++yMNtecovpGKbxBPp9iI6m/XZJSSEgJ6UQM9CxBPAzei+ts1GaVjMebK02LSC0vmUeShrV/d4Zdm8DElXsnyqpaHUx9vIrx65TUX+VN/6k/9R63vNmzHNOYFxNPAjUxjhpQQ0Isa6FmAeBq4EdXfrskoHZv8OHg6jXnqT/2pv5u+27AdC2NOe1aCzYjNC3T7A+Jp4EZUv2pCGnIU+9VfLZlIjffsGevFhqsxAzlRfCMV3yCexDdyu/MP59dPDh8EQy15c+Op2LMaM/iHv+xjIIsHj8eSB5jXYjy0vPjio0w8wHw8RF+IEecrQyhcjT5/0ga+5o+8PriUvuvc7Pzcuv68v/ep7zZsxzTmBcTTwDupBhyunOLTmFVNzwLE08CNnF8/OdOYt+vPjftx68/7e5/6bsN2nGjMuvEp9KaBG2EsJNmG9qaBG9mj/mq94ccJzan2rMZc+c1//Vcaasyp7ODY+hXGQpJtaG8auJHrXz/0Uif2zBelsGRtkwNqzP4QAg8hj+grBg8nER5vXpERId9YfGAENXuYXxNvPKg+m/XPve97VvHt+4rrn/qezNiiz/196w98UyPd3Ma8v3vouw3bMY15wbH61XTDiROaM405iQfn6DMWkmxDe9PAgF7qnMbsyYwt+tOYPZmxj05/GrMnM/Ze9N2G7TjCmIHNK+16Ab1pyEbY5nr6xCENPAoUknhwrH413XDihOZsN2Ys+X6M+RbnXzm//tpLBEvGqu8wZl5e2UPrr7X5GAgPNq+/eCztV2csXmeRqQ/txw0ifGxE9P2RZhQfS9mgz4YL+odct+sz9h//rR9q/Df/+XsbadcOfPu+aP3eu9v8eO8zrM/9feHn3tTAmCv73V/ODqetz7G+917l/LsN2zGNecGx+tV0w4kTmjONOYkH5+ifX3/tJTKNWfUZO435sepzf6cx37++27AduxgzpIF3omOTbEBvGngUW/QhDVwFi/3l/+t/2VDr7VkymdWYAetVMwbi5FBbKjuI4hshuxEdm2QDetPAo9iiD2ngnejYJBvQmwYGtZcIqDE/tY+AQbVnxR9pHkva/Co+e0QXD7bE/cGmzcdJ7OsZT754oGr6/wQM9dnswjUbutWy/W3RR+eFb/76xuf+wc80MGk0idBLJrCJ+1Y+1O/Vr/E95mfqe1vuL/asJr3f/UUnFmdi+/rs6Wv8OuffbdiOacwL6IU0cJVpzMeyRR/SwDvRsUk2oDcNDGovEZjG7G3TYWtmm57G/Jj0uV/cwWnMtO9H323YjgsbM8Re1kjDV9F8SIKB5iSRjTA2ySbiFI00PIHFYsDVnhV6yazGzJ+s+NjH/0kDG1aI8wctqCoVnIjiG3qWHpoPSTDQnCSyEcYm2UScopGGr6L5kAQDzUkijRqP5AYGjDHzchvUqpMrN3jwaPvjbS+43vOlAx7hZRcfFeFx5QUXbR5v+5jJO1464KN4vDfos+Vhn+HEq7D9uU5HHzXfuIW//he+scE2Sk7sqonF9l30739+pr7qn3N/WUXH3l/UWJ/jH45sWZ97z89++m7DdkxjXiFO0UjDE9OYj4WxSTYRp2ik4atoPiTBQHOSSKPGI7kxjVnV0q7dmMbs8RvXP+f+soqmMZ+m7zZsxxHGrJsUpF0vSGlBEmykhEaSWoXMJHUncYogyQYpLUiCDTVmwIArmtMz5h/80Z9qYMMKcTVmSGUHmqPoGSElNJLUKmQmqTuJUwRJNkhpQRJspIRGklqFzCTV0Dht0FG80O4ZM+YNPGwVfxrtQfUIHwb53AEeWv+6hT3Y/hjbqzAe/pA6jJUHWyOqz8bH9uqvIuXlpL+rtF42vpBqVH3fHEWztrdvslWfyH3Oz9TXSO/+/tE//3UN2txf1k+P7fcXTc7F+kSfdeIrdvP6rPq3Mv9uw3ZMY14hpQVJsDGNeTtxiiDJBiktSIKNlNBIUquQmaQaGqcNOmoaMzmqWdtsrNOYPXJT+r37O41ZI3vouw3bscmYY4cKdANKyUEaciexb96JjkonXUXz4VL1V2MeQz6goJas/D/toFfBni9Vv5ImeYCOSiddRfPhOuvXCO06it7t9gw8eNrWB9Ij9gUMb/P6yz5CEgmHuH3tSiNb9HXjU/TlJJG68VX99//lb22QiTJtjaC2ZZOt+rTvc348MvWtfez9Hf9PXtWnrfWrpnLa+qS93/zQ3kPfbdiOaczTmJ00yQN0VDrpKpoP11m/RmjXUfROYyYTZdoaQY2NexqzR25EfxqzRu5T323YjoUxs/WMQajChlVJw1ep21+ll3PsuVLZgeooaXgCi8VKkwcnyMRcaaMQjtsIVw60F0uuxgyp7CBKHdCbW6WXc+y5UtmB6ihp+Cq92pReTj2XtusoeqlZ7VmNGeLSEvFMNmpEqY8x6CjaSqRFL9sZ25++kKTN9keETNWhrRAnX19Wo4NC7K0BvXWTTeIN9KFGlEvNj0aUZ1mf+4vdgt5fVk7c3MY595dMzshYbaNMRDVVQQnx6NWIcm3z7zZsxzRmR3WUNDyBxWKiyYkTZGKxtFEI322EHwfaO425R682pZdTz6XtOopeap7GPI2ZthJp0asR5Zr1ub/TmGkrkRa9GlGO1XcbtuNixgxsW5UkEtSND9LwBvqacxpR6irppEESCbBY/VpUNWOocdqYrtpwuHJEMGNto5CKb6Syg1R2cOvzv0f95NOu+iHYQFPt+ekGY1bIjCe2USNk0qYXQmQAmfpycsz3/rlvbGzRZ6PkZSbopkxvbfc22R5UElMRM6ARMmnTCyEygMyQCgWNkEmbXgiRAWSGVChohEza9EKIDCAzpEJBI2TSphdCZBW/a/Zqund/sWfPPOP+7rE+gcyYipgBjZBJm14IkQFkhlQoaIRM2vRCiARuw3ZMY16QThokkQCDnMa8nSh1lXTSIIkEe9RPPu2qH4INNKcx9zbu2p7GXCNk0qYXQmQAmSEVChohkza9ECKr+F2bxjyEzJAKBY2QSZteCJHAbdiOhTHrNgRsRkrSWkU3LyVJNepZ0pAAZc2EKHWVlNyIIgekUwdJqoFBqjFXwo/Dhonrl6mIqxmDWjKQ3zNmSGUHqfhGnaU0JEBZMyGmepWU3IgiB6RTB0mqUc+ShgQoayZEqUlH40A8yTZUuWfPvOimrZExqqOktAbxsf73v+3bE2xzynZ9Nkq2496mPIYaevpx6gGMqqS0BvGpDymtQVz1uUf3eX/JV9LibKCTBja26FcYVUlpDeJ767sN2zGNeYV06iBJNaYxx1SvkpIbUeSAdOogSTXqWdKQAGXNhCg16WgciCfZhipPY57G/Dj0uUf3eX/JV9LibKCTBja26FcYVUlpDeJ767sN23GEMdfNSOGFnr7WqxEyVVPPovo9YmAQpa6imaoTZQe12hohUzUxSMwynDihxkwmFqs5asm0NVLj1ZhrtTVCptavs6Tz0yMGBjHVq2im6kTZQa22RshUTT2L6veIgUGUGjo1DsSTYIOqaJNDtU87D6FCDgq0x6ThAWccn5feFEyMz6Kwdaa9OEj7aRB7bkPVovjG/dQP5N/i/AP5e9TPPUq3NYibmNC7nE6xCuea809tbsN2TGN2arU1QqZqTmOOqV5FM1Unyg5qtTVCpmrqWVS/RwwMotTQqXEgngQbVEWbHKp9OnwUgRwUaI9JwwPOOD4vvSmYGJ9FYfNN+3UQTpxgFKhaFN+4n/qB/FucfyB/j/q5R+m2BnETE3qX0ylW4Vxz/qnNbdiOTcYce1CCghTyt7PlLBStmQrxHuQkwSAV3wjZjWCQmGXPntWSycRo6SWihBMH2suoasyQyruTLbN0zfO/5Szb6+/FgXgSb/Qq57zpCRzwtDzGFTJR3kKIN/hfHI2cT+zIjXDfVa6zfiUmeQCZqcgBId64xfr1/n7k/X+5oRElyjiZVOoqZKYiB4R44/rn323YjmnMZ9U/jZl4D3KSYJCKb4TsRracZXv9vTgQT+KNXuWcN57bO3laHuMKmShvIcQbe2xMujUnJ05cZ/1KTPIAMlORA0K8cYv16/2dxjwmlboKmanIwG3YjjuMOe1BCbYkRNOudCd6FiJJvIGyZkKINFJXIgkmzq9fjRkw4IrmVLvdApZcjfmc+oFImpwGypoJIdJIXYkkmLi2+jWuaG86RVAzubp4bgdQ5x7oWdiYUkJie81KErkgepZZf48kckH0LLP+HknkZNyG7ZjGPI35hucfiCTxxrH1a1zR3nSKoGZydekZXoU690DPMjfWHknkguhZZv09ksgF0bNcf/1uw3Z0jTntO6twGWxDFVUbg45CoSktMT5LKnUVzhUFJ5LgKtWYt8Co8zm/fkBHuZX5hyg7OKf+VGRDM2lrL2esOcTZDniAafdQnTFp4Ea26KchRzHrHzPrHzPrdxu2YxrzWfVjkMl37ySc9UzOrx/QUW5l/iHKDs6pPxXZ0Eza2ssZaw5xHrlpzEoauJFZ/5hZ/5jrr99t2I6zjJntL521QS+F0lblHkmkkRJW6WVy3jHn149Bbn81zS8MYRQKnDEEA8475mHn/yve+rWr0Mt5xzxs/VAzOWOFXvJTV0N1aGv9PHhENA4aZ2yP3qgeNTMJJkI8jar0MpNgojeqR81MgokQT6MqvcwkmOiN6lEzk2AixNOoSi8zCSZ6o3rUzCSYCPE0qtLLTIKJ3qgeNTMJJkI8jar0MpNgojcK3IbtmMY8jdlJIo2UkEh+HNDLecc8bP1QMzljhV7yU1dDdWhr/dOYoTeqR81MgokQT6MqvcwkmOiN6lEzk2AixNOoSi8zCSZ6o3rUzCSYCPE0qtLLTIKJ3qgeNTMJJkI8jar0MpNgojcK3IbtWDFmHdwDoXTWhvb24Cw9kmAjJdxJFDmAStKJGtrbQ8+lxjy2ZyyZHDXmShQ5gEpS8Q3t7ZFOl0iCDeLJfRu/76++ofGd/+iDja/7yW9pvO1jH2hoThScoJJ0oob29ohSV0mCjZRwJ3quKLiRZFepOowNwYhU6O2pAfE0cCOqv12TUUpKCOhFDfQsQDwN3Ijqb9dklJISAnpRAz0LEE8DN6L62zUZpaSEgF7UQM8CxNPAjaj+dk1GKSkhoBc10LMA8TRwI6q/XZNRSkoI6EUN9CxAPA0M3IbtmMa8QHt76LmmMU9jVqoOY0MwIhV6e2pAPA3ciOpv12SUkhICelEDPQsQTwM3ovrbNRmlpISAXtRAzwLE08CNqP52TUYpKSGgFzXQswDxNHAjqr9dk1FKSgjoRQ30LEA8DdyI6m/XZJSSEgJ6UQM9CxBPAwO3YTuONuZ6eoXeLUStiSQYpLQBqeAEZ0/iQZR3J5wLi+UrTOHNCbVkOMeYOXsqO4jy7iSdNEiCDTXgasYf+NTPNogoatIPWz+ktI1wLipXnZANYkigY7dA/liTeBq4EdWvmpCGHMWsf8ysf8ys323YjmnMC6K8O+Fc05inMUMMCXTsFsgfaxJPAzei+lUT0pCjmPWPmfWPmfW7DdtxtDHHWRN8kIcPudCm0Aq9UesqSbyREgJ+qbpGUsGJJBtQ1bH1qzGP7VlRY37Y+nugiQ1XMw73XYWcr3rj722k4htRcIKqLlu/khKCOv8Vzkv9RJJ4I5KDuOSNcJaeGtCbBm6EsZBkG9qbBm5k1j+GsZBkG9qbBm5k1j+GsZBkG9qbBm7k/Prdhu2YxuxQ1bH1T2OuTGOGuOSNcJaeGtCbBm6EsZBkG9qbBm5k1j+GsZBkG9qbBm5k1j+GsZBkG9qbBm7k/Prdhu24mDGDZrKB6lZLnMyodZUQXM1kM1W0NwpYRZUrmrml/mrMoB/7Sq7cYNQ11I+VYqIYMPEtZqxx2ry47lkyRKmraOaW+nuE4GqmzjykhASPHGcnovrEtRc0vh00VUepZ9zOeOMgDmngUaCQxINz9Gf9W0AhiQfn6M/6t4BCEg/G+m7DdkxjXqCZW+qfxqztacwxpKHx7aCpOko943auf2MaM+vfAgpJPDhHf9a/BRSSeDDWdxu2Y0djTl2JqHWVcWbaVQN6tYaKKle2Z3Ku840ZHUVrqKQyEr1MLBMwXbVVhRrUmHuQo8r71V/hXD3GmbFgVue/Uh9p2lqtMu4dw9g4dYJeSAPvRMcm2YDeNPAotuhDGngnOjbJBvSmgUexRR/SwDvRsUk2oDcNPIot+pAG3omOTbIBvWngUWzRhzTwTnRskg3oTQOPYos+pIENt2E7pjEv2J7JuaYxq/J+9Vc4V49xZiyY1fmvTGPezhZ9SAPvRMcm2YDeNPAotuhDGngnOjbJBvSmgUexRR/SwDvRsUk2oDcNPIot+pAG3omOTbIBvWngUWzRhzSw4TZsx4oxQxoTqHRle6aea8tGqTk9NF8rUVIZie2ZnKVnzDA25ih1Fa1ESWUkepkYZ3LWBl920q88Ydjk0wbtpU1OKjvQShStqrI9M53ugtS1VM+LVesLdiCiRq69W9Cz9CAH0vBVNB+SYKA5SWQjjE2yiThFIw1fRfMhCQaak0Q2wtgkm4hTNNLwVTQfkmCgOUlkI4xNsok4RSMNX0XzIQkGmpNENsLYJJuIUzTS8FU0H5JgoDlJZCOMTbKJOEVDx7oN2zGNecH2TM4yjTmVHWglilZV2Z6ZTndB6lqq553G3IOxSTYRp2ik4atoPiTBQHOSyEYYm2QTcYpGGr6K5kMSDDQniWyEsUk2EadopOGraD4kwUBzkshGGJtkE3GKRhq+iuZDEgw0J4lshLFJNhGnaOhYt2E7FsZMqkroMCV0g5qfEhLhpifwv/43/81A4yhH8akeJcoIan5KSJB/jjEnwQBl0HqUNKRR84ljn7x2BjXXaszQG0Wb3jh1IopP9ShpSKPmp4REnOIoksgqrKXeqBrRj6edY8whGEQBiZQWJMFGSmgkqVXITFJ3EqcIkmyQ0oIk2EgJjSS1CplJ6k7iFEGSDVJakAQbKaGRpFYhM0ndSZwiSLJBSguSYCMlNJLUKmQmqTuJUwRJNkhpQRJspIRGklqFzCR1J3GKIMkGKS1wG7ZjGrNT81NCgvxpzJUoPtWjpCGNmp8SEnGKo0giq7CWeqNqZBozxCmCJBuktCAJNlJCI0mtQmaSupM4RZBkg5QWJMFGSmgkqVXITFJ3EqcIkmyQ0oIk2EgJjSS1CplJ6k7iFEGSDVJakAQbKaGRpFYhM0ndSZwiSLJBSgvchu1YMWZQoWNP38tU2P7UYk8DHVD9Wk+vKs2EXmZlD2OGWk+vKs0EMrFPtdvtMBYwY74EBamAVWo9kNIamgm9zDFJJEhpd8JaqgoagRjSUHs+1phDJEABUnKQhtxJKn6AjkonXUXzYdZfSUUO0FHppKtoPsz6K6nIAToqnXQVzYfT6ncbtmMa84n1wzTmHrUeSGkNzYRe5pgkEqS0O2EtVQWNQAxpTGNWZv2VVOQAHZVOuormw6y/ojM8RkfF7R6g+RCL56j63YbtWBgzQpqaKj4K1VHY+JK/ngxqXOr91K+cY8xP/+LXN6hZUf1U0lGorerr6x6ao2Mr2PPTnetXnR6c8alVQmSsQKaOog3ksKKqjkYUeqEaM/QexUoUk0Chkoav0qtW6eUce65UdqA6Shq+Sq82pZdz7LlS2YHqKGn4Kr3alF7OsedKZQeqo6Thq/RqU3o5x54rlR2ojpKGr9KrTenlHHuuVHagOoqOdRu2YxpzF9XpMY05Fd+4VP2q04MzPp3GPKRXrdLLOfZcqexAdZQ0fJVebUov59hzpbID1VHS8FV6tSm9nGPPlcoOVEdJw1fp1ab0co49Vyo7UB0lDV+lV5vSyzn2XKnsQHUUHes2bMeKMStPO1vemDhTgi0Pkr+eCReZim88vWj9oPo9Y8aSx8asOj2enlT/V7/7GxrhuHeCJWO6RDBmDFjNWNuQCk483Xn+n5q+Qo7q9DJDJCCf9RnFbISxPWPeThSzSjzPiSQS1AohDW+grzmnEaWukk4aJJFg1n8sUeoq6aRBEglm/ccSpa6SThow1m3YjmnMK0TBq6j+NOZUcOLpzvP/1PQVclSnlxkiAfmszyhmI4ydxhylrpJOGiSRYNZ/LFHqKumkQRIJZv3HEqWukk4aMNZt2I6uMX/8P3lbIs7d0AtW6E0DG09tK6SI5KkXAeW966/65xhziDd6+koU30hlB/RizJhouG+ADdc2+WrJFXKACLU9vWj9aWDj6QZ9YCWgRpuxShrS0Pj3v+3bG/F/kBtNmsqpjfMCcUhDGtoLcYEDVF9JUo16ljQkQFkzIUpdJSU3osgB6dRBkmrUs6QhAcqaCVHqKim5EUUOSKcOklSjniUNCVDWTIhSV0nJjShyQDp1kKQa9SxpSICyZkKUukpKbkSRA9KpgyTVqGdJQwKUNROi1FVSciOKHJBOHbgN2zGNeQG9aWDjqdVf9acxU9vTi9afBjaebtAHVgJqtBmrpCENjU9jVqLUVVJyI4ockE4dJKlGPUsaEqCsmRClrpKSG1HkgHTqIEk16lnSkABlzYQodZWU3IgiB6RTB0mqUc+ShgQoayZEqauk5EYUOSCdOkhSjXqWNCRAWTMhSl0lJTeiyAHp1IHbsB0LY459KnhqGxZytBXkKIhCiSSRBq/46E2eehF656XOS9UPGq/GrJYMyZUb1Zh7UOf2+rFVjBm7rWCr2mYUcF40o4xA7VmNuQd17jf/ivb26ue8KZj4oXd8d/A33votDTVpoFqFMwKV1KurxJAG+cCMKXwdS7+UVSNkqqaeRfV7xMAgSl1FM1Unyg5qtTVCpmrqWVS/RwwMotRVNFN1ouygVlsjZKqmnkX1e8TAIEpdRTNVJ8oOarU1QqZq6llUv0cMDKLUVTRTdaLsoFZbI2Sqpp5F9XvEwCBKXUUzVSfKDmq1NeI2bMc05iPqB41PY04JCercb/4V7e3Vz3lTMDGNWYlSV9FM1Ymyg1ptjZCpmnoW1e8RA4ModRXNVJ0oO6jV1giZqqlnUf0eMTCIUlfRTNWJsoNabY2QqZp6FtXvEQODKHUVzVSdKDuo1dYImaqpZ1H9HjEwiFJX0UzVibKDWm2NuA3bcYcxK0+Xu2qghZLJaSoUnTz1IqAcpa5CtZXt9Vf2NmaFaitaP+aKcWK9vKwG4uHBAfosEdosNdoVLHmLMStUW9H6yUyTPCDEG9vrH4OyGnO1Z61Z4bw8iqxJIiktoJfMSjzVAfnb2XIWrlczFeI9yEmCQSq+EbIb2XKWWX8SDFLxjZDdyJazzPqTYJCKb4TsKm7DdkxjnsY8jXkBytOYgXgPcpJgkIpvhOxGtpxl1p8Eg1R8I2Q3suUss/4kGKTiGyG7ituwHZuMmdJ7aKGpK0G5yVMvAsqp7CCVkdhef+V+jDmdNKH1Y7RYshpzeHBDx+pZMDbiqEVawPLSUVtIIokofvWMY/Qse9SvxgzHGjOktEBzKuhQeTy9G9GzEEniDZQ1E0KkkboSSTAx6wciSbwx60+CiWetfrdhO6YxH1F/ZRrzFpJIIopfPeMYPcs0ZkXPQiSJN1DWTAiRRupKJMHErB+IJPHGrD8JJp61+t2G7VgYM1tbD06TtBpaKJE0MKDc5KkXAeV0usT59VfUmJMfB2rJ7/oPvqnBqCR1J1vqx3r1VTaRJLWK6qMWpwjSkKPYUj+RNHAj59dPDpaMGuxhzNrbAx00K0lwADpKb0tSxmdJpa7CuaLgRBIcEGUHs/5U6iqcKwpOJMEBUXbw7NTfO1cqdRXOpToV1XQbtmMa8xH1V6Yxb2dL/UTSwI2cXz8505hhfJZU6iqcKwpOJMEBUXYw60+lrsK5ouBEEhwQZQfPTv29c6VSV+FcqlNRTbdhOxbGHHU36gmgJwq9UUBO8tSLgLKeq1fJOfVXsNjkxAm1ZDXmJJXoVaL1V7BhLJkvTenYyrH6UVIaVellJsFEb1SPmpkEEyGeRgE5GPNT+XgavduNGfRcKS3QnArbh2pCEtlIEmmkhBNIBSdm/UoSaaSEo0ilrtKrn15WNe0kvkoSaaSEBHtRhV7OO+Zh64deJucdc2z9bsN2TGNe0BvVYxpzj15mEkz0RvWomUkwEeJpFJAzjXk7qeDErF9JIo2UcBSp1FV69dPLqqadxFdJIo2UkAgnTtDLecc8bP3Qy+S8Y46t323YjhVjJrVCr54gqgyIp4EBOclTLwLKe9dfOceYUaAqJcQT9EbxjVR8Qx+ANPxOVF81iaTkgFFKSgjoRQ30LEA8DdyI6m/XZJSOxZgr3/vnvrGh9twzaT1j6loligm0HiUNPIEk2EgJJ5CKb8z6eyTBRkq4k1TqKr36tbdHOl0iCTaI684D+gM1PoL6to99oKE5UXCCStKJGtrbI0pdJQk2UsKdRJEDqCSdqKG9FbdhO6YxLyCeBg6YxswoJSUE9KIGehYgngZuRPW3azJKxyY/DqYx90jFN2b9PZJgIyXcSSp1lV792tsjnS6RBBvEdeeBaczpRA3trbgN27Ew5tBdhcF6mlRxg3gaGJCTPPUioJxOlzi//krPmPXjYGNj3s4e9SuqXzUhDTmK66+fHD4Ihlry5oba8/v/8rc21KRBz74datCrUFLymSTxRko4gVn/dpJ4IyUMoM4evfqB3i2kkwZJsKEGXM34A5/62QYRRU36YeuHlDZAq61w9iQeRHmruA3bMY15AfE0cMA05u1cf/3kTGM+jVn/dpJ4IyUMoM4evfqB3i2kkwZJsDGNWeHsSTyI8lZxG7bjRGNOtQb0poEBOclTLwLK6XSJ8+uvPJQxp7KDY+tXGAtJtqG9aeBGrr9+eqkTe+bjG1iytjFmtWd47keeb5xjz1FkIqUl4v8JEiktGCsnkUZKGKDKSkpLpNMFKS0YKyeRRkoYoMpKSkuk0wUpLRgrJ5GG9qZFm1BlhdWrq5p1XqFXz1hBExuuZhzuuwo5/ELfVHwjCk5Q1WXrV1JCcJ/z7zZsxzTmBeP6K9OYt3P99dNLnfoITWNOCQNUWUlpiXS6IKUFY+Uk0kgJA1RZSWmJdLogpQVj5STS0N60aBOqrLB6x8YA9OoZK2hOY64k2YCqxvW7DdtxhDEDp9FCFXrTkAbx5KYXZHx2hZwoOLFFQekZs4Ixqz2fZsxw2foVFkdPnzikgUeBQhIPztE/v/7aS0QfKoyZc/kZ1Zi/7/kDP3agPtJEavwcVHNMGjggDVwlDTmZJDsgDRyQBq6ShpxMkh2QBg5IAwN6dX1WWLE9NFNXNW3iZHIurBQTxYCJbzFjjdPmxXXPkiFKXUUzt9TfIwRXM9O0N7Q3ClhFlSuaWet3G7ZjGvOCLQrKNOZjQSGJB+fon19/7SWij9A0ZkhDTibJDkgDB6SBq6QhJ5NkB6SBA9LAgF5dnxVWbA/N1FVNmziZnAtbncasvVHAKqpc0cxav9uwHbsYM+goepObXhzOouetUBuZlSi+kQaucp3GDGngnejYJBvQmwYexRZ9SAPvRMcm2YDeNDCovUSARwhjflp+/cjf+9CbA7Vqfbyf+8HnGxq5f9KEJDTzuQ89f8Bq/ub3/5nGrP98UsEJzaz1k6Prs6IrttLLxDIB01VbVahBjbkHOaq8X/0VztVjnKl3IXU1tIaKKlfGmW7DdkxjXhDFN9LAVaYxH8sWfUgD70THJtmA3jQwqL1EYBrzrP98UsEJzaz1k6Prs6IrttLLVPvEUKcxQ+pqaA0VVa6MM92G7biwMUOcKTKTg+5KraFCTg/NTJefqMasH/uC+zRmiOIbafgqmg9JMNCcJLIRxibZRJyikYavovmQBAPNSSKNGo/kBgaMMfPqCdSqqz2zsdJ2e/j+5xvf+dMHPGIfGXvuRw224w8atHk9br1v+fABH2XKqq8bymmM9T0+63+g+nUl6ypVdMVWepkYZ3LWBl920q88Ydjk0wbtpU2O1qxoJYpWVdmemU53cbQSJZWRGGe6DdsxjXkFzUyXn5jGfCyMTbKJOEUjDV9F8yEJBpqTRBo1HsmNacwen/U/UP26knWVKrpiK71MTBRDVaYx99BKlFRGYpzpNmzHEcacVBqp1jtJDnpx0umCVHaQ0oKUFqQJaagxY8ljY4bTjDkV00hlByktSIKNlNBIUquQmaTuJE4RJNkgpQVJsJESGklqFTKTVEPjtEFH8UK7Z8yYN6g9K77b2kbvEfuw2HM/cYBN+Ts++pcaGINv0z/8/AEZ5WNl49bI1Pexj0lfViPE0k2QqdR84tgnr51BzbUaM/RG0aY3Tp2I4lM9ShrSqPkpIRGnOIoksormaz1KGtKo+Smh4TZsxzTmFVJakCakMY15O3GKIMkGKS1Igo2U0EhSq5CZpBoapw06ahrz1A+pw9j71JfVCLF0E2QqNZ94z2Ix4GnMFc3XepQ0pFHzU0LDbdiOTcacxjd0A0rJgeZTVvLRC4I+5+qdXSPH1t8Di1VLhi3GjEI66SpxuuBS9SvM0hZ0VDrpKpoP11m/RmjXUfRut2fApLX9wqdebND2yEsvNrz9sRcP/NMDkXCIv/JiQyNTPxIO8UetzwoEXZmsSdAc0EwgE/tUu90OYwEz5ktQkApYpdYDKa2hmdDLHJNEgpS2EVWI4ler0kzoZboN2zGNeRqzwyxtQUelk66i+XCd9WuEdh1F7zTmqQ/3qc8KBF2ZrEnQHNBMIBNbTY67kXDlxjTmKH61Ks2EXqbbsB0LY055q7BQKlFZQsdSVvLUi6AXrOdl06SXSCo70LEKo3pgsdjtFmP+E9/4rY2eMYfsgFR2oDpKGr4K86OzVOnlHHuuVHagOkoavkqvNqWXU8+l7TqKXmpWe1Zjhri0ROy5jRpR6jYNOoq2EmnRqxFl6teIcp36rEPQ9Xksaqv6+rqH5ujYCvb8tPMUXKp+1enBGZ9aJUTGCmTqKNqK5qvasagOuA3bMY3Z0bEKo3pMYz72XKnsQHWUNHyVXm1KL6eeS9t1FL3UPI25RpSpX2dMOW3+WYeg6/NYpjFHWkCmjqKtaL6qHYvqgNuwHRczZmDbqjCWgpKnXgS9VDZKIK69qeBEKjtgbAWLVQPuGTOWTFuN+VhSwYlUdpBEgjo/kIY30Nec04hSV0knDZJIsEf95NOu+iHYQFPt+ak9zEDvGDJjR27UCJm06YUQGUBmSIWCRsikTS+EyAAyQyoUNEImbXohRAaQGVKhoBEyadMLITKAzJAKBY2QSZteCJEBZIZUKGiETNr0QogMILOu1TFf/e5vaITj3gmWjOkSwZgxYDVjbUMqOPH0pPrJ71H1FXJUp5cZIgPIVM0tkF9xG7ZjGvOCVHbA2Mo05mOJUldJJw2SSLBH/eTTrvoh2EBzGnNIhYJGyKRNL4TIADJDKhQ0QiZteiFEBpAZUqGgETJp0wshMoDMkAoFjZBJm14IkQFk1rU6Zhqz6vQyQ2QAmaq5BfIrbsN2LIw5jW+kkY1U2Sq6eSloJk+9CHw9P8pe5fz6YxICLBa7VRtW1JJpqzGnIhNxoiCVukoqO0hSjXqWNCRAWTMhSl0lJTeiyAHp1EGSatSzpCEBypoJUWowjifZhir37JkX3bQ1MkZ1lJTWID71IaU1iD9ufVYgpKUb0IsxY6LhvgE2XNvkqyVXyAEi1Pb0ovWngY2nG/SBZxY12oxV0pAG8bF+FN+IghP0poGNp6bvNmzHNOYVUtlBTEIwjTlKXSUlN6LIAenUQZJq1LOkIQHKmglRajCOJ9mGKk9jVkIwkdIaxKc+pLQG8bE+KxDS0g3oncaMGm3GKmlIg/hYP4pvRMEJetPAxlPTdxu24whj5jJASwRe6OlrvRpBM3nqRcCYlbiE4Pz6ydQ5wWJ5fY31Ys+KWrL+Sk4UUpGJOFFjj/r1LKrfIwYGUeoqmqk6UXZQq60RMlVTz6L6PWJgEKUG43gSbFAVbXKo9mnnIVfIQYH2mDQ84Izj89KbgonxWSrkz/qj+EYvk94UTIzPUiG/V7+uSdYwtooxY7cVbFXbjALOi2aUEag9qzH3oM7t9RNJIo2Y/MEMa2+vfs6bggPIv1T9bsN2TGM+on4ydU6mMUepq2im6kTZQa22RshUTT2L6veIgUGUGozjSbBBVbTJodqn9nCmJzBBDgq0x6ThAWccn5feFEyMz1Ihf9YfxTd6mfSmYGJ8lgr5vfp1TbKGMddpzL36OW8KDiD/UvW7DduxyZiRq1CQQn4PNHtWup3w4yAlNOISGqnsIBXfSAXfiRqz2rOCJWvkWGNOZQep+Ab529lyFhaNZirEe5CTBINUfCNkN7LlLMfWP44n8Uavcs6bnsABT8uDXSET5S2EeIP/xdHIZUmlrkJmKnJAiDdm/WNSqYGuYcwV48R6eVkNxMODA/S1flY47QqWvMWYFaqtaP1kpkkeEOKN7fWfBtVWttfvNmzHNOYj6q9MYybeg5wkGKTiGyG7kS1nObb+cTyJN3qVc954bu/kaXmkK2SivIUQb+jGtAep1FXITEUOCPHGrH9MKjXQNYzRTmMe138aVFvZXr/bsB13GHPagxJsSYhyqWPQTA56QVSfdio4cWz9CvrVmNN77IZaMmw35lRw4vz6gUgSb6CsmRAijdSVSIKJ66xfe0Hj6RRBzeTq4rkdQJ17oGdhY0oJie01K0nkguhZZv09kkiCNQkYLZasxhwe3NCxehatH7VIC/auP3XdiZ7l+ut3G7ZjGvM05gsbm5IEE9dZv/aCxtMpgprJ1aVneBXq3AM9i25MPbbXrCSRC6JnmfX3SCIJ1iRgvdOYe2oPW7/bsB1dY077zipcBttQRdWU8NGLo2dJpa5yWv2KGnPy4yC5cmOLMadSVxnXD0l2FXQUFkpKS4zPkkpdhXOpzph0iiDKDrbXn4KNVGRDM2lrL2esOcTZDniAafdQnTFp4Ea26KchRzHrH/NQ9bMmAevVV9lEktQqqo9anCJIQ45iS/1E0sCNXH/9bsN2TGM+un5lGnPvLKnUVTiX6oxJpwii7GAac2WLfhpyFLP+MQ9VP2sSpjGrJm0lDTmK8+t3G7Zj06vsb/79/04iOWIj6mgkkYSO+sgPP1nlZz/8Ghr/2x96DdWBdKJG7J6rsH1r5ZBEBpxjzElqlVRw4vz6lSTSSAknkApOXGf9qciAXpRTV0PPSJsHlV4ePCIaB40ztkdvVI+amQQTIZ5GVXqZSTDRG9WjZibBRIinUZVeZhJM9Eb1qJlJMBHiaVSll5kEE71RPWpmEkyEeBpV6WUmwURvVI+amQQTIZ5GVXqZSTDRGwVuw3ZMY57G7CSRRko4gVRw4jrrT0UG9KKcuhp6Rto8bPROY4beqB41MwkmQjyNqvQyk2CiN6pHzUyCiRBPoyq9zCSY6I3qUTOTYCLE06hKLzMJJnqjetTMJJgI8TSq0stMgoneKHAbtuMOY8aG3/oD35R44efeFPzRP/91jbFBAr1qt2q04cTRqxEgXhmfV6cDmIg0a4008E6w2OTEieTKje3GDKn4xqXqryTBRko4gVR845rrpzbQmpPsKlWHsSEYkQq9PTUgngZuRPW3azJKSQkBvaiBngWIp4EbUf3tmoxSUkJAL2qgZwHiaeBGVH+7JqOUlBDQixroWYB4GrgR1d+uySglJQT0ogZ6FiCeBm5E9bdrMkpJCQG9qIGeBYingYHbsB3TmBekgXcyjXkLqfjGNddPbaA1J9lVqg5jQzAiFXp7akA8DdyI6m/XZJSSEgJ6UQM9CxBPAzei+ts1GaWkhIBe1EDPAsTTwI2o/nZNRikpIaAXNdCzAPE0cCOqv12TUUpKCOhFDfQsQDwN3Ijqb9dklJISAnpRAz0LEE8DA7dhO7rGjCX/3Pu+J0jeHGDMmtmzSeJYqVoykb/zUwd+63/6m41/8csjfvOlA6pDO50uwcXX6YOUvJH7MWbYo/4eSbxB/A88+dpEDLmTPepnlcLX/JHXB0m8kQZuhGqpXHVCNoghgY7dAvljTeJp4EZUv2pCGnIUs/4xen/jhoYmpCFHofqgZwHiaeBGZv1jzq/fbdiOacxOSt7INOYYcid71B+u3JjGPEb1qyakIUcx6x8z6x8z63cbtmPFmNnm/vHf+qGG2m1F7Tl1NdSeaQMmqmC0yX0bxHu9gAL2zLnGxKwlUlpC61fOMWbVSacbkMoOUlpCz6WktKCnjBm/8lvfEhxrz6qspLREKrvBKu2tPbXnJNVIUo2UkOCR4+EhEmUHkRzE87YRfbCTVEBvGrgRxkKSbWhvGriRWf8YxkKSbWhvGriRWf8YxkKSbWhvGriR8+t3G7ZjGrOT0hJavzKNeRozRHIQz9tGzn+wxzAWkmxDe9PAjcz6xzAWkmxDe9PAjcz6xzAWkmxDe9PAjZxfv9uwHQtjZrP763/hGxvhuKukfTChmbr98QEuXlnTVov95/90Hc3pmTT2rOdKM3IyqlnZYsz8qcexMVdSGQH3CLbka84YHYXd9sCSf/I3/3hAHJ1IS6j+dqK8gGvng4e60hTWIfacBBtJMJGSGzxyPDxEeMDqYxZDGhrfDpqqo9Qzbme8cRCHNPAoUEjiwTn6s/4toJDEg3P0Z/1bQCGJB2N9t2E7pjHfgWpWpjFPY47nKnpB49tBU3WUesbtXP/GNGbWvwUUknhwjv6sfwsoJPFgrO82bMeKMbOp8Sob2ATHW2EPNjs1Y0wUsFXsVhnHq2Grfuyw98A5xvzch54/8IMG7Q8fSKcI9O5AnefzYQFhpX/yU78n8Yc++rsbaslAr4965fckvuFDf6yRTnQyzMML3/z1B8rK/Nw/+JkGvWQCJg3o1PknHk9RUB/p8QM27h3D2Dh1gl5IA+9ExybZgN408Ci26EMaeCc6NskG9KaBR7FFH9LAO9GxSTagNw08ii36kAbeiY5NsgG9aeBRbNGHNPBOdGySDehNA49iiz6kgQ23YTumMZ/FNGagdxozjHvHMDZOnaAX0sA70bFJNqA3DTyKLfqQBt6Jjk2yAb1p4FFs0Yc08E50bJIN6E0Dj2KLPqSBd6Jjk2xAbxp4FFv0IQ28Ex2bZAN608Cj2KIPaWDDbdiO7qts3+Bk46uEKyTo5WtUbHZqyXxQq5qrgg1/+UufDIj0RlV9+MG/8pbE97z45xLPfd/zB37kwFt/7ABtj9vG/R0f/UsNrkXZYsxqyeDGXPSf++DzB77/wHf+9AGsmvvC/ySlqU5Q1fb6e6gxY8YVepWFVePKEkezx3M/+nzjLR8+MK6f2XBjFli3/C8LOfF/MAGzhD2P56f3OBHBqvmVovpoEVEj194t6Fl6kANp+CqaD0kw0JwkshHGJtlEnKKRhq+i+ZAEA81JIhthbJJNxCkaafgqmg9JMNCcJLIRxibZRJyikYavovmQBAPNSSIbYWySTcQpGmn4KpoPSTDQnCSyEcYm2UScoqFj3YbtmMY8jXkFzBJbTX4c0KuEKzemMZOvvVvQs/QgB9LwVTQfkmCgOUlkI4xNsok4RSMNX0XzIQkGmpNENsLYJJuIUzTS8FU0H5JgoDlJZCOMTbKJOEUjDV9F8yEJBpqTRDbC2CSbiFM00vBVNB+SYKA5SWQjjE2yiThFQ8e6DdvRNWY2srE9YxUY8KLLNkriwGaHcSZPHVBtGHtWk9Yc9AEb1raaMRvxcz/0/AHbmt0MmiuvGbO3eflJ24zkWGPmtXY1Zm8Xfaya+8Ks6h3BZnTOmeft9fv/CthVq00uDBiLFRa9S29OhE8HvNam94/9l//bBmd87oefP0BVw/q5Rp0T2qw02kf8T0xHv/cg1Qh/oAJLPseYQzCIAhIpLUiCjZTQSFKrkJmk7iROESTZIKUFSbCREhpJahUyk9SdxCmCJBuktCAJNlJCI0mtQmaSupM4RZBkg5QWJMFGSmgkqVXITFJ3EqcIkmyQ0oIk2EgJjSS1CplJ6k7iFEGSDVJa4DZsxzTmV7d+zGAa8zTmacyWmaTuJE4RJNkgpQVJsJESGklqFTKT1J3EKYIkG6S0IAk2UkIjSa1CZpK6kzhFkGSDlBYkwUZKaCSpVchMUncSpwiSbJDSgiTYSAmNJLUKmUnqTuIUQZINUlrgNmzHwpjZktjsMGZMmm3ODUDAJMJ9G95lCsBGibKaK23Ql9W1F4jzCzt7OaC9/+S/eEfwn/3d72m88N+9eOBjxj8xfsUg/vKBJ1844HFyyDee/M/f33jhf3ixcY4xo/DCp4yOPlUxhzqroP8LRYR5ftevvdjYro81hpsGaqjuyhLnS1PVnomoAWu89tJ+4ZdePPDKgXH9/E8VV6qrSyPMxpb/iVF97Jl4fZA0AvFENdSejzXmEAlQgJQcpCF3koofoKPSSVfRfJj1V1KRA3RUOukqmg+z/koqcoCOSiddRfPhtPrdhu2YxjyNeRqzK09jBh2VTrqK5sOsv5KKHKCj0klX0XyY9VdSkQN0VDrpKpoPp9XvNmxH15gVtWfwLU9yMGY1CbZIQFktk7ZGemgmENdX2bUXMyYS3tzAnhU34P/WwJ4BS1bEHl74pwfOMmZTcGMQe1B9YPaYSeZZ29wdImS+8N+/eGCDPpaMNapxhpsGGseSFXo1Qmb4eoJ8hUpgS/1cL3YLzAMzwMzE4mzQW/8nRvWPNWaI56pRjRl6j2IlnudEPM+JNHyVXrVKL+fYc6WyA9VR0vBVerUpvZxjz5XKDlRHScNX6dWm9HL0XO958r/aFT2v0qtN6eVo/RrvkaY9UB0lDV+lV5vSyzn2XKnsQHUUHes2bMc05mnM05idacw159hzpbID1VHS8FV6tSm9nGPPlcoOVEdJw1fp1ab0cvRcyUcvjp5X6dWm9HK0fo33SNMeqI6Shq/Sq03p5Rx7rlR2oDqKjnUbtqNrzGx8tNnUaI/RTBQAZTXOihpt6hqAZu8V9x2WjBn/qiFm/L5fP+Bx4wkvtz9u/LJhtrHdmLFkNea3v/Ri44VPH+jpY0J8JIo5HMNHmah/iz5GOLZM4INatNWAiahhq5raM21gFJrK13zbVza21M+64tU0/5tY/6cQe/ZMWZ9EmDHV54tqxPVB3QKPVs+YtxNP8irpqQ6SSFArhDS8gb7mnEaUuko6aZBEglk/YJy//du/sSvVni9V/3bQ6ZFOGiSR4Lbqdxu2Yxrzq+47jdnAMisYJ+1w5QYR7JaIqhHXNjAq/DiYxhzP8CrpeQ6SSFArhDS8gb7mnEaUuko6aZBEglk/TGOGdNIgiQS3Vb/bsB0LY9ZXeWxebG1sZ7R14wMioBufgiami31WEyXSs1jt1RwgR/UxY+LhzQ23ZHkp6pbMC20ivLgmYr3+gSnrffsXDmBs5xjzC//jiwfstW1P3yv5xQPcned+wqANfNHIvmKEgo/doF+NWe2WtkYqarSqA7wkdz/m42NCcuUGxrylflZUb+3RO4b/3VF95vMtP3lAM/Xx7qGPZX3kIA1paC/EMzxA9ZUk1ahnSUMClDUTotRVUnIjihyQTh0kqUY9SxoSoKyZEKWukpIbUeSAdOogSTXqWdKQAGXNBBSwzF/51Jsa/+9/+R9dHJR7xqyRVHYwrr9HSm6gMyadOkhSjXqWNCRAWTMhSl0lJTeiyAHp1IHbsB3TmKcxT2Oexjw3VieKHJBOHSSpRj1LGhKgrJmAwjRmJZ06SFKNepY0JEBZMyFKXSUlN6LIAenUgduwHUtj5hc7GGxJmDEvCWmH1yborTno8Is+1D5pA1aqpqu9imamrkD1MWNGhTc3sOfKd/yLvxIs7Jk2X+DBMD5/YIsxqyWDG/MnXzygXwoq+v4/Dfa61fPtC10ex4b5opGZ2aL+DfoYsxowVorRElGjJa5mXHEbFlQBSyZT41jy9vr5HxRWV8V/dQz/40LbfnnImz/yXUFPH8P2/wGysUm8kZ7Phj6cvNDmYSOSkoMY0ojns5Ge5AZfx9IvZdUImaqpZ1H9HjEwiFJX0UzVibKDWm2NkKmaehbV7xEDgyh1Fc1UnSg7qNXWCJmqqWdR/R4xMEABy8REP/J//rsXB+WxMadSV4mBAQo9NFN1YtqDOts1QqZq6llUv0cMDKLUVTRTdaLsoFZbI27DdkxjXrAwhmnM05inMS8LTmim6kTZQa22RshUTT2L6veIgUGUuopmqk6UHdRqa4RM1dSzqH6PGBigMI25znaNkKmaehbV7xEDgyh1Fc1UnSg7qNXWiNuwHQtjxoS+88efb3y3wTaExVbTrZAT+1cDS67GDD2jJQ4aB8amYBDiDRS2WDJWtzAGLFDt2TbuJ5898P6XD1Rj/tv/6bsCIsmVG27Mn33xgFp+0X/npw+4AQOVfMJgCHF7Jbuof6iPJWPDClZajROIAxareHzpykEMXM3h7GrPW+bnrT/6fMMNGPg/yx8waFv82Plh/au+rur0fAY8ojyKPKJEUlpAbzzPiXiqA/K3s+UsbAqaqRDvQU4SDFLxjZDdyJazPAv1V2P+a3/texv/r9/8f5wMCucb87Mw/z3ISYJBKr4Rsqu4DdsxjdmZxgzYJPaZXLkRztpIrtzw+NJxgxi4msPZpzEr8TwH5G9ny1nmxpoEg1R8I2Q3suUsW+qfxgwhu5EtZ7me+t2G7Vgx5v/4Vw/w1RH99YfbwYb5U4z6BxnVMkGtF3sG4kr4blB7k3gDM6Y3vDlwS2Zr5qtT+ooYiJBjX9R552cOvPALB8bGDMmVG27M6NsHu3r6/qEnXrqSY22P8wIWsGpea0fxa/pYMnbIR67ClRvhlI2eiapVqyUv4pZJHOpYCF9vYMzj+veeH9Vn/bvN21fRWOHp+Qx4wHgI9RFNaYHmVNBh44indyN6FiJJvKFbkhIijdSVSIKJWT8QSeKN7fVXY04u2yCudlsjaUiDeDXmKKZBJBXf2F5/jySYeNbWj9uwHdOYpzFPY+7qT2NOXYkkmJj1A5Ek3the/zRm1dyCnoVIEm9cW/1uw3YsjZnfp8HLUrAIJq1/NhH4c4qK2rBSTVQZ9yq9nBi+2osN06uW3MPNGKtmy6bNh7Bs+4azjBmr4KtBZgNV/4WXDDJ514q18BpWFbAZFDAb7RV9jBlLVnrGrGgvaK/aLR8cI4e2RtSMAQVqcHvu1L/3/FR9N2Z7MX4pY9beHujEc5tIggPQUXpbkjI+Syp1Fc4VBSeS4IAoO3jW6t9izKdRjTkKCFLxjWuY/0o6RRBlB9dQfxJsuA3bMY15hWnMEI4baC9o7zRmHjkeSH1EU1pDe3sc+2D3QEe5zo2pR5QdPGv1T2PeQjpFEGUH11B/Emy4DduxZszYEhuZ2VLyrQRWpxbIa2Qi4ZcNIhrXiBJDUk68oz5Bn9qUdCENvkT07pcPLOyZmdFt3ebnLGNGH3v4jFH0F6YCGA9t6/XXtoy1+t/7yoGePsaMBVZjVtxEjXDfBDZMWw2YCGOJhGc3XLZYMrgxP9D8VP30CccG9qzwaOmDp49oPHsJzamwfagmJJGNJJFGSjiBVHBi1q8kkUZKGNAzZtq8rAbiGtH8GqE9NmZIxTdSwgmkCU88a+vHbdiOacwL2LinMYPbp4F9VjBa2uHKDSKMJRKu3HDZacySU3nWNqYxSaSREk4gFZy4nvqnMStJZCNJpJESTiAVnDi2frdhO5bGzGtbfZXN5kWcrcoi2FjyuYZaYDhiEA4alqlGW3s1AsR71EyUo7xGeHDgVypXB4uv1pDDx4h4ZWqvOtWYkx8HyZUbjFro80s/ir4Xo/ZDhFev3Bfy6cVU6leDRF+NWcEs1aTdPgVMNNy3QSZxRfPVkiHSGtizgjH36t97flQfG+YX7Cj/zX/+3oBfBaomzePHw5mevVXiSQ56L8HSwBNIgo2UcAKp+Masv0cSbKSEVXrGfD7bjRlS8Y2UcAJp8hvP5vpxG7ZjGvM0Zgcrncas+tOYt5CKb8z6eyTBRkpYZRozpIEnkAQbKeEEUvGN0+p3G7ZjzZh5bUubbY5ftWHmlFwtUPOr1khbIa69+nWpSFtluz71EKGtNftmjelyvWCRxcZNJgbAa0/LvJgxd/T9xSwfZcIwuDv6wpY4XxlCYVh/z5ix5J4xE8FKseRqtGTSBh0VUolIbpAP1FnrH8/P697/i4GPOnJ+0O9ZcgVj1gj2nJ66VTgLfM0feX2QnudGGngmSbyREk5gy5bEPVVi+FEk8UZKOIFzttRjSeKNlJAYGzOR3mtqqL2as92YIRXfSAkncM3zv4Xz63cbtmMas1+XXy9s2LjJnMY8jXkaM2zZmLinSgw/iiTeSAkncP7Gup0k3kgJiWnMKflMkngjJZzA+fW7DduxZsyYMQaAaVlELU3B8EAtkDb07BPUaBXivV6l6td6lHQJDb9SRWeD/zVhc8cMbPs+x5jdBlB7xSj6/oqVCPnG4gNNGA8104aOPhuiWiBUY1Y0rpYMaq7pvXQjRBqaqWgOUGet3yNlfjDjr/zsbwduz8zG5vnBJv/x3/qhhtrtsYztmbOkIUG15zQ8wbkqKS0YKyeRRkoYoMoKvdxT/scOiKTTBSGbqMpKEmmkhAGqrKS0RDpdkNKCsXISaVRjxmjVYo9FrVqNWc+bCguOrT8lDFBlJaUl0umClBZ89bu/YYAq/MEff1OgOdvVttfvNmzHNGbHr1SZxlx6aSdXbqjFJlduhEhDMxXNAeqs9XtkGrPAuSopLRgrJ5FGShigygq93NNpzGPlJNKYxpzSEul0QUoLkncmVOGajJktzIx58bqPLw7RS6ZFMDa1vWqNgMXysrraLeZa0Zw6SqFX9aOkRnhwsLgiDJhXmvxPCRFyMGaumm3dfvUEFpucOJFcueHGjCXwMSWMoegv5p9MejGVjxtE+FgT9WNaQ/3kggleMqsZ09ZIvIteRyxZ40S2wJbdq1/nBwOG3/HRLwe/69u/L9gyP5hlfTV9Djxy+vhxFoyfj4+lIQH2HE/vKmhugXzODrUXNN5D8yvcux5Ysv6PHXGUIy2RTjEgihyQhgRb5kfRnDFp4IA0sFGN+bL0jFlJRQ5IA1dJQ04myQ7QUVgmdvv7/uobgmrARL7zH30w6OVUnde/+XUNPW9FK3QbtmMa86tXNI1ZwETVhsOVIxJeu840ZoNHTh9CzjKNeRpzjzSwMY25R5IdoKPGhhqOGzkPbczYD1ZkW1i4QkPjbJHJ5xpqhGqZPTMG4so4Xg276msNtLVO3+K5FmzY7PnJFw4srJpM2nzISObhLGPGKviKDu2i351/jJk29dvXe5588YDXP9Rns0te2FADhtqrEVDrBe1Nb60b2luJvbgxnh/MmBfXmPG//FevBEToxZ7H88N2jClinGqfYxPtoQ/ecx9+vsFZXvjmr2987h/8TIOzkE+EXjIBkwbV3A46UVgiJTee+9DzB+xPd3jb6k9pq3Dv0pJocPfVkoFeHyU/BAFWBcppX0tEAY1j66/z89Yf+KYgJZ9MKjihmVo/lvkrn3pTAxO9LCiPjRlSwQnN1Pq9vXn97IdWi61+xVu/tvF1P/ktAeZKHDP+wKd+tkGbHHrJjIERRzmd+k7chu2YxjyNeUH4cVB7NQKx8wbaG34caG+F2mA8P9OYt4NOFJZIyY1zNlbuXVoSDe5+cuUGvT5qGrOh9U9jvhRa7e0YM1ue8Z4vHVDT8rZZlJocYH5QrbHaajVXhfwvf+mTAZHeKHpph3gjSgpS2Q23N7tG/uSlXy9xM2b/sBWvPe0FMvNzljGjb8bQ0+eFrb+85aNe2AmZtNGxj0G946UDnr9BP7wwCD8OA2bTrBEgUtF82hoZwwYN4/rVmGljyS9/9uMN7cWYx/PD1syrbAxSLbmim7iC0WKuPHL+5yM/+HyDs9Cr6Ct0ckIwgT0/933PH7CND/14whOoUdW4cvL5cx1Vn/r5kzbf+dMH2Go9/0cN24K5d6yQ+L+xRCyhYGHVuLLEY0msQuVv+fDzjWPr1/lRM66M54fecxjX/y1v+dO7koo5gdPm3/Nl/XgmbXSsd6yfihnwZ3/m2xvYJ+aqFou5AhEsWak5qoMyZ9lev9uwHdOYpzEvqCbK5lgjQKSi+bQ1MkY33HH9ar20pzFXUKOqceXk9zYO3y6nMXf06T2Hcf3JRy9OKuYETpt/z5f145nTmDkwId+wMCd8GkvmRbcZs2+UvOC1UZicWqAaZDjoUdSxGDCEeMoBatB2OHGj1u/Xy5XSZh50TvQFshnhpYzZ20XfrYgPK33OsI8sef0YM18i4ldUYt5a/1CfTS35YgN92tVW0w7bIM42qplboAbqp+0R6twwP5guBszr6/oSe8v8sEGrQY7tma2cfNrkJ8dtsB2w0dDmXPTWNmqcJVwz4Zr2YPtDXjYyNjjVp0L00dGaXbNsHN7u6D/3Ywd+8Gt+V6Brwy1WWPSKMVfCpwPWDL2sNFbLcz/8/AGqOrL+Oj8v/NybGpgx7fPn57mfMH7oABux5/NHRc+oX/WxWD7SxReiiFxKf+/699bnY1mg5ordYqsf+tS3NH71f/mRoNozo8KJGxoHPdeW+t2G7ZjG/Kr1cr3TmA30abP9ARHdWIG4bpdEtkAN1E/bI9S5YX6mMftD3tmYVJ8K0UdHa3bNkza+aczj+bkf45nG7O2Ovpqlmii2isVenzHb9uSbPpsX1gWYFm02NbFkwAIxTtrhlAG9GtGX1bUXiI8/RAbaSw1AhbX+xZXa/3w80Y+AqTEbPj/2OhSLxW6THwfhxw3yAYWF8RR9r8r+6IK/1uZLPiRjVGQSt6/9vOvXDnh8qM+mxmaHvrctk3ZFN1aNs1GCxsdQw2n1Mz9Yr5oxEHFj3qDPtssWjGmp6YYfB2zi5Ogo2sCm78p2FjYdItqrEcaiPzbRLfOjmgqVa81oHjv/3MHfevMbAuxZDdVdWeyWL02xioiDrqsar720z1k/e8/Pfs9v1e8Z86X0XYfkHerfQ18N8o0//5YGJqp2q4aKGWO35Kg9A706Coir/ts+9oGG1tCr323YjmnM05inMbsy2y5bMNsxW/M05rE+d3Aac09/b+NR/WnMVV9N8YaN2cGQwC5Pv7oTThyoBYK+asYs1TJrpIdmAvGxPjUQiZIaqeyGGzAv7VkooDMAOj+2aLBYNeDw40AtWdu+7LgxcntU37GFq/Pvr69tmfpLXepniQNjN+iztVV94my7tM9H1aifyGn18wciAQOu0LtFn2039uWADRqDBDVIRTdxtntwZamfOAbPKM4yrkH1PVPqV32/OoNMzshYbaNMxDU781P1uXfY8C+/4SsDIuGpDQyVNpas0KsRMsPXE+RzFtpUAtvrB52fP/rnv66h7XPmx7H8+nxd6vklH+WuMV9IH/ar/7L6GCHWiFkq9UtQgA3zQhujVWPWF91EqhmrsqImXet3G7ZjGvM05mnMjm+7r3phwNY8jbnqc+8wyGnMPX3y6/N1qeeXfJSnMav+YzFmLh6jUiuyl9iLiSPTUJPD/Ko1bnkFrUabugaM9akBtE7wS9BX9HbV7/v1Ax43nvBy276o4x8jsmnFYqsNqwFDjb/9pRcbfBypp+/zbzmL+edDYZ8weAXEYpX6z9fXzS6cNTHuVUIqOL9+TJetGWoEiI/1fdvtWBftMZqJAriy1E8cgwc1XXprG30irrnh/vKRE/LH8FGU7fOPNfL6+l//xt9oYMz6Qpv55wcctNWAiahhqwGrPdMGPS9t9LnL2+vfe37QJ6c+X3s8v/ySEDVmIpfSh/3qv6w+FsiXl7BGjDOcMkGvWm81ZtrkEIEklSDnq974ext8jarW7zZsxzTmV913GnPRVxNNLhuMe5WQCs6vn42YzR1qBIiP9dl8e3ZIe4xmogCuLPUTn8ZMBLslEq4cZqxt0PPSnsaM8jRm1X8sxsw0fd6wKXAwLXr50pS1k8811AixSTVLTLfGgUjPYrVXc4Ac1acG4lFSgzr9WoCr439HiHDVRKzXP1BgvW//wgFuPA8qRqv2rFRL9o/123bAguvpeyV8LYra+NIUbWDJ8lECIozlFdDZ+mqlyWsb6KdgA30dC3vUz3ZcYRPXrZ94T58vLbAFVzukDfRqDqhxKmhq/R7pjKV3zLHrh6vzL6XQBr7IYV/hQKE3P1VfDbJnzGrAFb1H4ccBa4kc1JR6rvH9rfXvPT+q72N3WP/oY8D8ik01ZiJuz2fo+9jd6vexO+hjhPoRLTXL8M6AuIINq0mrMdex2uaMWPLXf9frG9RT63cbtmMa86tXN42ZsUVfbTV8N0A/BRvo61jYo36244pu+rSJ9/TZiLE9DFItMxy0Qa/mgJqrgqbW75HOWHrHTGOexqz605jprfq3b8xYEWDPmBZvdO0iw4MDtT3AOGljjQr2qRGsNBy3ob2KZqauQPWpgVG0IV1CsHidwqJhNmizOJhQmR+2yJ49qyW/+SPfFfDFedfk5/8dfV53+Aci+B8j4ixTvkhgC3FRP/kX0k/+2lD91NW4n/r5dQTMP/PJ1qzo1k+beNVn80UN88My60vmCr01x03U/gdO68cA6K34dWEMtO1/5nT9bJmfveefe602CUSwZDVavQu0K/QqjEUTG+Ys+r8C//5X/FuNY+vfe37uUx/rrX/oQv9AxTn6nn+D88OrbKwRwqEb1VAV4mrMPUsGclRf4exuzKV+t2E7pjEvWNz4acyiH44bqH7qatxP/W5a05jPvr+nzT/3GsvEIIHINOb71J/G3NN/JMb87pcPvN/wP+rABAFGteFjX7QrGCf0jJY4aBwYm4JBiDdQoB7QmhVu4eLGs0TUnm0Sn3z2APPzzk8fYGbYRjHgCi/EdGPlF7gvLH+o71AJH4tgCHF7JbKonz+S+Kj13/qjzzfcwMDMFevVdqWn/x0ffr7x3T9+AJvEYqvpVsgJf21gyVSC/pb6+Z8Mb1v82uYfS+ZVs1omEAk/DhYGzK8cETxejBn0LLQx5p49P+z8PJQ+X47CjIEId+p8/VuZH8xYUcvEVtWk6cVc1XRpY8ZkVmPWNjmgZ9Q29bz+za9raP1uw3ZMY3amMTs3pT+NeTw/+83/NObr1J/GjH74caDWiJXemDG7GZv1+g/VGSwkV2uo+WGQ4ayNapmgvdgzxMCAHKX2JvGG1hPlBVTuF8VXp/QVChAhxz6I/87PHOAD/T4/vJSwHLZUfu2ib8rAVquvKNlw+eDDZn3aHucFDrCUee2j9T8D+j63Ms9Y72uT/2p8uz6//l5/feZ29P7yCpoaevXvPT+X1ceSMUu+pKT2DOG+q0arVq2WvIhbZog09CzYM2bMn/jUOPbcq//W53+LPmaslqycr+/x3eo/Rz+cuIEdYpwKcYyZCJYJ9KrpVmMmh17aOpY2vRVyqFDt2W3YjmnM05hvXt/nVuZ5GvN++tOYX5uca9WfxgxYYPLFBvHbMebmxw1eJgARM63w4CD5XENtUgkHPaFX6eXE8NVerY12upCEmzFWzS2n/WnDbr/Dl99ZNLxLYenYaxbMwLdmtmn7YBERH2UfamCZHqu/UGCZosBi1d5nQN9f/PK/PvZjAp3/c/RdZ6hf76/2bqn/VuYfY8aSFTb9cN9kq6C9oL1qzHxwjBxtcxYsWe2ZNrgxd+rfe36uU595g1usf4s+v04EML8e1UQBM8awIzly1J61l1HEa+8Yrdlt2I5pzCtMY75F/WnM96M/jflh5/80feYNbrH+Lfpqcsn/Emqf4aaN6zZmbImJMFtKvpXA6tQCeY1MJPyyQUTjGlFiSMqJd9Qn6FObki6kwYfs+fjbwp6ZGV0WzI8uGmBh0bZefy3DWNN/7ysHXJ/l9Rlj6k/9q9fHmNniqzErWCmoASvYMG0MGIgwlgiZRHhxra+vsWci/CDjAeans396G0qv6zPW9Lv7DxQFb0PpvSL9necfe4v32A21ydrWCC+ZsVhFXz6P84mDZmpbI9g/r7KnMS9IF9J42IU19af+9etPY+7OT2f/9DaUXtdnrOl39x8oCt6G0ntF+jvP/+M1Zm6Dvsrm4vX2WAQbSz7XUAsMRwzCQcMy1Whrr0aAeI+aiXKU1wgPDvxK5epg8dF8cvgYAq9ceBVDsi4vIry6Yd7Ip5dFWT/6z5fip/4zrI/hwTXXT4XJgxtYppo0EQW7DU9tkElc0XwsWY0ZOBcvrhWMuVf/jvNDPnsFoEZc9bErzddeY6FPjuYDycSvX/9e1if5/BIPtWeMUK1RbRX4c436RxvVmEEtueYrnAUYSw1AhUD9bsN2TGOexjz1r0I/XLlxzfVTIYaqqFlqRMFopzFfqXFqPpBM/Hz9e1mf5GN4j8uYee1Am2l62bDJTa4WqPlVa6StENde/bpUpK2yXZ96iNDWmv1ms2i4XrDI4saTyQLitZVlsnF85Wd/OyCiL2Q0x3s367sOH4VggXJ3RN/jfOUAhal/xfrhvg10aGM2mMo5+vdTP4aqYJNAJBy0QQQz5uUzEOG5IJM2MIp2SDWIj6HOWv+O84MmCrTL/um9xBlFnHx4rPp7z3/RV/PDDtUmYYvR1kyo+eSEeCO8uaF/xAK0frdhO6Yx+3X59cLmG8+WEa78mvXKwtIc792s7zq7Ldypf//6GAagQxvLmcZMGxhFO6QaxMdQZ61/x/lBEwXaZf/0XuKMIk4+PFb9vee/6KsF3r4xM+lMEJNuEbU0BcMDtUDa0LNPUKNViPd6lapf61HSJTT8ShWdDZYmi8MWTewdjXDlsF7dIIj/y3/1SoO2LzWWEUvwFUP0fXnxioYI+cbiAxGoUTNtmPpXqY9h/OGf/50N2pgNKwdjvv76dYVDNWYFAwY+qKUf1wJmgF85oqgOORXNAeqs9Xtkj/kZ7p/ea7i+5lRUjf1HI7eofy/r0yOijwVijeGpR4HFpuAAXqH3oB7q52Nf2z78xVSWG5OcLFDDq6YI05inMYd441nWxzCmMU9jXuRUVI39RyO3qH8v69Mjov9YjJkpsEUT7woO/9zmB/70kmkRjE1tr1ojYLG8rK52i7lWNKeOUuhV/SipER4cLK6IB4BXIjwwRMjRB8OWBRYLmK5aL+g2oRFfNCwgPuagDzbLzr56v5h/MnVRftwgwsciqH/qX7E+hjE25muun/xY2KtwRZg0psuLa8y4/vEJfa3NWLVkjxhxijthbnv17zg/7CdH7p+6/ywimnOSvkdEn7FjfSKX0q/7597rU/XVmLHY+lK6ojnV1McKGDB2yxmBSDh05DDKbdiOacyvXtGRCyvctzGNeepv18cwpjFPYybie5HsP4uI5pyk7xHRZ+xYn8il9KcxA5Fw5chhlNuwHUtjZvqYSpuCmLWGxpkCbp6iRqiW2TNjIK6M49Wwq77WQFvr9FvItbCMbHk9+cKBxVIjkzYfUrB5CPdtYMn8Mn2NszWk/aKBPhuxf8SfZSf61Nadfxau1m9fP3jyxQNeP5pT/yr1MWBWCCuB9sKYz9Bn7H71U21a2A3MWFFjpo0l1z8+QbsaMPOjaG+F2uBe5+fI/ZO270imyf7jEdl/iHj8SH2vf4O+1k9E9T1ngz5t1ff23vPf0ccCwzXvBNPFSomoMYfLRm8PzstYNFVZNfn4mNuwHdOYT1xYasDTmKf+sfrTmKcx0/YdyTTZfzwi+w8Rjx+p7/Vv0Nf6iai+52zQp6363t57/jv6t2/MXJLxni8d0En3tk0xN0nB/KBaY7XVaq4K+V/+0icDIr1R9NIO8UaUFKSyG3777Rr9T15yvcRtYfmHEXhtYi9YdCNQM2ZjBd0gNB/IZ6Op+j7/9kLGX87wUQiWIJm0qdM+5vCOlw54PnFbuFP/2vRZA7pagPj5+vczP1SrqCUTwWjVgHl9XV9ih0hDFUIwImP0ubvX+dm8f3pa2UvZfzTC/rOIiL5Hhvpep+Vs1/e2aWobTY909Gl7vLN/+vxcdv47+hhkz0oxy9pW+6yoWlXg5bmeF+hVHUaB27Ad05inMU/9B9BnDehqAeLn69/P/FCtUk10GrPvJ7J/elrZS9l/NML+s4iIvkeG+l6n5WzX97ZpahtNj3T0aXt8GvOrrtygV3UYBW7Ddqx9+IsLZnK5wdwSXnTYzfCJ4MbIrVULVIMMBz2KOhYDhhBPOUAN2qZCqPX79XKltJkHnRN9wWILhY0gXLnB9qpbg0L+L9iBJbOwevq+1Piww+cM+8iD18/C5UsC9qrHF7fWP/WvWJ/1oNxW/bqqFfRpY6hYr5oxEKEXC99uwEAN1E/bI9R5n/OjewU5R+6f20Hf26JPRPU9h3osk8ixaP0ekfpV39t1Tvae/6KvBqkWqGCZ2lbjJIKhVlsFclDgw1ygOaqvoEmv27Ad05hfXTpc75ELi61hGrO3p/6R+qwH5bbq11WtoE97GvP2/XM76Htb9ImovudQj2USORat3yNSv+p7u87J3vNf9B+LMdsl+aRw8Uw9MOm0ufiypLBAjJN2OGVAr0b0ZXXtBeLjD5GB9lIDUGGtf3GltvgWH2HQhWUwP9hq3SAqWLWaN/n+QkYXluh7L1XZL2331z62cD2ZhUgmcfvawLt+7YDHpz6ZU38HfVa4r2fT97Zl0lYw4Aq9WPKJxnxS/TvOj+4q0DFFMlOwobtWbGIRqai+F1P2Z/Y3jVTN3llq/b436pVu3j999hi12/rEILFAzC/8tUFc7RP45Z30Qh0FZIYTN974829p6Llop1M0UKAX3IbtmMZ84sKaxuzxqU/mM6nPCvf1bPretkzaSvLjgN5pzIruWrGJRaSi+l5M2Z/Z3zRSNXtnqfX73qhXOo15P2N2mFCw6YvPtTf09gC3U9FXzZilWmaN9NBMID7WpwYiUVIjld3wBcRLJxYK6AyAzQyWrBZbYbPAknvGDL6wyvLyRQm2cHX+/fWOLVN/KUT9LHFg7NR/pPqsMdhD38dG8X19VnLVJ06FtM9H1aifyDn1k1/rP2t+dN8o+yfxtBE1dI+KLSsRyZGjEaXaMOgo2mNiYODX1dEf759OTH5jj/m3XsxSzQ+zVIP8Ux/80wn+1ASmSw4myljaaslv+9gHGnoW4EtQtBlLGwVVJu42bMc05mnMnj/1b0ufNQZ76PvYKL6vz0qu+sSpkPb5qBr1EzmnfvJr/WfNj+4bZf8knjaihu5RsWUlIjlyNKJMY34sxszFY1Q6lfYSYzFxZBp6S7iR1Rq3vIJWo01dA8b61ABaJ/gl2NXpYnrfrx/wuOEvZ+yD+HwMAXtmfmLXCNgs1Iz5JSSgcT7OUPV92TH/lrOYfz408QmDV0AsVqn/7S8dmPq3rs9aAvRp81Ep/rfvOuuPshvpAQnGvUpIBXvXf7Q++0ln/2TPcX0yjdiOGrpfAXtaCiaqQi9Cu8L+SbvunBCCqxy7f+4y/0Uf41Tzww75UNgY7Jmx0DNm/XCZGnAPzQnxhtuwHdOYX10905in/lXqhw810Kc9jXnv+o/WZz+ZxmzzE5tn457mv+g/FmNmmj5vsLCASafXXl/QTvemoTeSJQXcbEy3xoFIz2K1V3OAHNWnBuJRUoM6/VqAq+NxIsJVE7Fe/0CB9b79Cwd8YVkmJo3R6lYS7tvAkuuv7WTBjfX9awPUxpcKaANLlo9CEGEsr4Cm/o3rY0LjP3px/fWDPh2Afgo20NexcP/1H6s/3j9jq0zoHgV1H2N/q73Hwv5JW3W262vlfnVn7J+XnX/VxzixQOxTrdfVir7mYMAYJ6ZOhJfemkkvcMbtJg1uw3ZMY3716s5YWNOYp/5++hjSNGa4//qP1Z/G7Fe9ef+87Pyr/mMxZqYSWF5MOm8kbBL1lkC6Zw298SwphduvERYBo0B7Fc1MXYHqUwOjaEO6hGDxOkWXF21uHgtC5geLxXpps2myxdAmrr3gmnx4oaPP6xr/QAT/Y0SchcUXCWwhLuonf+rfuD6GNDbma64ffSpXVD91Na6t/k36sXk2VF/2T/R1z9F9CdjfaOs+Rpv9rfaOR9HWnbCX09MHrbyHzw/Xy2zQ3nv+iz7GDNjndn3yX//m1zVUhwi9gOVj2HCsSU9jdtIlBHpjfDExG8OFhd1OY576e+hjVNOYx/p7179JPzbPhupPY6a99/wXfTVUTHS7PvlXZMzvfvnA+w3/peRcADDRnY8t6I2kXeHGAwuFJaU5xEHjwNgUDEK8gQL1gNascKv0xvgt1OVlN/7JZw8wP+/89AG2SDVd/9iC5WvvIoc/UqZLtqO/Mv+i73F7IbOof+o/In0MGNNi/dB2Yz5b/9bn5yr0bWzdP9NWk9DdiR1M2xXd38jsWbLufhpnLJFKiDfIV31Fr+Kc/fO1yW+cM/+76asxo48ZK/q6G6NVk6ZXbVjb9LoN2zGN2ZnG7Ez9q9Sfxuxcs76Nncbs8zON+bLG7GZs1us/VOfiBb0loDeMG8yygHrLQXu5/RADA3KU2pvEG1pPlBdQuV8U316w5fXaXWwQIcc+iP/OzxzgA/0+P7xUIcfaHucFi8FmCgt9Pvhwtr4vNV7LTP1Hp8+PRbBhhfj5+rc+P1ehf+T+qXuR7lG0t+xv2rvH/kkvVaFMm/rBL2rn/fMq7q/pVzPGXBXiGDMR7Lln0kTchu2YxjyNeerfgP405hvQn8a82/55FffX9B/CmNt6atjycojYpOvNAG6SordZIX5ar9LLieGrvVob7XQhCV9MLDVuCe1PG3Z7HL78zk3lxQi3ltcgxO1jBX6bUeBma68to6k/9cf62LByWX1XuNn5eWD94f5JJG01DXYk0D1KdzDioHEY9yq9nBieemtVSrqQ4LHun/pCGyvtoQYcftzAjDHsSI4ct2E7pjGvMI156l+nfnLlxmX1XeFm5+eB9Yf7J5G01TTYkUD3KN3BiIPGYdyr9HJieOqtVSnpQoJpzBittuE8Y2ZaKdSmNc17kO5TgxcgtLm1cb8bcb8jrhElhqSceMfSINLLrJEospEuJOBD9nx8Y7G8mJnO/HgbSq+/NmHs49bXZY2CLnrgwaBtva7PWNN/7ysHXJ/H4zPG1H/c+qwi4ihcdn1CUfA2lN7L6qcNp6H70jn7mxJDUs45+lpnuoTgged/5/WJJeurbAxVzVXbGuGVNcasHPMqm4Io3aYmzX6gtwq45bS5nXHX022uESWGpJxYVQ0ivcwaiSIb6UKCO258Z368DaX3iIUFRcHbUHqvSH/nB2PqP3J9VhFxFC67PqEoeBtK72X104bT0H3pnP1NiSEp5xx9rTNdQvDA87/z+nw4Y2aa9FUMxen0WURvBreKG0lbb6dCDhDRhVJ7NQLEe9RMlGuFoFehVweLj84zG5vnx5eL5j8L+nyMgldGvEoi2R4Avt4D/uoJffLR56GqX13glwYM9RcVnqH/3d/87wY/9eKfuFq0zvucnx31yWctAWrEVf8617/mA8nERYE9R/ci3Z1iQ0uQA0Ri82zUXo0A8R41E+VaIcTm2bjs/Jw4//e4/vVXi2DA+oKaSPLgBn8Isv45yGnM172wNB9IJn79+sMHYxrzZdE673N+dtQnn7UEqBFX/etc/5oPJBMXBfYc3Yt0d4oNLUEOEInNs1F7NQLEe9RMlGuFEJtn47Lzc+L83+P6fwhj5rUAbS7jZcMuXm+G3iTgdmqbW0tbIa698Vn/RqStUpdOdAUhHr1UhT5tvRaFK13cGG7bhvnxXuKMIk4+PFZ9ewAWBmwvjmjziyT5ks/ihRIPBl9p4BEa6vtrTypBh49yoEP9J+ljcr/55X8Y/Fc/+W2Nl37lA41P/sMPPQgv/NybElSldbo97zw/u+ujiQLty65Peu9dP20vAbuQ7k60T9vfYvNsRNoqj3b/LOuTr6eu/HInWZ+a472b9bFnwJixZIwWsN6eMQOZbsN2TGNeoXtjNsyP9xJnFHHy4bHq28INV27wANCexnwayZUb05hPXJ/03rt+2l4CdiHdnWiftr/F5tmItFUe7f5Z1qea7sJ6ZX1qjvdu1r9fY2ZSmCArMc37Ktwq0BtZ2xVdKArxXq+iC6iiClSi6FVwvY7OBkunMz8eoddYfGAhBBOq9jj0bfPFhsd/dMH1+cAFGzeatIHHgEfoFYPNnQiPB6+YiJBvnKaPvakdYntqzw+FWjIQoVo35p3nZ3d9XVF7rE+N3Lu+7jPsPOxLtGOzWmX7/qYQ7/Uqj2T/lPXJbgPhymG9+oVD4voniLrrs7P+MWYsWe12O9OYpzG/GtlD3xbuNOY9oJ5w5QaRacyeU1G1+1n/Gin6us+w87Av0Y7NapXt+5tCvNerPJL9U9Ynuw1gt0DkNo2Zy7ZJWfxznh/IW6/ejHSfAr2RtLnBRPRmA4ujojl1lEIvL1tqJudFkzbotfgrC7t2j3DVurA2zI9naoQFJPoesRw/1z3qE7mUvs7PFmP2Rf9xg8eAj12gz6LnAeBjGrpxk2+/OmBRP5n0nqSPvWHGgPnRVlPEDnswqqIKFXKSVEBOrQrcmHeen3vSZ71tXv++tmV9LiKac5K+R0SfsWN9IqpPBHT/0T2q7loKvb39LTbMhObUUQq997N/0qvz45nMNpkaGc7/Qt/WGxYLmK5aL1R7pn3s+ldjxmL19XUPzWGs27Ad05inMV9AX+dnGjOjKqpQISdJBeTUqmAas67PRURzTtL3iOgzdqxPRPWJgO4/ukfVXUuht7e/xYaZ0Jw6SqH3fvZPenV+PJPZJlMjw/lf6Nt6C/dt3L4xc3lcqk1BzFqDOBPaQ28Y6E2tEdosAmUcrwuut5gghjdqDZAuJPCbYYvAI8P5Ie6jaLOMbHk9+cIB12FhWSYRj++mr/eXiOp7zgZ92qrvbT4EZPoYMMaMJdNeGLPq29cbnnzxgOuzlfMVBdqiz1itX+On6WNvGCGGpxaINaY3zHcSztqokUoMDIirMRPRthvzzvOzu/6G/cc1ZX36ujXN8fr3+JH6Xv+R+hpRdM/RHYk2+9I5+xuM4w+1f97n/hPu28CSX/7sxxsaZ0cKbw7QZ9fasv750lQ47p1gyVg4kWnMZy0sjwznh7iPon3Sg83Yy+rf54MxjRlQgxqpxMCA+DTmhb6sT1+3pjle/x4/Ut/rP1JfI4ruOboj0WZfOmd/g3H8ofbP+9x/1IBv35g5pfGeLx1gUpgyxdNsOlJXQ29YDxYHbb3NtFkEX/7SJwMidUkBvbTJ6WUC50KZNqQLaXDjFxGZH4+wUFhALBGZH19elsOfhAupw9gH0ve23F/V90hHn7bHTd8/rMFrH3uByRLHhhVf+mSy3NGxj1G846UD/rKIuD0YVZ/54YWS5/NRIzRP0q/GrO3txsyoyjhHe4EzKrUq/tfBjXnn+dldn1VtuD5rkvUm69PTZK3C9vWPvkeG+l6n5WzR76H7DPsV7T32N/JR3kNfK6cN6ZIbvfn3ts25tplzj3Tmn7bHh/sPqBnrXoQx9+yZfOy56vv6tPWPMavRKthwbZOPJU9jdjgXyrQhXUijt7CYH4+wUGRh6fzUhRVSh7EPpO9tub+q75GOPm2PDx8MfQyAuGceu3GLPvNzWWOYxvyw8++r2nB91iTrTdanp8lahe3rH32PDPW9TsvZot9D9xn2K9p77G/ko7yHvlZOG9IlN3rz722bc20z5x7pzD9tjw/3HwhXbuhedDvGbBepE+ELlCnjRYRNFoUyfT6Jlq8RqDcs7mJDb3Nt18XBAoJYPSlnO/W8itZc0evV+SHiN1IXGfNpmUTG7K1fQX+haW1fFaLvbXkwvK0vMG0jTmu9wUcqvH42br6EYK86fXNXfdu4vV30/VHhwxqfM87Q32LMCr3HkkRWSUMaxGtVC2PeeX5219e1RM5w/9H1Gct4I+h7W/SJqL7nUI9lEtlC2lIautvUveuy+1sde1n9ekVKmoo70fvrEbm/Ov/ermumrE/2nHDlRrVkhfxfsANLHq9/PvaFMWO3FTXsasZEMGy3YTumMZ+4sPR6dX6InP9g761fQX+haW1fFaLvbdaJrpnOg6FcszFMY37Y+V+sJXKmMZ+xv9Wxl9WvV6SkqbgTvb8ekfur8+/tumbK+mTPuX1jtlP6ouTimRpgUmhbpk+fZBLZTrqXDRYN7VgBDeLjDylA7dWXObW3nlfboNVG8Qnmx9vcvLJl6MMP96nfi4Dqe4RFryvB9BcfwSCHegxfP7yuZJT9Unh/7Wkbtyez0Mkkbl9LeNevHfC4Phg762Nv1fzCLxvEx2CWlZTW0N63/sA3NVJCwB+uoAaqYhRtN+ad5wfuSV9XHZT1CWSmYEPXOW2NVFTfiznj+arorqL7D9C7x/4GxB92/9T50QjU++t7i66EzfsPtorRQvLgAKtW8yb/jvVpvfwhSMwV68VigbjaMPDLO+kF8t2G7ZjGfMTC0nZFFxbzw6KJhEN8GvOlNm56L6o/jflh5x9cX1cdlPUJZKZgQ9c5bY1UVN+LOeP5quiuovsP0LvH/gbEH3b/1PnRCNT763uLroRn2ZgdLhhsUuJz7Q3iPn1MkL108ojle1syPWL6GoG4i416yxV69VVM7a2RHuTouWijTFupNWtEqY8x6CjaSqRFr0aU0/QrMTDgrvX0ub+eo+j6YVMG27gX64fXm7ZN81LIX1qyxRv68NTH43x9H4uy0TNmTFGtEcJTE1hsZUtORc8OtUI15v3m5171dV0N9x9F13Ms70QkR45GlHOeL91J2Ge0rZCpEI/NrVF7a6SHZgLxy+pzddpGmfaYmNjA7/tJ+w+WrBZbYVfBknvGDN31aasXY8aS1ZjVhv/UB/904uu/6/UN7Jkc7Nlt2I5pzJ6j56KNMm2l1qwR5bQHO9KiVyPKafqVGBhw13r63F/PUXT9sO3CSRt3uHKj92Cco+9j46mbxnzX/Nyrvq6r4f6j6HqO5Z2I5MjRiHLO86U7CfuMthUyFeKxuTVqb4300Ewgfll9rk7bKNMeExMb+H2fxszhDw9GK5fKS4bFg0Em6CsgG/W+Xz/gEev1lw/kmz69Fb1h3HhtV1gKW17RxCpspK5VOC+atHvU+nsR2hXqT8EgpEKhF6FdUX29OiUEV9GHgfvLnV3cX/sigX/Mh22X9WMf+VmsHz409IkD4b4N9Gnzizx5bM7R91esmIHU//aXDjAWfTVm7FNtr6Jmmdw0oZlJJND8GgHiVLVizDvPz+76sj+Q6fqyw7g+mUYs0UZa0o37f371+dL2sfsPUD/6tFNCcG36XDWatEF7lZjwVY7df7Bn1o8aLbDDqBnzS0hA44v1WdY/xoytYswYLR8KG4M9Mxbchu2YxtyF86JJu0etvxehXaH+FAxCKhR6EdoV1derU0JwlWnMFbXb5KAJzUwigebXCBCnqmnMEEu0kZZ04/6fX32+tH3s/gPUjz7tlBBcmz5XjSZt0F4lJnyVZ9uYeQw+b/BgAJNCr71e8DbQy+NExEbphPoPzOk1fe8VfSKgN0xvJAtIlxGQw6KpcSCiY3u9mqM1oE9Ee48Ffdqqcz36ei+4O/X+eqTc37d/4YBv3GTytRnG8qUa2gYPyfiPXpyj75bARzmIMJZXrNaLvttbsWS11eSUDeJkVmLggCTYSAkJlKkQeybC1e03P/TurT/ef3RlKmkBN3SFP9Tzy3mBCGPHvZoD5KBf40BEx/Z6NQfI2UOf2SAHfZ0f2hW9s373z9h/2EkwWrXncN8Gllx/bWddn6qPMWPJfGlKrZd8FHT9aw4vtKcxL8b2ejVHa9i+sMagT1t1rkdf7wV3p95fj5T7Wx+M8cY9jTkJNlJCAuVpzEpawA1d4Q/1/HJeIMLYca/mADno1zgQ0bG9Xs0BcvbQZzbIQV/nh3ZF76zf/TP2n9s3Zi4VeDyYFN4YMB0YM3FOTNt6413W4XUT+ahpG4q+3ox0nxr19hOpcPs1oqPGY7fra1W0GVXj2ka/xmnDfvq0e/qgd6FH9/6y+Nhw9f7a6yD/QFBZP1uM2T98cZK+f1HHHqRYnIf6yUfT9LE3rK5nzBVytsOo5MSNEEzUsbRXjHnn+dldPzaHhuqX/UdXo65eGD8p+z1fgL5GGIU+aK+imakruF195gp9nTfaoHe2h68f1gOrhXZnfWKxWC9t9hbsmTZx7YXF+iz6GDNgtNvXP/mvf/PrGii4DdsxjXnBdn2tijajalzb6Nc4bdhPn3ZPH/Qu9Oje37Jw/f4ON+5pzBCCiTqW9jRm0NUL4ydlv+cL0NcIo9AH7VU0M3UFt6vPXKGv80Yb9M728PXDemC10O6sT+z25o353S8feL/hvzScEwAToR/TIG6l6Im9RJ0+o+qneQ+4VXrzaNelo9ALvYVCHDQOjE3BIMQbVIW+Vkgb/RpnLJFKiDfIv099Re/FpvtrC/fJZw9wf9/56QOvLZ4GmXwsiIVucQwYY+aRoO3GTOYZ+rxQWtTPH3Gjfsv8977q325gcoBlauRYqrleFuyZyrmK/eYHdtS3sdv3B9AVyxOk7cp9Pl8ooK85xEHjwNgUDEK8gcLt6jOf6NNW9C6fs/+wn6jp6vrU3kXOPa7/acxOrKqGxoGxKRiEeIOqdGGRQxv9GmcskUqIN8i/T31F78U5D8Zri6dBZlm405hPYxqzrlhWuLYr4/VPDu3zny8U0Ncc4qBxYGwKBiHeQOF29ZlP9GkrepfP2X/YTxamK+tTexc597j+NxkzDwPW6z/0pjhhJY5V2/S9VmWDCDkb9PVm6E3ipmq7Lg695aC93H6IgQE5Su1N4g3tvV19ZhVl2noX/NZsub/2RYJ3fuYAX5jx+8tLS3Ks7XFeEBm8VsKGFeLn6/ujwmslrZ8PLtlYNWYsWQkvvELcmHeen931N+8/rEzWKrDCtR2Lv0EkLf6G9sbD1YiBATlK7U3iDe2d+km8QS93DWXasfk0/KbvvP9gxm7Jqn+P699t2I5pzA45Su1N4g3tvV19ZhVl2noX/NZsub9nLNxpzOcwjZkVru1Y/A0iafE3tDcerkYMDMhRam8Sb2jv1E/iDXq5ayjTjs2n4Td95/3nuo25PQ8NezwcIkwKESaC1wjEKYjTkE+O9tKmN8QbRKxXb4bCrQK9zQrx03qVXk4MP6FX6eXE8BN6lV5ODE+9OqsxyUG6EUH3/n7asOXr8MslWJS82GFp8hqHuH0sgvWDDSvea4/B+fquwMOgvab/3I8+38DkbovnPvh8Y+/52V1/uD8QSUuxoStWV7Kuc+KgcRj3Kr2cGH5Cr9LLieEn9Cq9nBh+Qq/Sy4nhqbfeNSXd6GC//eeO9bmzvtuwHdOYF/RyYvgJvUovJ4af0Kv0cmJ46tVZjUkO0o0Iuvf37IWbXLmhC/d8fVfoPBjTmMfzs7v+cH8gkpZiQ1esrmRd58RB4zDuVXo5MfyEXqWXE8NP6FV6OTH8hF6llxPDU2+9a0q60cF++88d63NnfbdhO5bGrMMQUlHgxLSt1//Zzlj7EPl7Xzng08fp27/9GzxmxFGwaU3zHqT71OAFCG1ubdzvRtzviGtEiSEpJ96xNIj0MmtEiSEp55r1Y5Ib6UYE3F8+nuP3kUeCO9u5v96G0uvrh7FTv/ROfW8baUE2dN2es/6VGJJyrlP/9W/4PyT+jf/N70qQeZp+JYaknHP09T6mWxw88Prc2R/dhu2YxryIx6pqEOll1ogSQ1LONevHJDfSjQi4vw/2YEBR8DaU3qnvbSi9t6WfFmRD1+0561+JISnnOvWTKzeSKzfIPE2/EkNSzjn6eh/TLQ4eeH3u7I9uw3YsjZkfU/NPcv6pzmA7AV9fAf+nPZdNPqVQdP1oOF/KJl9fVaFPHAWL6M3gVnEjaevtVMgBIrpQaq9GgHiPmvk49OsMg94FvTuwuL/czc3315e75k/9qa/5QDJxUWBN6lrV1RsLPkEOEImHq1F7NQLEe9RM1df9s+YD8R41Exv+3o/+/cRP/9cfC9705Hsb1aQrVV/rr70aAeI9aibK9Q5CbD6Ny66fE9fn0B8XCif5o9uwHdOYFxDvUTMfh36dYdC7oHcHFveXu7n5/u69cU99h2Tij0ifNalrVVdvLPgEOUAkHq5G7dUIEO9RM1Vf98+aD8R71MxpzKetnxPX54MZczVg+4c5bX5RIl9iWfyDnRPzkXFKtMtYnJhMCuW1AG0u42XDRunN0JsE3E5tc2tpK8S1Nz7r34i0VerSia4gxKP31vWZVfRp671Qzrm/3kucUcTJh6k/9WmbTlp+AatUVy/th32+YvNs0Etb90/Nr2ypXy2Z9rGg09Mnrr1p+IAt9Yd49HIHmX/a6XYHx66fi61P3I0fy5KJD/JRL3wQ/ZP80W3YjmnMK5y2sG5dn1lFn7beC+Wc++u9xBlFnHyY+lOftumk5RewSnX10n7Y5ys2zwa9tKcxKyEevdxB5p92ut3BsevnYusTd3sAY7bBLKPxHxVY/ECbE3N5tIEiKPEVg4thUrgAG5XmfRVuFeiNrO2KLhSFeK9X0QVU6SmE+Gqvcj36zKSid8HvMujdZOl37q9H6DV8/WhORdWmfkXVngF9XYesTNYt7VjMq9zn87Vl/yTzNH3M7xd+8Zcaasz6+lohR3nDc3+xwajtMEp10okaZEbZgdZf0Rngbip6319bPI0j14/3GieuT8wVR8Oe+REtEfzOcP0j/dFt2I5pzN1eZfvCUkJ8tVe5Hn1mUtG74HcZ6sLt3F+P0Gv4+tGciqpN/YqqPQP6ug5Zmaxb2rGYV7nP52vL/knmafqY3zTmY9eP9xonrs8HM2YrZcvCctGPG5yGH2vzj3eK5pT8GFyNmRJtUhb/nOcH8tarNyPdp0BvJG1uMBG92cDiqGhOHaXQy8uWmplkA82poxR6H0qfeUOTNui98Ptr984j3DV9MDbcX8/UCA+A6HvEcvxcU/+Z0Sei+kRA16eu4bqqFXr3fr627J+n6fcMkrgapPZWUBjnv8k+MqaRel5QHSpJZQdc3f3sP/Tq+vFMViOZGhmuz4U+fme/WmShj9PRe5I/ug3bMY15kVNHKfTu/WA/lD7zhiZt0Hvh93fDgzG+v56pkeGD4eea+s+MPhHVJwK6PnUN11Wt0Lv387Vl/zxNH9urBklcDVJ7KyiM8980jVnW50Ifv7tXY+aH2FYKC4iFxZKiTdxPrJdhHx9/8sUDfqmUwkfMaXN5XKqNXVyYxZnQHnrDQG9qjdBmESjjeH1geosJYngwjl+zfp1DSDci8MVqi9gjw/tL3EfRZv3YmnnyhQOuw4NhmUQ8PvWfAX2NKLomdcXSZt1ew/M13j/JCdmAeE8f28MOeZUNxLHG8MsBWyxWjZkIoyKhEQMjh0q2zI8Sl9/gbhKnDWkZBL7SWEviL/Tq+vT8DeuTtq5Pb4s/Mlb1NX6aP7oN2zGNeQHxcxYWjOPXrF/nENKNCHThemR4f4n7KNqsH1sz2zduxk79x6qvEUXXJI+Dtlm31/D8jvdPckI2IN7Tx/YwwmnM4CuNtfRojZl/Vts/wPkTAiwjxf+0AJlIc3r7Mfg7Xjrg/3gnbif2H4ZTuvGeLx2gaKZM8TSbjtTV0BvWg8VBW28zbRbBl7/0yYBIXVJAL21yeplA/u3qM1co04Z0Ixos3EVE7q9HWIgsUJa43F9fJ5bDn/wLqcPYqf+M6ffQdch6pr3H+icf5dP0/85PPWmkzbNBnPxj9bE9LPOL/+yfN9QO1SYVtXDAYlMwwVk0oqM4L+i5qCQV36B+2lxj70pB7yxtSEui0Vuf3rY1qW3WpEc665O2x03f/Uv8kfXPC233Oz7qhSee5I9uw3ZMYz7iwaBNTi8TyL9dfeYKZdqQbkSj92Bwfz3CQpcHQ++vrxN5MELqMHbqP2P6PXQdsp5p77H+yUf5NP1pzAr10+Yae1cKemdpQ1oSjd769LatSW2zJj3SWZ+0PW767l/ij6z/+zJm/Qe4CWHDCj+y9kI5MR8it3+qe3F6YXZib9tFepscHmCmjBcRNlnoM30+iZavEag3LO5iQ29zbdfFwQKCWD0pZzt17G3p13lTdM4rer/0/hLx9aMPCevBMomMmfpjbl0f0pJr6Gqsa/uy67+OPVYfG1a0t44d62N7WCZGiD0TD3cMME79ZZznw9l7UEmv/mOpd1xJS+VOWJ+LNWltdyVZn96unlX80Q2YD3N9zjjDH92G7ZjGfGgE8VRcZGHVsbelX+dN0Tmv6P3S+0vE148+JKwHyyQyZuqPuXV9SEuuoauxru3Lrv869lj95MoN7a1jx/rYHhaI9U5j3g7rc7Emre2uJOvT29WzHsyYrdtF+ec2pdsv3fZ/ttuJyfRCySRuH/t+168d8Lgas+pTHPrApNC2TJ8+ySSynXQvGywa2rECGsTHH1KA2qsvo2ovEL9F/Tpv2gad7Zj8BPfX2ywGW/SRcIjL5g5TPxIO8Uetr5GKrjpdn0DvLT5fQHysjzXyShnrVTsMP25gyWrM5JwPaqqv5yWnVz/U3vH81LuvbajrRyOg69Mjtj4XTmTrc/ERMHJYz8Z+/ug2bMc0Zof4wz54UHsfVr/Om7ZBZzsmP6EPhi+GIzfuqf+49TVS0VWn6xPovcXnC4iP9THFaczahrp+NAK6Pj1i63PhRLY+r9SYHUTBTrz4aDj/PLfT+D/qeSlNiQZfD4Bqz37BYJe30Le4Tx8TZPoesXxvS6ZHTF8jEHexUW+5Qq++iqm9NdJDM4H4benrXNFGmbZS51wjSt2mQUfRViItejWiTP0aUa5TH3SlsQ61rZCpEI/F36i9NdJDM4H43vq6fxLHFDFmBTtMwYBR5JwPamrGgEmTQ/2XnR/uvrZRpj0mFl6Aa/TWJ/7iOYr619n+6GNxRsNt2I5pzNOYPdKDHJ0r2ijTVuqca0Q5beOOtOjViDL1a0S5Tn3QlcY61LZCpkI8Fn+j9tZID80E4nvr6/5JHFNMvtvADlMwYBQ554NacuXGNOaFf13YmO2D4P5jaoZRhP3IenFifuj9iQO6gLgA2vwiOr4k4C8HKA6j1Uu1lwwLfTJBX5HZqPf9+gGPWG/Vp7eiN4wbr+0KS2HLK6xYhY3UNeB29Zk3NGn3qPPfi9CuUH8KBiEVCr0I7crU13blPvV1dWn72PUJrE/0aaeE4KH0Y/NsaET3T/QxRewWC9Q21ghqmYwiB4hsp47lvBVy4tIa589PD1YFmrRBe5VYkKuoGeMvOMvCX07yR3/FjRmL/ttfOsBY9N2G7ZjGvNgCKtz4PRYW3K4+84Ym7R51/nsR2hXqT8EgpEKhF6Fdmfrartynvq4ubR+7PoH1iT7tlBA8lH5sng2NTGMew6pAkzZorxILcpXrNmY7zdu/cMBPjH3ysW+K4EPhtA2W0fiXtvsPzBnyeQNlYFLotdcL3gZ6sXMiNkontOp7r+gTAb1heiNZQLqMgBwWTY0DER3b69UcIOcW9XUO0SeivceCPm3Vmfrw7OjH8msQYey4V3OAHPRrHIjo2F6v5gA5p+lv2T/J/NsfetJQs1Q7rJZMhPzLgjLoGanksvNTezWH1UIO+rp+aFfUC3CH6i8eKf5yrD+6JfNRLyKM5RW39aLvNmzHNOZpzA4RHdvr1RydQ/SJaO+xoE9bdaY+PDv6sfwaRBg77tUcIAf9GgciOrbXqzlAzmn6W/ZPMqcx06s5rBZy0Nf1Q7uiXoA7VH/xSPGXhzBmBjMA+6Ro++e2/0Ab4yRup9mysPzn21wqqD5vDLjIou9t6128LiAfNW1D0debke5To95+IhVuv0Z01Hjss6Ovs0qbUTWubfRrnDZM/RqnDY9DXyOMQh+0V9HM1BVcm/6W/ZPMj/zwk4basxqzGiRgnOGmF6SeBdSY4wIT+80/awl9XVe0QV2gR9dfTvJH/6KUmXGY10GffDTv+PDXSSfesrCmMcOzo6+zSptRNa5t9GucNkz9GqcNj0NfI4xCH7RX0czUFVyb/pb9k8xpzJqZuhqsJfR1XdEGdYEeXX85yR8vZsxPPnvg/S8feOenD/gJgEL5sTaiFmcBsbBYUrSJe6aNfffLB9D3Xxpe9eVjXB63S11cGFOg02dU/TTvAbdKbx7tunQUeqG3UIiDxoGxKRiEeAOF29VnVtHXGaaNfo0zlkglxBvkT30lxBvk364+CuhrDnHQODA2BYMQb6BwDfrj/TMGNjBmtWfsEJOuhJtekHSKgEq4dq1ZiclpMAP7zT/rDX3ainrBJn85wx95Zb3Q549Iom+ZbsN2TGNebBl6a2lX4q43WDr7LSwUblefWUVfZ5g2+jXOWCKVEG+QP/WVEG+Qf7v6KKCvOcRB48DYFAxCvIHCNeiP988Y2JjGzNgUDEK8wXpDn7aiXnDdxmwfBH/nZw7wgW//oTf/6EbC2h7nBbXBn7hgGSn+py8Ya0W7GZv1ug69wkocq7bpe20WGkTI2aCvN0NvEjdV23Vx6C0H7eX2QwwMyFFqbxJvaO/UT+IN7Z36SbyhvVM/iTe092H1+RMXafNs6J++UGWM+Wc/fAA71NfLoC+ZMU6N8+s8k+MOQCEEG3GigEqoVq+u1g/aO54fcpTam8Qb9LKro0xbXcCtYYu/nOGPbtW81lZ9PjhmY92G7ZjG7HBrtR13vUEk3fWG9saqasTAgByl9ibxhvZO/STe0N6pn8Qb2jv1k3hDex9WfxrzeH7IUWpvEm/Qy66OMm11AbeGLf7yYMbc/lXesNM7fDkaUf5hjjT/DCfOh7/tNNiw4r12Gf4hL7NPhwiTQoSJ4DUCcS6YyyCfHO2lTW+IN4hYr94MhVsFepsV4qf1Kr2cGH5Cr9LLieEn9Cq9nBh+Qq/Sy4nhJ/QqvZwYfkKv0suJ4Sf0Kr2cGH5Cr9LLieEn9Cq9nBh+Qq/Sy4nhJ/QqvZwYfkKvgg0rxMcK2GHPLImrMQPGTLv2MkqpOaA5aszKuP5xr9LLieGpV3f12OSDZARB11/O9kdXwIy11/zRbdiOaczTmO/oVXo5MfyEXqWXE8NP6FV6OTH8hF6llxPDT+hVejkx/IRepZcTw0/oVXo5MfyEXqWXE8NP6FV6OTH8hF4luXKD+FhhGnMMT726q8cmHyQjCLr+crY/usKJxswwhFQUODFt6/V/tjPWPkT+3lcO+OVx+vZv/8be+tgwcRRsWtO8B+k+NXgBQptbG/e7Efc74hpRYkjKiXcsDSK9zBpRYkjKmfoQQ1LO1IcYknKmPsSQlHOd+mrMkLyzga1qL8ZMRHshBgbkaETzgUq2/C9FjSgxJOWcNj8Qm3yQ7KCBv/DxYfcRLBln2dm/3IbtmMa8gFtOm9sZdz3d5hpRYkjKiVXVINLLrBElhqScqQ8xJOVMfYghKWfqQwxJOdepP425ZtZIbPJBsoMG/nJ9xsyPqfknOf9UZ7CengivpvlnPvn0UnT9aDhfyt5bn3x9lY0acdHXm8FN4kbS1tupkANEdKHUXo0A8R41c+orNXPqKzVz6is183HoY4e/8Iu/NAAr1QjGTLv2AmZMu5ejqDGrPUOvfqi9GgHiPWomyuzqoDs/uFOIO8DCX8jZ2b/chu2YxjyNeeo7NXPqKzVz6is18370pzFDzUSZXR105wd3CnEHWPgLOTv7l9uwHUtj5gS8FkaUf5jzo2xOwD/q9R/sxPnIOAp2GYsTk7m3Ppoo0Gaa+CiZjdJbojcMuJ3a5tbSVogD+fpxfHK2tFGgrYR4g/z99ImgD5G2Sl360RWEePROfSXEo3fqKyEevVNfCfGGfp2pB5aZgsG4F7bkUIkaMxWm4htRfPTuMT91V9T9310D08Uv4IH8y23YjmnMC/QW0h7feCCfJaVjt7RRoK2EeIP8/fSJoA+RtsqxGweRqa+EePROfSXEo3fqKyHemMYcXQHxuivq/u+uYb7gfgEP5F9uw3YsjZnBiHJ6XhETQdT46nd/wwAvxTL/4I+/KVjkiL7GK67G9NEGiqG2VwwmCzNmgmyU3owe3DbQG7mlzULZHq9tXV4157L6FXRSsEG816tM/dSVmPqpKzH1U1dirH/NxkyF9z8/dSdU0ubfcH9R1E34p91mf1x84Au3QjPMq1H8y23YjmnMjt623q3ttVk62+O1rQur5lxWv4JOCjaI93qVqZ+6ElM/dSWmfupKjPWnMVf9uhMqafNvuL8oV2TMlMIw++r04p/b/EDberFM7Pb3/dU3BNWAiXznP/pg0MupOq9/8+saXg8/NuflAJPCJVGVGjNTYMa8qJ8Pvluv3pJ0z4LeDeZlS40fi47V9n76LHEidbmzuCuaU0cp9FJ/zUyygebUUQq9U18jCr1TXyMKvY9P//qNGXr1A7PBWeCPf/VXB+TUUQq9qs9eB7rngzqCGzD+wj/qiJCDMW/2RzfdjxtENviX27Ad05inMTuxUyQ0p45S6KX+mplkA82poxR6p75GFHqnvkYUeh+f/jRmoFf12etA93xQR7huY+aH2JRiEosTS5wTY6tf8davbXzdT35LgLkSx4w/8KmfbdAmh14yY2DEUfZzMU328fQnXzzgU8ml8hF22kzfsP50bxJ6I4FbTrvebEUVQnAQqeytD3pFtDmvMo7XDaX3sEEMD8bxqT+OT/1x/FnTv35j3jI/6POlrIra85b5qXud7pBuseov5ilPvnDA/QVjJpP2kf7o7c3+5TZsxzTmBdxCRW8tNz66EqoQgoNIZW990CuizXmVcfzYjSOGB+P41B/Hp/44/qzpT2Ou+nWv0x3y1oyZf1bbP8Df86UD/IPd/zHOj7JN4s/+zLc3sE/MVS0WcwXMuKI5jFIdlDmLX579mP0dLx3weojbhfkP25kaw+u3SdFbAp5m0526GtzIMZoZAwP0UzCoo4goGo+04Hx9FjftupRZ4l/+0icDIvWRAHppk9PLBPKnfiQkyJ/6kZAgf+oT2W7MZJ4GCkk2QWY15nH9KPMrSvjVnsmVA7VnpafPnqborgjuI2aW/ieDMU7iZszuL5v90TNpo7PBv9yG7ZjGPI15GvPUn/oLyL8VfewweWQC8yPzNFBIsgkypzF75sWMWf8BbkJ+An5Y/bkDfCwL1FyxWzVXwHTDjwNGaabGQc/FqwC/eJ04uzBv89qBNjkYsNmzv+g2M2YiFrfH8jUC9XbWSLV/9NX4e/qgmvejDyzlXpvFTRt4ACBWf8rZTh079ZU6duordeyzqR/eeSdY4GkkqQFqzFvqRx9r/+I/++cNTBozJkIvxrxlfuqeFpthQ/dPdw38AqegXT1lgz/ykS7Xx5j5ktUG/3IbtmMas0O+RqDe1BpBXyN+Y84wzuhq7KEPvUVMuy762DXufDC2UMdOfaWOnfpKHfts6idfHBAuewJJasA0Zte/mDFbt4vyz20rXQ3yjT//lgYmqqarhgpqtwqj6E1DGjqKzLd97AMNreFdv/ZiwytUY9b6uXimHph02pbJTdLMuHNH4Zpin16M3dRFjv3PgUfsvLTH7KfPklVY9LRjlTeIjz/EAbVXX9bVXiA+9WsvEJ/6tReIT32sERurqAVqu0Zqb49qxorWCbX+3rneVP4wpRqzKijaG9tagx3P90nZP9kndf9cfASMHPKN6o/8UQp/rc2XoEjGyMkkbl+L6vmX27Ad05inMS9gWdOOtd4gfv0bU+0F4lO/9gLxqV97gfj1609j1t7Y1hrseL5Pyv7JPqn755Uas2OiGCHWGM4a1C9B0VbTrUZLROPaJkeVFTVpv2wuTC7PYULBpm/x0XaL+63iBsjHqcj3tmR6xPQXkY4+t1n1qzKE1CF+7/qgi1iXNQtdoVdfJdXeGumhmUB86oNmAvGpD5oJxJ9N/e3GTKaivdpWaj7t5MfBlvqxWz2jtrFnImSiEJOzqq97F21Im16j7p+O7J8OzgK4D9Q/48jra37tFS+90cfCgbHiX27Ddkxjnsbs6PKti1uhd/xg1EgPzQTiUx80E4hPfdBMIP5s6mOTWFpFDY9MRXu1rdR82smPgy31T2MGt2E7lsZsHwT3H1PbMCyQLy9hjRhnOOUqmhMe3CCukZrfg5yveuPvbfA1qre/9GKDH6f7ywcunonWqbSXwIuJIxP0FbGNet+vH/CI9aLvEdHXnLG+3mz0PW6g42q76Xu+6ROp6CLWJU67wtLf8gpOH6TUNWDqj5n6Y541/WqZCnEMD4hrBGom1HwiyY+DLfV/5IefNDDdMWTq2LF+bGWNtNE1tu+f7i/FH91fzIMW+zMfCvuEwStuzFj0q3+5Ddsxjdl7/VbJxHlEboxHdjNOV9tN3/NNn0hFl7Iu7ljrifGDocSu1EhdA6b+mKk/5lnTxyaxVdpKtVviGoGaCTWfSPLjYEv905jRdxu2Y+VV9tu/cMBPbEIYIa+mQc0yvHMVcmCLGWucNmfEkr/+u17foB5/RWAX7D+QZ5o+b1jlDpNOL69/aQO92CERG+U3z3rR98iF9D1yj/rea/p+LtEnArqgdYnzAOhjoA8DW0ONAxEd2+vVHCBn6od45AA5Uz/EIwfIeRb0e8apEaVnwMR7aCb6yY8DrXNc/89++EmDUbSxYSCyfX7q3gXsb74TwpH7Z/VH/1oUY/nSFG3AkvmoFxHGFv9yG7ZjGvOrveXG+C2UG+OR3Yxzb33vNX0/l+gTAV3Kuri3PxgaByI6tterOUDO1A/xyAFypn6IRw6Q8yzoVxuuEaUaLYQHr6KZ6IcTJ7TOcf1YL6NoT2P2wwczAHuwsniVjTVCOHSjGmqFXjXmHuSovsLZ3Zj5ATs18/NzphKkfn8jwSRibMSZJtrWu3gdQT5q2oZHpx+u3NClDCxxFj0PBpEKj4dGdNR47NQfj53647FTH5tMPhqooaauhvZugVFjY9Y64T7nh72LUbGVNXSvU+7YPzv+yOto96O6P/NFKTPjhX7xL7dhO6Yxv9q23sXEkY+atuHR6esC1UUMLPRjHwzQUeOxU388duqPx079acyqz97FqNjKGrrXKXfsnx1/vCdjfvLZA5ixopaJ0apJ04u50qvtOhZqPjmgo7RNPa9/8+saiymzSXz3ywfeb/gvJWeCgImWj0F53KZyMXFMMfpkGo9PP63OgEWsS5x2fbQUeqH3IBEHjQNjUzAI8QYKU18J8QYKU18J8QYKj0kfm7x/kh8HUXYwrh+Ig8aBsSkYhHgDBfYuSFtcsGn/FH9k/3znpw+8tjk3yORjX7gScXtlvdDnj0iib5luw3ZMY341Po25wFJmuWubRU+7Ek9Fgwdj7wdv6ish3kBh6ish3kDhMeknv7w3kh8HUXYwrh+Ig8aBsSkYhHgDBfYuSFtcsGn/FH9k/7wvY7YPgocTN7DD8NGAOMZMBMsEetV0iWgv9Hpp01shhwoX9myT4mZm1uU/tKdXWIljdXZ7XpvlBhFyngF9Xay6oFn02o4np0FEHwnQXh4/iIEBOUrtTeIN7Z36SbyhvVM/iTe093HoJ198cI6tH4gr5Ci1N4k36t6lsMv51rdl/zR/fOdnDvCFKN8/eSlNjrU9zg9YAavmtbbq88ExG+s2bMc05lfZcmOmMUt7y4OhvXs8eNo79ZN4Q3unfhJvaO/j0E+++ODoDMe0B9q7x/2te5fCLudb35b986GMmV8nAphfj2qigBlj2JGcckB7GdXrHaM1+4ekzH4cIkw6ESaa1xTEmVCmiXxytJc2vSHeIEIvkZvVDz9O6FLWx0CJJ+SEXqWXE8NP6FV6OTH8hF6llxPDT+hVejkx/IRepZcTw0/oVXo5MfyEXqWXE8NP6FV6OTH8hF6llxPDN/Ymd3xAehUq416llxPDV3t176KdtrhEd//kQ15mzw6/PATT5cU11strauJ8OYr9GQXMWHvN5t2G7ZjG/OrUn21sHrlZ/bQ6A5Yy9JY+8dN6lV5ODD+hV+nlxPATepVeTgw/oVfp5cTwE3qVXk4MP6FX6eXE8BN6lV5ODD+hV+nlxPATepVeTgzf2Jvc8QHpVaiMe5VeTgxf7dW9i3ba4hLd/fNhjTneYzfUJmtbI7xkxmIVffk8zicOmqltjWD/vMp2Y9bLZiJ0UoCJo229/tqBsfYh+Pe+csBvD9PHn8K+d/0f/JrfFbjmOfrYMHEUbNmldRmwiJX6giieh0Y8CRHXiBJDUk68g2oQ6WXWiBJDUs7UhxiScqY+xJCUM/UhhqSca9aPTSxI212D/ZOPx/o+iSWzc5b9mR3Y23DG/uw2bMc05mnM05hXMmtEiSEpZ+pDDEk5Ux9iSMqZ+hBDUs45+rGJBWm7a7B/Xp0x+4+p7Z/k/BIPtWeMUK1RbRX4c436RxvVmEEtueYrnAUYSw1AheBf+pb6/VUDF6/TR8ReHWBLnk8vk14/2n7v+pjxb735DcG//xX/VuMsffL1VTZqxFGwiC5WFjELnbYud4UcIKIPUu3VCBDvUTOnvlIzp75SM6e+UjMfhz67FujOBr4Tyu4Hi/2TnJ33f7dhO6Yxv5q/YeLuU38ac6VmTn2lZk59pWZOfaVmPg59di3QnQ18J5TdDxb7Jzk77/9uw3YsjZkT8NrTRNX8sEO1SdhitDUTaj45Id4Ib27oH7EAvzAuu9TvLxb4UTwTxEsJfeFAnI+8o2C3IWbtnvWxZPjlN3xlQMTtuaMfAxsr+tRMhbRZRnyUzKrSJasLGlju2mbp01aIA/l8EULHbmmjQFsJ8Qb5t6tPBH2ItFXq1hNdQYhH7+3qM58o69xuaaNAWwnx6I3iG5G2yrXND5E99OO3dTa+5o+8PkjJieupv64K3d98V8R02Q/hgfZ/t2E7pjEfMXH3o6/mOo0ZBdpKiDfIv119IuhDpK1yPRuf9u6nz3yirHO7pY0CbSXEozeKb0TaKtc2P0T20J/GvNg/d97/3YbtWBgzL67BT2//xNZ4JVx2ABabggPSKRJYMhfJx75Ac7bX7xPH7aENTCJT/IrB5BIRfY+Qbyx+4I/aBn0MlRfXmPG//o2/ERBZvNYWfR27yBF9X0yYMQvIqtLF2oNlDbrQt7R5kLbHa1sfv5pzW/oVdFKwQbzXqzwm/TqHKGyP1/Z91l/pKYT4aq9y//qY8fd+9O+vgj2fo6/0FEJ8tVep+nUlKGlza/j+rOhuyT9ddt7/3YbtmMY8jXka873qV9BJwQbxXq/ymPTrHKKwPV7b91l/pacQ4qu9yv3rT2O+ImPGFKvJEcFcgQhfVQo3TeiLa15ER1dDeyvj80ZhkaNjezlVh/p9mvixPC8fmHSmjB/jq7GRb18tX7yOIJNeJv3jBpEN+mqutLHklz/78Yb2uumaPnHAvIEcz9T6WSJmzIv6+WKA9eqSTWs66D0AvIyq8WPRsdq+XX22GCJ1u2FzqWhOHaXQS/01M8kGmlNHKfReVl/nhzb6NX4sOpY2ZydSK0llB5pTRyn0XnZ+FHr31seSv/jP/nnjp//rjzWSKwfYc1XQiELvfc4P9xp0TwPd8dyA2Z/5RwsRcjDmnfd/t2E7pjFPY361flmmunx1cSs8DLXNg1Hjx6JjtX27+rpZ0CYOaT8KNKeOUuil/pqZZAPNqaMUei+rr/NDG/0aPxYdS5uzE6mVpLIDzamjFHovOz8KvXvrT2O+UmPGMrFSbIyIxjG88MIEmYwlwijaxLW3B2dhbBQQyqpZPz5GL5kxMOIoL26Dffz9yRcP+K1iKvmIPG1+yM+tsrGLGyNxvzEn6WOlGLAaLRG1YdBMjBx0lNszy2tYf1q7CV3owCNBuz4MiiqE4CBSuXV90BmjzXmVcbxuWL3NDmJ4MI7vp89Vo68zQFtzKjq3MdWDSA89I+0oLxjH95sf4g+rjzG/4bm/2PiFX/ylBiaNGROhl0zQPwH5sPUTqfdaV4hbrO7Ptic/+cIB358xZjJp77z/uw3bMY35iInb+8agP42ZSOXW9UFnjDbnVcbxa9j4lBge9OJcNfo6A7Q1p6JzG1M9iPTQM9KO8oJxfL/5If6w+hjtNOarM2bAwABLw+QAY+NDWPQySttkqo5Cbx1FG2XOQibQqzpEGKvUHNXR+n367Mf473jpgL98IG4T5z/M57WDvaB4z5cO8ELD8/lRP9NNJu0j9TFRtVVQG64R2lhy99U3S8fw+m3R6JIFT7PlmLoaLPQxmhkDA/RTMKijiCgaj7Tg+vXZXGjXrYQt5stf+mRApG5JQC9tcnqZQP596nN1jNIrpV3ReYtpDOb89zKB/NP0MVqsV3nTk+9t8HKbHKy6gj2HeEP1o/jVSoD80+oP8Qb3VNFVAb4Pm1n6n8TFOImbMd/P/u82bMc05mnMKxucp01jlrZyvr5uHGwo2majOX9jioQE+fepz9UxSq+UdkXnLaYxmPPfywTyT9OfxnwDxqxmpnHgI1RAL5maQwRrBO0FclBQTc1R/Q996lsav/q//EiAMjnAKPJB46Dn4lWDT67eGJs4b+sLCptovwH8MP9zhv1I328kN4YP2R+pj5UCFgsYNmgOBqy9C0tGn9cytKnBNjjs2V90mxlT/2L5Wr5GoC73Gqn27/Mjxt/TB9V8HPrAVtJrs7mQA2xAELtPytlOHbuHfr3SSkxUzI9G5vxrznbq2C362Krac23zchuTTq4coFP1t1PHbqkf6j2NxdDQ9eO7oq0fVpq365658/7vNmzHNGbnWOOcxgx10dcI+hrx+TljY42uxi3qQ28ToV03ne0b0xbq2D3069VVYqJifjQy519ztlPHbtGfxuztumfuvP+7DdvR/fAXZqY2BmpyZL7tYx9oqMnxyzvJBDJB42Tq2Df+/Fsaqk9ba8CMUSBH7Rno1VFAXPVr/e/6tRcb/sJBjdPwSaeXW2u/lNxfa9iN8WRuJJnE7WPxY/2v+bavbPzJT/2eBmaspsvLaqgGTBvoXRiz4fWzOKgfWJS0LZNFrJmxso/CNWV79WJs0S9y7H8OPGLnpT3mdvXZMhQ2HdqxyzSIjz9EA7VXXwbWXiB+WX29CtpKmooBc/6V2ntZ/Z/98JOG2nMFk+aDYGrP+tEwFJJ4o559v/mJ29rgjvs6kfXDOtH1s/gIGDnkG/vt/27Ddkxjnsb8KrbxedsyfSlLJpFjcc0bNE7YT183DmBboR17TYP4sRsT7LfxQU9fr4K2kqZiwJx/pfZeVn8a89UZs1qaGpi2ydGvJylqcpiu2qHqqyUzKkk16pegABvmhTZqasz6opsIOaqzpX6fViZOps+hF+zGLD46z+sLuw3+0oOXxtxCYKzoqyX/oY/+7oYaM20suffxLgW1b/jQH2v4KbR+FhzY8lrUb3FfyixQq18Xt7cl0yOmv4h09HkMVL8qQ0gd4o9OH3QT0W2FjUahV1/l1d4a6aGZQPwc/XoVkC55lTn/xB9WHwPGdEHtlraiHw0jQmZPv0Z6aCYQj+JX9fXe0YZ00xt1/TiyfhxbOU5s/o0L7f9uw3ZMY16g9deJ2/vGTGOuyhBSh/ij0wfdPurmotA73phqpIdmAvFz9OtVQLrkVeb8E39Y/WnMun4cWzlObP6NC+3/bsN2bDJm4uFeq5CD3fI1JP5Eo6qRQ1uNmS8vqU7IJuhV60VNbZg2OUQgSSXI0frf/tKLDX5c7y837IPy/mN8ppWbZDmLG8OHAj5h8IqDm2E3+H2/fqDqY6VYstozRosB84Ia1JLrKNpoev0sDhaiLjV7Sbion0zQV4hSv0esF32PiL7mjPX1YUDf4wY6rnaz+p5v+kQquonoFkO7wtaz5RWfbmSpa8Cx+rVySJcZ6Px4ZM6/8FD6GDOvpkFNl97axp6JYMw9/cpl64e4lY10oxvb14/vnzvv/27DdkxjdsjR+uvETWPW+j0iC9cju22srnaz+p5v+kQqupXo5hJ7TWK8MSl7bHwKyrVySJcZ6Px4ZM6/8FD6mOs0ZvD986GMGZNTowrfCjROm5fVWBpmjLEBcZQ180998E83NJNeqOdSiCvYMGepxlzHapszUpXW768gbEL9B/52G97+hQN+Y2yi/WPx3CQ+NE8buCX8qJ8IY4s+JlrBetWMgUg1Zqj27Gf/vEHlwKKkl9eDtIFetksiNsoXt/VSv0cupO+RR6Tvvabv5xJ9IqAbim4xbEC6DelmxKZW40BEx/Z6NQfI2a4fxTf0unR+PCLz45E5/1egj61isaA2TO8YPkTW09c4ENHaer2aA+Sofr13wP31lQBHrp/99n+3YTumMU9jfnVp0rt54/MlLgvXI7ttrLeu772m7+cSfSKgW4luLts3Jo0DER3b69UcIGe7fhTf0OvS+fGIzI9H5vxfgT7mGq7cmMZM7wMbcw9ywkET2Ft4bYM/rcgrayCiObzKZiyoJudVQ1WIqzH3LBm21+8/wGdC+fk8bSaU7YObaq8jPJ+Ngzi3gQ/K281YvO4o+s/9yPMHftT4iQMYKhaLAVfIUdSSaRP3pQZaP29sWGS1ftrWu6iffNS0DVNfNbUNRT9coaFbCbDFsOmwMRGpsD1pREeNx56vr9XS1us6Z348Z87/veh/5IefNJLXBvRWMOO/81MHkmxwP/XT5t4xKm5lQ++1csf62Xn/dxu2YxrzAs5OVXXivD2NmfrJR03bMPVVU9tQ9HWD0E0E2GiO3ZhAR43Hnq+v1dLW6zpnfjxnzv+96GO0yY+DcOLENOaV9Xm+MWNOWJoam7bDwxpqctrGaDFgLkmN+clnX2yQo6gCZ1STprfWQxszJrMas7bJAT2jtqlH6/fpM6j//S8feOenD/gNAG4kP/ZnCHF7ZbG4MfwRMdHHmL/jwwe++8cPvPVHD4TjDnjuh59vvPkj39VIXQ3/0pTV9u6XD1C//9L2KL5B/fIxGY/bUlvUzxKkfjKNqX+sftodAjYR3WJo161NoRd6Gxlx0DgwNgWDEG+ggH6tNl1OcOz8vDb5DdLm/N+LvhptNWAgUhU0ooR4gwr3nh/uHaRbHGxaPzvv/27DdkxjnsYsxTeo/6Ib32viDdKmvuinPSJgK2G70TabDu1K7EoNNqa9Nz70a7XpcoJj5+e1yW+QNuf/XvSx3mnMvnh23v/dhu1YMWYsCrA02tpLm94KOSv2Zh80Jw5kpuEN4hgzEc4I9KrpVmMmh17aOpY2vRVyqLDW/87PHOAD8f6hAF5KkGNtj/MCHLhVvNaIu9jggwOi/9Yfe77x3AcPfMdH/1LjuR94/sAPHviqP/P7G/qCmrjn/JDxfcKHDri+LRrf7Gxr8zrpFVbibIW2fBf1EyFn6p+tr5uFbihsOtqOnatBRLck0F62P4iBATlK7U3iDXqpCmXawFX4pV1ofmAlfiH9mPyGXgszoO2YnAaRNDkN7Y3Jb8TAgByl9ibxhvZO/STeqPdO4S77rd+yfnbe/92G7ZjGvAI5VDiN2dmycKf+2frhCg3dRHRzob1lY9LePTY+eqkKZdrAVfilXWh+YCV+If2Y/IZeCzOg7ZicBpE0OQ3tjclvxMCAHKX2JvGG9k79JN6o907hLvut37J+HtaYAXMCLLDXO0ZfYispLaFniZM2qATDjuTIUXvW3kvV7z/kt9vj8OVxJp0XF0w9rymI24/9/TagwM3QXrvNVf+5Dz9/ANPlo2FmvW7JxM163Yb54BhmXPXbftSw7ckhwqIkwkLkNQ5xFhz1k0+O9tKmN8QbROglMvVDvEHEesMPErqV6DakxA51Qq/Sy4nhg16tM11CY85/r1fp5cTwE3qVXk4MP6FX6eXE8BN6lV5ODF/t1XtHO93iRHf9lP35svu/27Ad05jvQGve+8ZU/WnMz45+2h0CthLobT3ET+tVztHXOtMlNK7//qaCA72u8Qyc1qv0cmL4Cb1KLyeGn9Cr9HJi+Am9Si8nhq/26r2jnW5xort+yv58r8aMIfFSF0uD8KqGZmpbI9gnr4LV3uI9dkPH1rZGaj1AXEf18omDZmpbI7X+xbQy0TrpwI2hbb3+WoOx9iH7975ywG8/t+czxtQ/W/+7v/nfXeVS+mfVjw0QR8Ee+7QvBGwiCi/o0qWt0tukgN6aE+8AG0R6mUSoikgU2UgX0vBrt/nh41c+D2x59N7I/NPWeQAiGteIEkNSTkx+g0gvs0aUGJJynjV9vVO0Id3ohq+NB12fbsN2TGNetDUyjfkW9ZM/BZfSP6t+Hm/iKExjnsYs8Zj8BpFeZo0oMSTlPGv6eqdoQ7rRDV8bD7o+3YbtWBgztqSWxp9H7P2RRAwMGIuZQfz+kMMv6+BL2fwY3P7JT1ztmVHoEEmna9R6qJZRcD/1+6sMJldvDxFeHdtj7/n0clPrR+en/hn6WNH3fc8farz0Kx9o/OaX/2FAhF4yH6x+8vVVKmrERV+3DGpWuKJf+L9/LKjXm4Y0Yv9q6OalEO9RM9ki2eyIx97XoH6/Urk6WMwPOVc5/1yLXl1MSIIcIBIu0qi9GgHiPWrm1FdqJsr1DgL311eC3H1YrB9yhuvzDzz52uC09ek2bMc05hPr32XjmPon6WM805j1etOQRuxZjbqRAfEeNfM+N76Fwj3OP9eiVxcTkiAHiDA/UHs1AsR71Mypr9RMlOsdBO6vrwS5+7BYP+QM1+eOxqyWBtXYyAkXbKi91T9i4SemLB4wXitZ0ZqJHaKj+lpVrQdqJtR8ckK8EcU3jq3fX1zwo35uAC899IUGcT5Sj4LdZpSn/jn6WM4n/+GHGtgSbXjh594UYGDE/72v+rcbW/QvXD+aKNDmwX7ZsFFsFuGmjbENb6FaNdsW29O4zdZGW9Etjwht4Cp6dOenzD9fC9Q/3EJE519zvPfs+Qe9ItArpT2eH+3VrwNF2irVWqIrCPHonfoK8XrXQO9ypbt+bH0uDNjWIW1+BTIfy9X1uX1/cBu2YxrzNOYb1sdmsFtMiDZMY4ZpzK6/ef5Brwj0SmmP50d79zAe7Z36CvF610DvcqW7fmx9his3WIe0dzTm8LMTwNj0jzl6EZT4ikFxRHj87J/w5KOQZDeCxabgUZxTv0fINxY/8OfG2M3wNkz9s/WxGewHAw43aqiZqT1jzFv0L1y/mgH2YKN0U+CKqhmDXl38/0dCcypq0mxwbFW6edV2b5vTtqJX5DNTqdYo84/FQrhyWC+/YhaI/+vf+BsN2ufMfw+9ut4M0K6okSjEe70K85+CQU8hxFd7lceh37sjtBW9s68tyERnfWLDf/jnf2dDLZmViTGftj+4Ddsxjdk5p36PkG+cuHFP/RBvbNB3gzHLmcYMmlOZxjye/x56db0ZoF3pWQvxXq/C/Kdg0FMI8dVe5XHo9+4IbUXv7GsLMtFZnw9szPW1cEVfC68YG6fkx+D6YFCWfTWbf8iTjwJq289Om7HR1diucH794Jn0MukfN4jwY39ebrDpT/0z9LGWn3rxTzQwrbExY1q0GeX23NHfsX4eUTMG1eeKouAEVxfu2xhfKdQ5ATI5Y9qzgrrBsUUS0baiW57iGxzzgykS4esobHwy/1gsYLpqvVDtmfZp8++VWK9Wni4w2DI/xAHzqGhOHaXQy8vemplkA82poxR6b0t/PP+0Fb2zyvb1ucWYT9sf3IbtmMY8jfkm9TGVacy9K4U6J0AmZ0w7V/BQGx/zGe7bmMYM9N6WcSr0XlZ/PP+0Fb2zyvb1+WDGjFFBeNhGsDc3NkrhI+a0+RANl2ol8kjwpakkNUANlQjnpR3FR+92TqsfNO43hja32T5e/+SLB3xrmPon6WMn/9VPflsDi9UXv9XAAEMik1Hg9iz6O9bP4130uSK9Cr0W0Hj460ZUhwg6nJGz6yaV9rKEboiKKrgFyvwQf/KFFxs+P2x8ZNKW+Q/3bWDJL3/24w2Nsy2GNwfos1FumX8gHpewSrrkRp0NjdDGJJRxvBpSz8wghgfj+O3qM6vo6wzT7kVA7+P56xMDZgWy0mgvjFn0t+wPbsN2TGNecFr9oPETN+6pv0EfI5nGvB3VIYIOZ+TssWc10o6WuJ+NTw14GvOtGCfx/fSZVfR1hmn3IqD38fz1ea/GjC2BGhtGWNsKcSzWjY2y7MT+w3D+2W7/wH/Plw7wwpBRPSvVM2qbfK1ZUbWegkL8tPr9ZQU/6me6yaSNjn2M6B0vHfD8qX+SPkYC2DNgwJhNeFKDCL1kYskoYMz8eU2var/6sQTD9e2hpZLw3QYmSuUa1+viiiqao+g8qCZnjz2rUTey2N0S2hvJgW9nzINtRv4nF9mYiNvGp/eX+VejVTNm4wO2QtB8IJ9Nczz/qeyGp1n9qasRlz+gZx60sZkvf+mTARFGkaPQS5ucXiaQ/5j0mT1G6UzS7qH3K25fcP761NUIxD3zyP3BbdiOacwO8dPq94m+kPFM/bE+RgLhyg0sB/vpGRKZ05hVk7PrhlU3MiIV7Y3k4PyND8KVG7oJTmOOhAT5j0mf2WOUziTtHnq/4vYF569PXY1A3DOP3B/chu1YGDPmlByuoSan7QrGtrgwO7G39R/4VigWyKgkFdSz19qo/P7r9xvAD/M/Z9iP9P1GcmP4Eoi9yvDNfeqfrY+dqNFC+FOCTM3Hkp/7wecP2B/N3L1+e8i9bTlcRTVgjFkjoFeUfDcY5xBXTc7ObKSdK4idLjY4bSs9M/M5MSP0dp2TMv9sc+HKDbY/tWTFt0XTx5LH8+8GTFW86Lb6ub+1fo1AnQcioOZR29WcMCSgt+Zsp469Rf06exWd+dpW9lifyjn7g9uwHdOYFxxb/37GM/Vdp6M/jTk5bjDOIa6a05i9qmnMR1LH7qFfZ6+iM1/byh7rUzlnf3AbtmPFmLEu4NdkVuglX43tjT//lob/kUT+wa4PhuFFWy+ZqKGAJhBPLtvQGqCOgig4QS/5UXzj2Pq5zfxScn/taTfGk7mRZBK3j8W/69cOeHzqM5PM2wZ9tWQ1Wtgef+sPfFPD7RljNv17ur/2cHItapNjS8ZEq9GCxsmscahnYR4wJ92qYufaiM8YF8umxjZE3PQXH7HRjU/mB1vVLS95cIBVq3mTv2X+vSpgU6ZtmX5FkhmXuRHsQcG0aIcDNYiPPyQFtZeXvcRrLxC/LX2dJdpKmuqN6P09Z3366mLUhfYHt2E7pjFPY74x/WnMarHEQePTmLfMv1cF05iN2vtQ+jpLtJU01RvR+3vO+vTVxagL7Q9uw3Z0jRkD4486VMLhGuSrvbmxURYnltM71kumjqUGtWF+6YeiNZBDDfdfv2M3ZvHVC15f2G3gpYe/NOMWAmOn/pH6aszhuw3+sCNW1OutcTdme6H9WvF71u/YA1+NWa2UiFppNWYivThqIR50jdk2Gt/C2JKM2NcOcat/EZFRHmGgbXO+wTE/bGQg+o4pY8lqsRW15J4xw3j+HatncX8t7tci9XvE8r0tmR4xfY2AmoqajRoS0BvvgRu1t0Z6aCYQv2b9OkuQpnSVOv96vzzCfT9pfTqxOTRO2h/i/ywbrE+3YTumMU9j9vxb0Z/GTASI9OKohXgwjXlxXqtncX8t7tci9XvE8r0tmR4xfY2AGoxajloU0HuOsSmaCcSvWb/OEqQpXaXOv94vj3Dfb92Yky8myMTSUMDY3v7Siw1+3O0vB+yD5v5jcLskMtUaMVo+FDaG2hgL91+/3yTLWdwYPjT0CYNXHNwPu8Hv+/UDU/9YfWxMbRUwXXqxXjVgXlnTS6aOArelveeHh5ONwDKpqtqq2rOCoULqChgLar3AWI1wdp8Bqd9f7RqLTU3q94jlMDMe4UoBEdnsqr7Pj8w/9sz8q9EC25maMb+EBDQ+nn+/v1ZD3NzGa8U3rNevS+r3iNZPvunTW1GbqSZUwbq2vCJWI0xdA65Nv84MpGkM9O545F7W5/b9Idy3gT5tfpEn/1uJvtuwHdOYpzHfjD42hq0qmCu905jDlRtqwMBYjUxjpoa4uY3Xim9Yr1+X1O8RrZ9806e3omaj9kO7cqyxQeoacG36dWYgTWOgd8cj97I+t+8PrFVAn/YRxowpYlSYVvLCAWpvGJv/E942LP+BuV3G279wgAsjk1F8VUk1/bLZ8vhRuUU0h/NixvdfPxPtH4unWr5UQxtK/T526sOR+lhIBZNTY8aS1ZjTkMB/wYjp713/C58/QD2AiVZzrYathEM3yAfNqQZMvsYZpbPhV80GZxsW9fumZvWT4xE2Nbs6j3ClQC9qRDr69Nb5x6QxWrXncN8Gllx/bWdv/r0GkPr99SZt6NSv1171vVf0iYBajpoQBqY2pmaGddU4ENGxvV7NAXKuRz8mp6HzNp5/j9z7+hzvD9jw+I9eoO82bMc0ZodRx9a/5cbU+n3s1Icj9dVCFExuGrPmqAFPY/azS/2O1D+NucaBiI7t9WoOkLNdPyanofM2nn+P3Pv6HO8PFzBmDOn1b35dQ02Lf6r7D7RZuHKpmokCeD4bFh++oP3/b+/tgiNLrjs/+90PfvCTdm2FXuTwyoHRtMSIBruJahS+qlAAqlCftz5Q+K7u6enu6ZnmjDjDGWCGlLjUTpOz/JCllbgOUtQGvRGzDDv2YV82NlakV6vVymuK5JCiZD3QERsrRziscIQVepRPnv+ZnFN5cS8uUCigCn1u/B4y8mb+K3FRyF9PTt57MWHx5dPtkRDPl43mfCH0cgHaY7Q65zLHLzmp+Unjt/xR8vtfOXA8Zd5zQCpQXXwRG2ej39n39H/9wPFFBpu/VP5Yxs9/6hgP/umAhXSoMa5h1ANdH0eLNl6PhLiS8Yk4i1ENLezr6UmXgb4+WPFDm/j1QZnPDl0fnYlywvWHYqFelDGpQc8oo16fBfHrL4xj/D6ciOVDCUCLB8Tl5I0VAL3pGt0rve/k5+urgbK+bqNcf2kzhu9n+vyQRcz4foqG+TAxm5inMt/ErNG6jdcjwcT80eCJcYzfhxOxfC0YKEcTVxRq4lytONP7jp6vrwbK+rqNcv2lzRi+n+nzw4WJ+ckPXyeOPnC88j2H/AAAA8W2FwwU9bxkNPSD4SVZ+kdixpHvbTql4/fhhOWfNR+PBwGQihYzavpfOCCGxPylA+JSx89942KGMiFIyBLi1IrFWY0+611LBM0IfVaDs7hWcTH3v3xAyPjxUzOvfuDA9ZGH/vuLQ6AZttWgjHqeqoauD6YwnZ9w/TGFaenq66/PDrVJuP5jHD8Tz9dq0cQlhHJcXRqcBUkiRD3Q9QB9g0qPDyeQcDn58asRXC7PWa//R79cAs0u9Pv5UTiBlrH5AQKGmPH9RFnEzC1Fw3yYmD+sn2DxfBROWH4s38TsXUsEzQh9VoOzJuaPBk9gJOcbPxPPD7ziiasIZUgL5TjeaoQWm26DeqDrAfoGlR4fTiDhcvLjVyO4XJ6zXv+PfrkEml3o9/OjcAItY/PDSGLGRvBXvu/Ahm/5n974j3QMkctSjwUigKFgWU8PFP9jHH0t3/LHnI8FaqhFBMPL1LJwzUvfo+SjLPVnHT//0SaJOa5nrd44aBlHtwlMTCAZLTGSRDHzP3QwYenxy2THU5tcB5xVnFCPqRBp+vro/BGuPyY7MJQfu/5jHH+GfC0Y6AdoIaHszUegRisN6LPQG/AdPWijiZ8Nwgl9dnz5+KmRjDLAVZJLd0HXH5xQnyV/hO8n/rcLNKxBPfqKhvkwMVv+tco3Mes2gZUJE/MYx29iVsTPBuEEzuKnRjLKAFdJLt0FXX9wQn2W/BG+n6OJmf6rnOCPF/DwBEw6+A9zTD1YJkI9b3uRHwMJ+GPQZ/nHsHzLv5x8LFOLjN9loJkLyj/n+Gm+IJSeIUUoGaoG3rJEFkknEZcx0DLWZVEyttR93iHTDaYtNX4BNTiLGkxkWAZEPRJwfdAebfRZlC/x+guowaejZpTx46wPJ1DDZ72PA7SKtMY0qD/fWU1SG9/9HGc1SW1895Sz+joEl4gY/fpLDfpe0fcTGtbo76domA8Ts+V/2PIa5ZuYgYk56foLqMGno2aU8eOsDydQw2cD03i0kNLVdb6zmqQ2vvs5zmqS2vjuKWf1dQguETH69Zca9L2i72dgZUJ/P0XDfJwkZnytMVAVKuCDUeaz8p/t6MubyH/lRw758TA4+m9/wvIt3/I5X0tRKxmgHmihgnRVxzUM4vlYuEZZi3n/ywcE9HxV10cnSBlMcr6e1pHA03rgGI9WEcACL8paWsCbzNfrGo3vErTxa8gEapJaxms0vkvQ5qz5+idFGQQXipBry9cf27vkOkOZODvu3++Y80XDfJiYLf/DawXs+lxKvon5aq+/TpAyGCUfekA9EkzMCS1Ro39SlEFwoQi5tnz9nz0x4/9U4z/J8Z/q6Kw/HjVYGsJ/5qM9zmLQ8VtHcFO25Vv+1Obj9gYwej5EGFcmgCzjYNHbu/ZEkIxbxTRIiH8K9Iw2EHP81rIs10euAGrGcP2nIB/t/TqqXzhFvcrXyoGK4qKKgzYANVqE8bO6BqA+iXjLy8mPXwGA6yNXUl09MHT90WbKvz+iYT5MzJZv+ZnyTczp10euAGrGcP2nIB/tIQmANNSrfG9lAhLSWvImC0AbgBpvTSJ+VtcA1CcRb3k5+fErAHB95EqqqweGrj/aTPn3RzTMx7CY8QH4z3aE4j/M8b+y8QFYNND/wY56bBlHAl+moQ9GS8s/Y3755t/zzMz9ouei8iVnaq/POPKHBMw5KONBerjJYZR8iBNShEqhSUgX9XH0WW/WAJzVYkYNyrql/lzdHkDPQ2JW45/23+8Y85GJBJQxTWOrEffyPia0hAB0pctQF8oa1AO017cboU2WMhJQ1vhwAu3HkR/vBfRVipN4/cf9+x1zvmiYDxPzROebmC8/31uZQA7KJmb56ab89zvGfGQiAWUTc2p+vBfQVylO4vUf9+93zPmiYT6GxYzOCMXH4z/hUYNQZuh/aOOD+cOkDNAYfX/EWL4PJ1LzIeN/8sa9ExE9T/D4pzcfGk5/6Pwo+RChd6QnLmYsMqMMlWqhxon3AtAt6tFS5ySJWW4zwxYwNX75iab29ys148jHZA0ZY4LmXoFXTkRrSYsqS1kvAmepj5e1PuNtLio/6SzKGn1l5MrH0Vcb//SZ8u+PaJgPE/OHaROWb2KWxuh7ifkmZhPzOfNNzAllE3OWfNEwH8Nixo+Kbnzr9NB/buN/aOvQ7zCowf/Wxn+8Y9D4SPTC/zZ/BvIhVJD/hV/wZM9H33/5j54S/8uv/QoRWNkjer7Q8cvZka9P+dubxIXl64kP7S92/Co/i5hHyddi1rLUKgU4C2F7K3uhauK9dA1AfdCR0G2GxMxK7v99Rr/QAj/v2K6/tJ/efEzBLOahfNzYw2e1eAIneZIElrSkfFZ0X10eX74WuS5r9JXRiIBx/fGPHtTgqkLMl/P7Rfsx5IuG+TAxf1hzQfneyoSJ+cLyL+UPA/kmZhPzSPkmZkb3RdnEnJ4vGuZjWMyYXvGjcsTQB6t6+WCUcZl4+/iTP3NIDobCZUzTUn9N8yHUwJ0e6DlLPnIelWeJH//zf0xA0shBDc6iJYCkRdWp+Unj1/XnvD7YBME5/+zdiND50iZLPqY2lS9llY++Ol/Xj54PAUPMUDLKQ2I+Yz6UDAVCikkSBWivxextGqB7IROK1fXxT4/31b1Ez3gFCC9rX+b1R98py4ceUvMD3wQEliK03pJkBnSCD0ypiTPufKB/Io1OEAWq64/6Jz95nZDrDzGjJcpT/v0RDfNhYr6wfAjSmzjAxCxtsuRf0R+Gzjcxm5ilnD3fxKxqkjAxJ+WLhvkYErNMnfwf4K/91CE1+I9x/K9sxOE/wFHGx/P/Bn/8A4f0wkcymKal/trlQ43QZ/riM/QsOQn5SIN6Ne9sLRLIQRsfGzCk51j++K4PQL6UecFHyipfEhLyZTyo53zZTIFRqfEj/6zjz5KPR8xDwxp59Py58qFGrcMkMaNet4+LGS11WQPFapCmM5P6Ai3m3a+9SOjrM+7rP5X5mJoZyVdS0Ugz1klwigiMdSK6pe/oQX5Q6Yn3Qo1G1/tmntHzgT7rG3tEt7jOLDN5pSPEhnoW8yX9fsecLxrmw8R8AfnQpIkZIF/K/MWVssqXhIR8GQ/qOf9y/jB0vonZxHzmfOiWkXwTs6qJo8/6xh4TsxwygXJTBEkN/mf1jx2YUmWg/MEyyfJ/qmNw6CV9OS1ec53ytUrTF58hZh9FxPNF3iozXs7+j4B4PmrGd32SQD62PEgN58tNCCp/6A8Po0VZLxDx+OUPQI0f+Xr8o+RDw5pR8rUUk5QMvEF9+zhJCYGPPToTLZHjO3qQrMUsL8289Os/ZflYVkUZbSBg1rMsdLNskD8kIW6va0BcWvGauP5l/Er8SflAZ44vXyfrskZnapCPkUg5fs2n/PsjGubDxHwB+VqcJuYkkI8vrtRw/uT8YcTzAysTo+RDiulaBd6gvn2cpITAxx6diZbI8R09SDYxnznfxKzaaJCpk3VZozM1yMdIpBy/5lP+/REN8zEk5n/xSoOQSZM7oCw1/J/tUkYoD9Q3cPW87VvX6Mzrmq/FqdGLz6iBLNELxPOPHtYItEQyyroGaVn+ERDPR3kc1ycdnS+y53xZ2OEvNPI/+ecOqedxyngY+dLjLP8Z46HwyJccNX5pOQH50BuEpwWpgRS9QQlv4gC01H0DE3vimUD3BWgpSv7igUOLeczXB1yTfEy+yAeQCsrcckg5XO89dCYkU+lTBsPSGmrD/ziQGv5clNMZd75GclQ+cnT+E70FDG3Qnrmk3y/OXmi+aJgPE/MF5GtZakzMGp1vYk5Xo3cnEfjYg5a6b+BjTzwT6L4ALU3M0niUfK0TYGLOgOSofOTo/GdazCB92sXHBJWE7oWyxjfzZ3WNZlry48rUZegZNUmy1KAe7fViNXKQgGQNzqIlavRnaZAP4jWa8V1/Wd7hfEhanx3SNr646usr4CzgP4yhWxdUviw6YVERf0IAfceWj9urAPKhNwD5ZSHwsQcS1VoNfOzRus0CXvuIW6REzMzFXh/pO7brL32vKh/CADx9D+VzvagIguF8LScpq5ZSw/lDNQn50JjOjycDH+Xqryh/qCY1X1D5Aq488L9cYhy/Xx9OXFC+aJgPE7OJeahGM77rr7+4JuZ0Ah97TMwTna+FwSIZyud6kZASj9RweymrllLD+UM1CfkXK85x5w/VpOYLKl/AlQf+l0uM4/frw4kLyhcN83GCmDXv350l9KQZr0FLlHEW+JAU0NJH+QRdg5Yo4yzwISmgpY/yCboGLVHGWeBDUkBLvficzlvdRSJLPsSMpWmgpYuz8TL0jBp8YhAbgJH4S+GvgK5BS5RxFviQU/FRKciXlf/A3vgLx0s/cGC7xBMsXvGNCrKNAl9r/JFwm6E/DGzK+C6DJaax5Q8JmPNRxoM8cZOVzh/SHjz9nkO/ZlEehPnrDshSKxkaji9HBz4mtJKT8vtfYjAqFvDB/+DY/pIDYxvl+oz7+k9QPiZfiIRbSj4vAg/loyXQS8QqX2r4LPKlRuXrNun5WmbIl3oGOZJ2pflSc8Z8uf5T/v0RDfNhYjYxj/H6AB+VwiT8YZwv31uZQD7KJubLuf4TlA+RKPFIPstjKN9bh+CzIiSVLzVKPFKTKrak/IsS57jzpeaM+XL9p/z7IxrmI1HM33nz8FT0NK0JmhGov975nz/sBEDDmuz50Cp0myTddDCGpHz/0SmgV5ygGYF6JOtyEicoGVsh8EXHlx5LQHxWNlzw2Zd+4pA2/EWX2xLQFzctoAzGnA8Np7/0Ip4vYsYqsZb0VxiUASsTcoWAoWQt5sDHhFZylnzZ6oUatGclj359kDC9v9+z5j/6UwbJAFLBWSzPogxwFrpCDfcSRfFZ5EvNBeVLzZXmS43KlxrkgMz5ODu93x/RMB8m5hMImhGoT8/3PvYEViay50OuJmb9xcXZSfvDMzFf7fWftPyLEpuWFvKl5oLypeZK86VG5UsNckDmfJyd3u+PaJiPITEHsy0Rn3DTCbp7/ujLb3mSWuJsUBmQ/ilx0H4axw+tBq71BL73oBfQaX7wxOWMH6C9vv5ayXGw7UuWg7CBAl9o7I9AGV9o/Hnjj5aXg6Q9Jg7U488ANyrwH4Nfa7rA/CxiHiVfXr/IsoRogRYz0DIG0pcVKwvX/AJHqYeGuTy+6zPu6z9B+VAF0PlYccUkHs9Hmc8O5aM90nQZWL7ORHncv98x54uG+TAxDxF09/jBE0ktcTaoDEj/FA3kGvjYE/jY461M6DQ/eOJyxg/QXl//wMQBJuZ4vkjUxDz5+d46hM6fFrH5cGIa88f9+x1zvmiYj1PErMHEmg5aegecig8n/vLb7xK65mIJhnoiaBkMMgUfToxj/Fq0gYMDJnP8Gn+RPVrJWNIZ+uLiJWv6T4558kPH0QeOV77nkD8AgD9UbLtAF9SPOR8ChpihZJRFzCPnY8FZb+DSAtbsfumAGHzZsfOeQwTMJOVP+/WfiHzu++oHDuTLSxd8OIF8bGtCGfU8lQ/lY4pHPloylp+YP+7f75jzRcN8mJiHQMtgkCn4cGIc4zcxX+YfBjhfvolZeJbzue8Ui42Z4vxx/37HnC8a5iOTmIPZ/ALRnwIxBA0CsCiqe2UhCLlA9KfY+JMIQoghJWOZCF9lLPv4bzmBjRX4+vKNCq9834EbEmRTBhaF0IbLUo/kS8nHKy6gYY28+mLkfIx/aAkaYKMWNpGxvHf+oQM3RMnrGjPnT+/1n4h8npRFNqwWycFZxQn1UBHrZygfNWhj+en5U/79EQ3zYWIeCf0pNv4kghDCxHy+8ZuYJzrfxHm1+VP+/REN8zEkZkzNSWBSPlr7704l6JiRLPlBlzNh409n9PEH9g1AftJSNsDmL/my4qvMmybwZyCbLPjPQ8DN+2iJhSN89bFMpBPwZ4CEseVDw5qLzZcEHr9s5oKY8cAQ3uR1UflDZ8cw/qGz1yOffEOwfgTUQCqogUiwDIt6TOjIR3u00WdRxlkfTqAGZ1HzLOeP+/c75nzRMB8m5hMIOmbExh+YOAD5JuZR8iWBx29iHkqYhHxow1uHQA20gZpRxIOzPpxADc6i5lnOH/fvd8z5omE+hsSMqRN8pf28R9cHM3VAUq8k4i2DwAAfHvSKk9QyCAxI6pVEvGUQGODDg15xkloGgQFJvZKItwwCA3x40AugDZavtYCDZkTgYw9uQviVHznkzw9f3+8z+muNL7r+0gP8YaDMZ2VZCX0t3/Kf4Xw8nigdfVvmWfOn/fpcbb5omA8T8xBJvZKItwwCA3x40CtOUssgMCCpVxLxlkFggA8PegG0MTFbvpQtf8LyAwefiIn5qvJFw3ycIGY9+Wpw1s/RROdjPxuA+qBjRnR+9kz00gQNPDiLNKA/BaA+6JgRnZ89E700QQMPziIN6E8BqA86ZkTnZ89EL90XYo7zfkzSQ0rGVxlf+vitBbipH9sosGSEpSR8ufWfB2qw9IRlLrS3fMt/xvID4xL/8h899eClOBr9klkwJOlY/rRfn0nLFw3zYWIeAvVBx4zo/OyZ6KUJGnhwFmlAfwpAfdAxIzo/eyZ66b6Bjz3vm5gt3/IvMT+wMmFinuR80TAfQ2IO5twATKaYfIGevgHqg44Z0fnxTBB0ORM2/nRGHz/aYCMY0gI3E+8rPWsxA9n8xdtAhr64+FrjDwDLSvjSY+EIWy3wB4DtIXpBCfW4pQEJlm/5V5T/D2Z+xjOOfK3h4L0mAdCzlnFczJohSeNzxzD+af/9jpIvGubDxDwE6oOOGbHxo42J2fItPynfxJw+/mn//Y6SLxrm45xi1hO3BmeDjhlBXxDEEvps0DEjNv500BcEsYQ+G3T04CzGCT3jRikoWZfRBmgxy5cY4EuMr/iPGHy5UYM/DywxoQbtmaENF0jjP4aPwgnLt/xLzIeM/yZa8IiekTZyPmQM3QYOPhUoOV3MmiFJY7Qjj1/aM9P4+/XhxPnyRcN8mJiHGCUffUEQS+izQceMTP74cRbjNDFLY/S1/Gc+38ScPn5pz0zj79eHE+fLFw3zcQYxA0y+waztwdmgS0YwTSflox4EHc8EEoJwzyj5Nv74WdRAyVD1KWLG4g9/6WVZG9so8IeB5SN8rfnW/qHlILTUX/rvMKjBtguVL38S6IVtHZafOR+/nQvLH/fv90rzIWDwxws/76n/3f/SM0q+CLI8S0DMj/7JJhHYl0B9ElrPGmTGOUHS5xo/kJY4O5G/388c5MeKaJgPE/MQo+Tb+ONnUWNivn75Jubs+Sbm9PEDaYmzE/n7DTx64YiG+RiLmEHQ8VR03yDWg7NBxzORJR8EHU9F9w1iPTgbdDwTWfJB0PFUdN8g1oOzQUdP/CxqgBbz+7wFDMT1rBEl4M8GZTx+j/+Ehv7wVL384aGM7Rh8e8OTP3PEM+UfAZafno9NLpyD347OlzZZ8rGsp/KlrPLRV+fr+mnJh4yxcA0Z//X//VkPanAWej5rvugwpuQktKSh1YtFxpN5/OO+/hebD33+9LvvEf/fX37nRHA2TtDMg7MmZht/IrpvEOvB2aCjJ34WNcDELPXTm68mPvx2dL60yZJ/RRPr5eebmNPHP+7rf7H5Uyxm4OdiIuh+Iro9CAI9uk0QkhH0DWID/EcQQfcT0e1BEOjRbYKQjKBvEBvgP4IIup+Ibg+CQI9uE4QQ8XrfmICAIWYsbgOtau9jD/4wUJapnxegXvupQ2qwGIWtFvhzwgIUyvjz420aj3/gkF74k7P8zPkA+VLmBUMpq3xJSMiX8aCe82WzDEalxo/8s45/cvK1mFGGkj/44XcIfRZizp6vlZwu5nHLOI6MLcP1ma7fL/QZmDXAmzggaBZgYrbxn4BuD4JAj24ThBDxet+YMDFL/dTmA+RLmSc+Kat8SUjIl/GgnvMvZ2K9/HytXpRNzPr6TNfvd0LFrCfZ//Dv/iAF3VITBBJBAyKIOhG0DKJOxX8EEQQG6JaaIJAIGhBB1ImgZRB1Kv4jiCAwQLfUBIFE0IAIok4ELYMoQtejDLTUsaCdJGbIG2C6j4M/FfwhSQ02a/zYASXIHyr/4YkkeKkKf5w+yvXltHiN5UvfWH4SyMeWGanhfLnJROXLUqGa+KSsFxh5/DKBqvEjX49/8vMh3b9hAWP5Or6InT1fK/mdrUVPXMyXKeM4Ms4M12dafr8m5lNAyyDqVPxHEEFggG6pCQKJoAERRJ0IWgZRp+I/gggCA3RLTRBIBA2IIOpE0DKIInQ9ysDEHK+Z3vwkkI+JT2o4f3Im1qvKNzHr8Uv5Eq//ReVfmZiD+TeFb3zjf0whaHwmgqgTCbqcgyAwIGh8JoKoEwm6nIMgMCBofCaCqBMJunhwVosZStZixtnsegaY6HUZfzAoSw0vW0kZf1T8h+obuHq+7UHXWL5v4OpT89PR+SJ7zpeFQZ4Qkf/JP3dIPY9TxsPIpImzeCUAP/Qf+ZKjxi8tJzgf6tUyBqgRMWfOh/C0koEW89UqGZwgZubyr/9F5ZuYTyHocg6CwICg8ZkIok4k6HIOgsCAoPGZCKJOJOjiwVkTs665Tvnp6HwTs5zlfBOzHv/lX/+Lyr8yMUcHe8TW/QPCz8KeaH+HOH7zTebI8fobjgePiEG7RhzWVolBN3IcbBNByInMNztErtYmot2+Y2+baPV7jmqFmLuz4vj4HBHVaoROuPtwQNj4r3b8KEPS6WLGdK/1rMUM0CaONwERr9HgzyyoJHQvlDW+mT+razSWH68BsjzI+ZC0PjukbUx8avoTcBbwxDp064vKl0VL3AyDKRig75Xmz7R/3gMBx8HZ7PlxMWsdQsy65qoYErMav4CfDvDPO47rL1xQvonZxGxiNjGbmD/kgibWy8/3ViYCH3twNvv4TcwC+l5i/pWJudXrEJ3BLtHqd4lod5voPzgg2vtbxPGTV4nPvPMOcfzWkeOVV4mjF18iRAm9tkPKjqhRJ+L5uWpELPe2COS3ohbxwuN7xODBoWOnRyAfSviQ6kck5Nv4L3P8M0tdQusZxMWcpOcsYtagpZ704zVoiTLOAh+SAlr6KJ+ga9ASZZwFPiQFtPRRPkHXoCXKOAt8SApo6aN8gq5BS5RxFviQU/FRKchkxw9NfOMvHC/9wIHtNk9+4sCNLrINB9MiJlluMzSxYlPPdxksUU5kPqR7+2t/xxOvAajPkq/FHLiQmAQxY1Ed5Zm5XySSrs90/X5NzCbmqRy/iRlngQ9JAS19lE/QNWiJMs4CH5ICWvoon6Br0BJlnAU+5FR8VAqTMLFefn5cw/EagPos+Sbm7Nf/YvOvTMxYzJwrVojc4joR1WsEJmtI4u2jI8fx2wQk8c47bzuOjwlIYtDvfMRBn7j7wgGBxdhWu0VE9TqBT9H5dx8eOh7dIwZ7PeKFx3cJ5EfUjGANgFxp07EZOWz8Vzr+59Z2CeRDz1rScTEDTO44m6RnLHSjrGvS0TmaoBmBessHQTMC9UjW5SROUDK20mCixKSJJUQ+Kxt2+OxLP3FIG54o5bYW9MVNLyiDic+HdOOs/sHPERAzyqhPz4eYvQU92PD143/+jz3Buyg8QccLB2LGDV0i5mvx+zUxm5hNzALOQg8o65p0dI4maEag3vJB0IxAPZJ1OQkTs873Jg4wMV/O9b+o/KsTc6HiWFxzLDg+XKhsEIPdnuPhIXH88icdn36TeYv45rd+l/jGt36PePr0K4TMy193PP3cewS0oZdDcwslIp4/2Ok67u8zB8QLDx1QS9RrO7a6RG6t5ljecNj4r3T8M/MR8WGyGz/GkEXMKMf1HBgiQEsC5XSC7h58Yvrn4mxQGZD+KXHQ/jqNXys5DrZ9yXIiNuBgQsT+GpQxIf4pg9tdeDlR2n/AoB7TKG504cnUr1VOSH7/6YHjPebXHd7KnkQ9x/LjSr7T+2UPxBw4+FR02vnQaVrJWsxJ1+dirz/0Nm4CpwYEPvYEzQKQLBrmw8Rs4zcxm5iF9E+Jg/Z6/IGJA0zM3sceE/NFXX/vzrESODUg8LEnaBaAZNEwH8NihhJWyo5lR9RqEoN7e47BDnH33r6Dl0axlHr86BXH4ydEtLPlwPSNZU+oRWAfcGbUdOCzop0eEc+HKp7+6heI3NIGEc+HWgQb/5WOf+YTDQL5GD/ytZ69jz2Y1qFkTRaRaCCGdNASyVnw4QQ2qemaiyUY6omgZTDIFHw4cfnj10rGkuDQxIqX9GGxEdMr8+SHjqMPHK98zyETNMDjErFtB11QP5H5O+8dEP3PKb7ogHp1OU48X4tZK1mTvogdR8sV5ez4EE+imBOuz8Vef+gtXYTelAFBMw/OIhkEDQJ8YEDQLADJomE+TMw2fhNzIj6cMDGnEwyVMDGbmE3MIGgWgGTRMB/DYt6oO0pVYr5SJ2QxEwubfOON3ITDHD98mcAyadSJHJiyux1Hj+FJH8ueUZ/ptgnk5zabBKbyeP7Tzz4lZJl3ddPB26N0fq7ScKzXHTb+Kx3/zEqPQH5np0tEu1tEFj1DxvrGKgg7mP1PJLDRBaI/BWILGgRkH7MmCLlA9Kdc5viHlIxlTEy1WJb0szCBjTmYXvlGl1e+78ANLbKpB4uWaMNlqUfyxOdjEbv/Dxi1oC01qj49X4sZt0tpLl/PvjsRV7IGIx/39R+3OEF6ex8YEDTz4CySRcN8mJht/Bc2fhPzRYntotCfYmK+qnxIVwvYxDyO6w+9BeYL8KYMCJoFIBmkt/eBAUEzD84iWTTMx5CY5xbXHaUagc0+h1sdR2PD0W4QchMOP8Li+PEnCVne7PccuIumWiVwK05uieFtTTo/X48I1BwN7jruPySOX3pCyPIplFBpOjYaDqTlSwRuJUrKt/Ff/vhn5hoEHgWqx99aKxJzdwpEXM+QQZKYoRMIAOUkdE46QceMZMkPupyJyR8/pJsE8rGIDbSeATZ/yWSKqZY39WCalk1APH0LePgDWmJhE1MzljF1AqZpJExkPhauZTvYlxgI+11HlnzoLfBxCufTc3Z030xiTr0+o19/6C0wX4A3ZUDQLADJ4K//6gcpBB09QbMAJIuG+TAx2/hNzJnIkh90OROTP34IOAnkm5iT8k3M6ddn9OsPvQVGDAh87AmaBSAZBE4NCDp6gmYBSBYN8zG8lM1LjnOztx1L6wQm2cOo5qivMmuELHW++1Vi/6VDAo+nwKKoTNa8XUjg5Hg+lm3ncstEq7TErDhqNQIKKW33iRwewYGQzPk2/vT8ix3/zJ0WcVgtEoN+26HGP3drjkB+XM8QQ1zMOAsxoEbXA12Pvkkk9Uoi3jIIDPDhQa84SS2DwICkXknEWwaBAT486AXQBv9I0gIOmhGBjz24SeZXfuSQW2IwvX6f0dMuJmI9KQNM3CjzWVn2RN9rnS96U8Ir3/x7hJZl4GZiFD3HazQ4m6RkjA0MiXls1wd6C4wYEPjYEzQLQPLaf/tfEd94s0r8088fngjOxgmaeXAWyaJhPkzMNn4TcyLxlkFggA8PesVJahkEBiT1SiLeMggM8OFBL4A2Juaryjcxp1+f6ytmLHjS3E3zbLPjKFaIwVaL6XiOHzwkWo26oxMReOhErtxwYBMT95WpnJOT8ucWS4xbVm3V645q2cH5c6ubRG6t6jhXvo0/Pf+ixo8HjMjDT94+JvBQT4xfklW+1jMmfYgZYIqPS8KbIwBnkRNPA6gPOmZE52fPRC9N0MCDs0gD+lMA6oOOGdH52TPRS/eFmOO8H5P0kJIx1WJSjt/6godOYJsPljSx1InJV0/fqMHSMbYLof0zkJ9FzCBwM5Fdz0FUCmgfF7P3sUdGnnp9Pv7kec/5rs/liDkwa4A3cUDQLMDEbOMf4/hNzHHQSxM08OAs0oD+FID6oGNGdH72TPTSfQMfe943MY8538Scfn2ur5h5qr3T7BIoz82vOnIrxGGtSBwd7hPYzoOF0+hgh8gVNx3YLoTJeqPp4Bts5kqbRHr+3K1PMLzgOYZ8G396/ujjn8lHhM4/fvEl4jCqE63VRULnbzfWCa1nAGFgcg88kQLaQx7Au8eD+qBjRnR+PBMEXc7E5I8fbfT/VgjcTLyv9KzFDGTzFz9EYmhixbQLgWFZGJMyFjaxFQgT9J8wesET9bjlBgmZ87U88CgMeSDGBeVLzgWNPy7mdOJiTtdz4N0UIOO4koG+qkBGzj/dkID5OqA89DjSc10fE7OJzcZ/Qr6JOehyJiZ//GhjYr6q8ZuY06/P9RVzteXAawlAoezgiXguXyKwLUim7HbLsd0jFjp9Ag+skOkb8KMnblQPiZnSjoNfpw/i+XMLa4TOz5WbhM6fybUYKjRnlntEvr1F2PivdvzIj48fi9uH3YiI52P80LOWdGCFU4EMjmLi0eBs0DEj6AuCWEKfDTpmZPLHj7MYJ/SMG6WgZF1GG6DFLJMswCSLKfhHDCZf1EBvWCJGDdozQxuCkMaT9UfhRGo+hBH4xiN6HiF/HOOPixk/ha7RaDHj59J6TsJfhAAtY7QMPo7AeOLIyPn6QMOf+Kf/OaGVjNd4QMznuz4mZhObjf+E8SM/Pn4TcxYmf/w4i3GamNPzTcwaE3PQLOAUMeMlBDO36wQma5no6x1iudcn5pttAguYd5o9Qh49AQ2gjMc0cvm58gExU+g7VD5urZlZ3Xas7xHZ82eKW44VR1K+jR/lyx+/vNNCjf/46Jh4+Op9Avl4dGh7sE8M7u45tjvEKGIGkEdgHQ/OBl0yAs0k5aMeBB3PBBKCcM8o+aOPP34WNVAyVH2KmLE4ydKSZW1s84HYsPyLaZcfPTG0XMkt49O9TPrYFqTyZcpGPrYdqeVrCCZ9CVf0jPFkzk8fv5yFVL7DoCZDvvykMR0mERezJmjs8fYN8OYmkhL8ryZARs7XJ4uYz3x9TMxZJm4T27M8fhNz0PFMICEI94ySP/r442dRY2LW+enjl7MmZhOz4hQxz1ZqxMxSx8GT9Uxp25FvO1b7jrU94rnyPjGz0HbcrDg+tuq4EzkWOw5ogF9sINN3se9Izc/VOoRsIFrdJOZyBcfteULnzy4VHRubxMdbbcLGf7XjR77cWFVvO3hx/vjJawQeHYr89uEeMdjfIrA17LC+QQx2esQoeoYqAut4cBYEHU9F9w1iPTgbdDwTWfJB0PFUdN8g1oOzQUdP/CxqgBbz+7wFDMT1rBGlYdpF+fcZnoK12DDFe68EYOp/8mevE/FM+UcAypwDkUAzEA9yUBPXDCQtqk7NTxq/rhfxoIztYHz7UPr48boLkZzSYRJxMQcNzk08TV+rODJmbILj6wABQ8xQMspDYk66PljWVtcHZROzic3Gb2I+AZwNOp6JLPkg6Hgqum8Q68HZoKMnfhY1wMQs9Qnj1/UmZhOz5hQx57e6xGyjTdxudxxRRMzWmo56i7gdtYnZ9Qpxc6HouDXryK8Qs0slxzKzUGQKjjp1b95sDojnNg6IG5uHxPOVfWJmbZdxyrlROSBkdxIWXX9p0XGrSqTn2/ivdvw6Px9tOVpdAgvXIN/qEcevfYp4+tkvELgNbNBtEk9/7T3ii49fJM6nZ0gi8E2AdwkRdD8R3R4EgR7dJgjJCPoGsQH+I4ig+4no9iAI9Og2QQgRr/eNCQgYYsbiNtCqDqxMYGJFWfTGC5iv/dSBGkzu0Gf64jMEIDmYsmP5SNNSAVpgaONjA4b0HMuPj18WY7GVCTrBAizK0A9vE3v8A4f0iucfVQiRXGz8cbyV/c8VNDg38TRcsTgY7e7XXiTkp+brk3t3noCGNahPvz5yPVHP1webxaDPdNF6EwcEzTw4q8WcLlpv4oCgmQdnTcw2fhOzidnEbGIeiXgarlgcjNbEHDTz4OwpYp6tNhybVeJmacOxsUnMVuvErWaLWOx1iNlGRNxcWWVKDhbDzVu3HHcWidnVDUez5WCpWP6zkI+tYXiQ59x6jYh2+0TncJdY7W0R0cEe0WrWia//9m8RT995l3j308fE0QsPiKgTEdn1rCWB9knolpogkAgaEEHUiaBlEHUq/iOIIDBAt9QEgUTQgAiiTgQtgyhC16MMtNSxoJ0kZsgbQDZxxEY8EaMGUzwEkL74DA34KAJpugZtdGa8nP0fAfF81Ojxy2alHzsgXYgE4hEN81It5O2jXF+Vf/SwRmRf0M4iZvy8SQSNPTot6BKAcfY/d0AMLVDz9YGGNdjSpa+P3ISmro8sZSsxowx9/nXspYqawLueoFmAFvP4EA3zYWK2/AvONzGjZRB1Kv4jiCAwQLfUBIFE0IAIok4ELYMoQtejDEzMOh81evwmZhNzFkTDfAwvZVc3iWq7RhTqFSK/sfER7SZxo9wgSvs9ovdwl6gd9IjibocodBtEbSciCjsdon5/myh0m4TlX+/82bUygVdZyO1SDB4ngo1guPVrvunYfXhAYIn7G9/6JvH0i79BHL/xBoH6l1+7TwwGu0TgjxSg8ySCxmciiDqRoMs5CAIDgsZnIog6kaCLB2e1mKFkLWacza5nAPHoshYSpnhvBU9cOdAAeoF4PvSGlloeugZpWf4REM9HWY9favgGKilDKiwq38DV820/uiaen13P3soefRY/aXZ0X03QzIOxYZwiZv6pRbpYjsZLLPilFLg+ELO+PtIS9Xx9PvnnDqlXYobesiwdxwmaeXDWu3Os+aJhPkzMln9h+SZmEHQ5B0FgQND4TARRJxJ08eCsiVl/VjwfZT1+qTEx809tYtbgLJJFw3wMiXmh1yE27vWJ1a0Wgan8VqtFYAtSPnLU9ntEdbtNFMolIr+yTGCpM79aIgpRzbHVIop7XcLyr3c+FsB/uX5IzFcaBF5u0RnsEnhoiei5GhFzGw2iVa04KhvEu28cE8cPXyaibpto7WwRdx8OCCyAb90/ILxFPBD58ZtvMkeO199wPHhEDNo14rC2Sgy6keNgmwhCTgT/jMD4sSwf7W0TrX7PweOfu7Pi+PgcEdVqhE64HuNHGZJOFzMUovWsxQzQJo53klcRpnhM91oGKEM5qEFLnYOyBvVorxerkYMEJGtwFi1Roz9Lg3wQr9HENQx0L5Q1EDPAhqnsY9bgCmQn6O4JmnkwKhEzI7rV0gXx1zhi+ZqvDxa95WYzKJzB7VUAeobeAvMFeFMGBM0CkDzufNEwHyZmy7+wfBOzidnEjHwQr9GYmE3MAMmiYT6Gl7JrVWJpq0Ng0TIftYhcr0ssdhpEvlwmlvtdorjTIQqNTSJfKDp4yp5dLBKFyjqBmvzamsPyr3X+zfUK8TzfgjW3UScg4OXeFjFfaxJzxQqB26igilyhQrQ2NwncQHX86BUiqlU/olEnWr0OAc23+l0i2t0m+g8OiPb+FnH85FXiM++8Qxy/deR45VXi6MWXCFFar+2QsiMpX48f+a2oRbzw+B4xeHDo4IeiIB9K+5DrNn7cRKf1DOJiTtJzFjFr0BISwkSfzlvdRSJLPuSBpWmgBYaz8TJUhxp8YhAbgJF44xLxGrREGWeBDwn47E7Vg58XI8EINUlixvjPh87R6DYYz/aXDoj+e47drzpwo5Rs44KSIenvOYbEjNulvusYErB6qCce5Il/mjz5yevEuMU57nzRMB8mZsu/sHwTc7rYpn38JmYTs87R6DYYj4lZEzQLQLJomI8hMWMx8+bqOpEvrRGF6gaB7UK1vS6BTUBYFM1XykTpsOfY6xKzxXXixp0igcdQYLF0odUiLP/ZyZ+Za3jmChUCksCjOu80ugQkPd/qEp3DHQISGvQ7nqgbOXa2CYgcvXKL60RUrxGQDST39tGR4/htApJ75523HcfHRDx/cNAn7r5wQGAxudVuEVG9TuBTdP7dh4eOR/eIwV6PeOHxXQL5ETUjWGMgV9p0bEaOKR//c2u7BPKhZy3puJgBdIKzSXrGQjfKukbz+cNOALSkQWbQkdCfBeIyi0s3HYwhKd9/dAroFSdoRqBe5/uL4MGo9M8CJeOfHf7HJLxBz4HO0eg2GAmU3P+CQx4wwhp+6ScOETNe+4HboiBpvqlMygw0nP7SC2woG7c4x50vGubDxGz5Y8k3McfFZmI2MWvQK07QjEC9zvcXwYNR6Z/FxBwn8KUnaBaA5HHni4b5GBZzYZ3Ir64RWKis1cpEATQ3iXw3cuAGG94ohOXQpa4Dj2a8sbLuKJYdKxvE7ErJYfnPQD4WugV+bOdMrunIR471XSK3suHYbDFu0u8cbBNQy9OnXyEGgx0i6nUIeekkL3rnFtccC44PF1obxGC353h4SBy//EnHp99k3iK++a3fJb7xrd8jkC9e+brj6efeI6A9vZyLV1jG8wc7Xcf9feaAeOGhA+OPem3HVpfIrdUc12L8uBHuw2Q3fowhi5hRjus5MFCAFhLK6QTdPfhE/blaZnG87QKgf5SDjzgRfNY4xo96PzDi6eMBoX8KKHMcYoby9Wdpot/ZJ/q/fuD4IoPNX7jBCZu5/pTB7VK8lC0bvj5gUJ9ZzNd889flTNyWf73zTcwmZg20hLKJOZ2guyc+ftT7gREm5nGLc9z5omE+hjd/8ZSNSXl2ZY2QCbrVIAodx0KrybilS2wUwqIoFjbx4sKFTkRg0xAEACz/WcufLTCVKjGz3COeK24TkHGuWHFAVEsbBF4N+fZbRwREAnVBMNISzy1ZdkT86JLBvT0Hi/zuvX0HL+1iKRhbyY4fPyGQL/rBsi3UKLDPODNqOuQBKTs9Ip6PET791S8Qevw6X0Z+LcaPF4kiH+NHvs40iN8AADbcSURBVNaz97EHWoKSNdCMd8+peHulgJbeYaeixfY7Rw8JXaPxwzg3wVBPBC2DQaaA9hhhfPyBL4l0MQeNTwWb8gCWrKFkEfOXDhy4V4r1DDE/+aHj6APHK99zQMACHrfJ275E5FwPAUPMUDLKImZuOW5xjjtfNMyHidnyx5hvYvZWuwbjNzGPQjDUE0HLYJApoD1GaGIetzjHnS8a5mNIzLXtFoEHRyy2HPmoQcgkjhtjFFioxNkbSw5M2cWoTtR6TcdO29FvOSz/GcufrTKcgMVtvEpST/eyzLu6SUAJx69+ihgcbjtYWrn1umODKVWJ+UqdkMVYLMzyjUNyExGDB5VgmRevxBDldDsOXiSHtLBsG/UZfrAJ8nObTQIqiuc//exTQo8f27t0fq7ScFyL8c+s9Ajkd3a6RLS7RWTRM2Ssb6yCsKGWdAIbXSD6U/RtXUlkH7MmCLlA9Kdg/FjQTiIwa4CWuiYIIYaUDPVi4fopww/gFN51yCYvvlHqle87cEMUNm3JIjbacFnqeYEa4BUX0LBGXn3BfaG3dBF6UwYEzTw4i+Rx54uG+TAxW/4Y803MJmZgYh4H+lNMzOMW57jzRcN8DIm52tgkClGdwGYfLGPmF+aJ528tELKkia09mLJLVUexQhSqZaJW2yAKmwxqeJXN8p/N/JufyDnml4iZuSYhi7pQQqXp2GgQuEXn+MFjYrDVdvBNQdg2Nbe47ijVCGxWOtzqOBobjnaDkJuI+BEcx48/ScjybL/nwF1A1SqBW4lyS0wsP1+PCNQcDe467j8kjl96Qsjyb2z8kpYvEfRPFyIpfxrHj5vf8ChQPf7WWpGYu1Mg4nqGzJLEDJ1otSShc9IJOmYkS37Q5Uxc1fgH67c9WO5OIrBvgH6kCdB6BuWjCiEyxnI0bovCA0OwyQsPGAF4cYVeuMbLKn7I6ARe0IaGNTrfu3NKEQ3zYWK2/LHnm5ivx/hNzEGXM3FV4zcxTwuiYT6GN3/xtp3C8pyDZt7aBh4fkV9eJgqFHFFdW3DUyo5ei6g/2CZwUw2mckzW+bV1Qm7FUS8ZtHzLP18+lkznZm87ltYJSOIwqjnqq8waIUu1736V2H/pkMDjNbCoK7Lh7U4CJ8fzsew8l1smWqUlZsVRqxFQYGm7T8h2NoRkzp+u8c/caRGH1SIx6NO/mdp6/HO35gjkx/UMScTFjLNaLboe6Hr0TSKpVxLxlkFggA8PesVJahkEBiT1SiLeMggM8OFBL4A2+EfS+2pLWtCM8M8TDcBNUL/yI4fc8gS5fp+BmPXjRJR0BYgZZT4ry9rom5ovjzThfxbohfSP1tUJvdjOZ/HwE+n7Fcf+lx3SEkv0/5AZc75omA8Ts+VPTT70ML1iA9M7fhOzDw96xUlqGQQGJPVKIt4yCAzw4UEvgDYm5okTs9wAg0m213bwQxkLVZor12ShkifNQnmVwNRZ7TaIQrtG5Jt1R6NG4PGNmKzzG2XC8i1/lHxZsCX3kCeaHQffcDXYajEdz/GDh0SrUXd0IgIPzciVGw5swsLNWlARJyflzy2WGLcs3KrXHdWyg/PnVjeJ3FrVca78aRk/HjAiDz95+5jAQz0xfklW+VrPmPQhZoApPi4Jb44AnEVOPA2gPuiYEZ2fPRO9NEEDD84iDehPAagPOmZE52fPRC/dF2KO835M0kNKhkoh3fhrHPFQEezkwpI1lrIhV61n1GDpG9vB0D5zPm7Nwu1bIj+tT9T8fQbb1tBeqfSEW7+gVd1+DPmiYT5MzJY/NflJ4pkWsSXlT8v4Tcxx0EsTNPDgLNKA/hSA+qBjRnR+9kz00n0DH3veNzHr9mPIFw3zMbyUzQ+UWNjqEvlyhShslIhqmSnNewqri0SxXnHwaw8KzRqRX1938GQ6W645+MUGsqRp+ZY/Qj5UcafZJVCem1915FaIw1qRODrcJ7AdCQu/0cEOkStS903Z7gTZbDQdeLFEaZNIz5+79QmGF2zHkD/548dDVXX+8YsvEYdRnWitLhI6f7uxTmg9AwgDk3vgiRTQHvIA3j0e1AcdM6Lz45kg6HImJn/8aKP/t0LgZuJ9pWctZlD+9iaBh4QMiRNahYCxrA3pYuEaW70g4D9h9II26nFLFRIy5IsUoUk86gSCxKI06iFL1GNJGeLkmiFxaq0iYQz5omE+TMyWPzX5kEGSeEzM6fkm5nR0fjwTBF3OxOSPH21MzKiJi1POIuFSxYwNOOsVAi8nqEVVQhYniyUHP3oCU2qhWSXyzQaxvNsnZjfrDt7CIy822Ngkbnc6hOXb9RklP1dtOfBaBVAoO1gkc/kSgW1Nopx2y7HdIxY6fQIP3BD9gHX36Iwb1UNiprTjWOp64vlzC2uEzs+Vm4TOn8m1GH51Bz+INN/eIqZ9/MiPjx+L24fdiIjnY/zQs5Z0YIVTgQyOYuLR4GzQMSPoC4JYQp8NOmZk8sePsxgn9PxH6jEmuow2QItZJAqgSSj2RwzkihroGUvQqEF7ZmjDF9JYxh+FExnyZQkamoQUmaENWRBnHDRG3y8zkCtqIOALzRcN82FitvypyTcxX+34kR8fv4k5C5M/fpzFOE3M0liJ88rELI+MwDsJMJm2mo5um6i8sE0sbkVEvuMoHmwRs+UqkedFSJRvlCoEyljYLPZahOWjbPnny8dLFOShniwbEVW9Qyz3+sR8s01gAfZOs0fIozOgMZTxmEkuP1c+IGYKfYfKx61BM6vbjvU9Inv+THHLseJIyp/e8cuDVNX4j4+OiYev3ieQj0eHtgf7xODunmO7Q4wiZgB5BNbx4GzQJSPQTFI+6kHQ8UwgIQj3jJI/+vjjZ1EDJUPVp4gZS8osRVnWxjYuiBPL19AqP1pkaDkaLbV0v8OgBtu+VL4IGL2wrSwhX5aLsSFLS/HzjK7B4jOkC2XqbVwA7Xn52q9FX0i+aJgPE7PlT02+Fs/0im3ax29iDjqeCSQE4Z5R8kcff/wsakzMH1n5SsSMFxLIjSs8mcqr8isVB78cMN9pEwu9DpHfrDiWV4ibt3OEvIqft+pgmsbrDep3twnLt/xR8vHSyZmljoNlM1PaduTbjtW+Y22PeK68T8wstB03K46PrTruRI7FjgMa4xcziH6KfUdqfq7WIWQD1OomMZcrOG7PEzp/dqno4KX4j7faxLSPH/lyY1W97eDF+eMnrxF4dCjy24d7xGB/i8DWsMP6BjHY6RGj6BmqCKzjwVkQdDwV3TeI9eBs0PFMZMkHQcdT0X2DWA/OBh098bOoAVrM7/MWMBDXs0aUCa2i/PsMK9ZbmdD1ImaUsR2Mb6968meOeKb8IyA1XzQJNcY1ybcw7X7VIQJGGy6X8ahR1KucITGPnC8a5sPEbPlTk29ivtrxI9/EHHQ8E1nyQdDxVHTfINaDs0FHT/wsaoCJWepVziWJuXp/myjubRFrh31iqd8hsPA4W28Ry/0ugQ0+NxeKRH7+lqNYdJTWiWK1TNRqwL3woHbQIyzf8kfJz291idlGm7jd7jiiiMAtVci/HbUJnX/z1qwjv0LMLpUceFEHXmq5UHDUqXvzZnNAPLdxQNzYPCSer+wTM2u7jFPmjcoBIbursGj8S4uOW1UiPX/ax6/z89GWo9UlsHAN8q0ecfzap4inn/0CgdvABt0m8fTX3iO++PhF4nx6hiQC3wR4lxBB9xPR7UEQ6NFtgpCMoG8QG+A/ggi6n4huD4JAj24ThBDxet+YgIAhZixuA63qwMoEZImy6JMXqF/7qUNqsPiMrV7QLRaoUYaeeZvY4x84pBc0fMZ80SEWkFGGPnmj1vaXHEMaZoZe0cEC3vsth9RgsRpbvUbIFw3zYWK2/KnJNzFf7fh1vok5CMkI+gaxAf4jiKD7iej2IAj06DZBCBGv940JE7PUX76YC9ttx1aLkAclMliQXOy1mQ4x24gIecEAky8UCXlRQXmVqHUaRHGv69h1WL7lj5I/W204NqvEzdKGY2OTmK3WiVvNFqHzb66sMiVH3ont5q1bjjuLxOzqhqPZcrAULT9LPraG4UGec+s1ItrtE53DXWK1t0VEB3tEq1knvv7bv0U8fedd4t1PHxNHLzwgok5EZNezlgTaJ6FbaoJAImhABFEngpZB1Kn4jyCCwADdUhMEEkEDIog6EbQMoghdjzLQUseCdpKYIW8AWcYRm7JopQabuX7sgErldikWs8gVj/Bkufoo11eJWdek58vtTCxO0SQvNUOf0CTQ4tQ1uqUsVvMLKpB2vnzRMB8mZsufmvzLEY/lp+ebmNEyiDoV/xFEEBigW2qCQCJoQARRJ4KWQRSh61EGJuZ4jW45djFj0021XSPkdhd+OKLQbhI3yg2itN8jeg93CSwzyoMVeSKu7UREYadD1O9vE4Vuk7B8y7f86c2fXSsTeJWF3C7F4HEi2AiGW7/mm47dhwcElri/8a1vEk+/+BvE8RtvEKh/+bX7xGCwSwT+SAE6TyJofCaCqBMJupyDIDAgaHwmgqgTCbp4cFaLGUrWYsbZ7HoGEKQunyBUvsFJyli+5i1gvoGr59uudM11yhcN82FitnzLt/xM+SZmEHQ5B0FgQND4TARRJxJ08eCsiVnXXGa+aJiPITHjJpaNe31idatF4E/9VqtFYIsKliVr+z2iut0mCuUSkV9ZJrAUhscuFqKagxc2sSBp+ZZv+dObjwXwX64fEvOVBoGXW3QGuwQeWiJ6rkbE3EaDaFUrjsoG8e4bx8Txw5eJqNsmWjtbxN2HAwIL4Fv3DwhvEQ9Efvzmm8yR4/U3HA8eEYN2jTisrRKDbuQ42CaCkBPBPyMwfizLR3vbRKvfc/D45+6sOD4+R0S1GqETrsf4UYak08UMnWg9azEDtInjnUTEazRxjQHdC2WNb+bP6hrNpOWLhvkwMVu+5Vt+pnwTs4nZxOyb+bO6RnPWfNEwH8NL2bUqsbTVIbCohdcS5HpdYrHTIPBqP9z0UtzpEHg9Pjbv4E96drFI4NGMqMmvrTks3/Itf2rzb65XiOf5Fqy5jToBAS/3toj5WpOYK1YI3EYFVeQKFaK1uUngBqrjR68QUa36EY060ep1CGi+1e8S0e420X9wQLT3t4jjJ68Sn3nnHeL4rSPHK68SRy++RIjSem2HlB1J+Xr8yG9FLeKFx/eIwYNDBz8UBflQ2odct/HjJjqtZxAXc5Kes4hZg5beWES8Bi1RxlngQ1JASx/lE3QNWqKMs8CHpICWPson6Bq0RBlngQ/xiIb5MDFbvuVbfqZ8E3O62KZ9/CZmnAU+JAW09FE+QdegJco4C3yIRzTMx5CYsdh1c3WdyJfWiEJ1g8B2ktpel8AmESya5StlonTYc+x1idniOnHjTpHAYwqwmLbQahGWb/mWfz3yZ+YanrlChYAk8KjOO40uAUnPt7pE53CHgIQG/Y4n6kaOnW0CIkev3OI6EdVrBGQDyb19dOQ4fpuA5N55523H8TERzx8c9Im7LxwQWExutVtEVK8T+BSdf/fhoePRPWKw1yNeeHyXQH5EzQjWGMiVNh2bkWPKx//c2i6BfOhZSzouZgCp4GySnrHQjbKuSUfnaIJmBOqnPV80zIeJ2fIt3/LPnG9ijovNxGxi1vjAgKAZgXrRMB/DYsYrBFbXCCxk4bGI8hSI5iaR70YO3IDBG0mwXLbUdeDRfTdW1h3FsoNfmC8vvbd8y7f8Kc/HQrfAj+2cyTUd+cixvkvkVjYcmy3GTfqdg20Cann69CvEYLBDRL0OIS+d5EXv3OKaY8Hx4UJrgxjs9hwPD4njlz/p+PSbzFvEN7/1u8Q3vvV7BPLFK193PP3cewS0p5dz8QrLeP5gp+u4v88cEC88dGD8Ua/t2OoSubWa41qMHzfCfZjsxo8xZBEzynE9BwYKQBskoJxO0N2DT0z/XJwNKgPSPyUO2l/U+EXDfJiYLd/yLf8M+SZmE7MGWkLZxJxO0N2DsYmG+Rje/MV/0vijnV1ZI+QPmF/YV+g4FlpNxi1tYSMJFs2w8IUX2y10IgKbSjBBAMu3fMu/TvmzBaZSJWaWe8RzxW0CMs4VKw6IammDwKsh337riIBIoC4IRlriuSXLjogfXTK4t+dgkd+9t+/gpV0sBWMr2fHjJwTyRT9YtoUaBfYZZ0ZNhzwgZadHxPMxwqe/+gVCj1/ny8ivxfjxIlHkY/zI13r2PvZAS1CyJosINYHDTgQtkZwFH05gk5quuViCoZ4IWgaD9IiG+TAxW77lW/45803M3mrXYPwm5lEIhnoiaBkM0iMa5mNIzLXtFoEHCyy2HPmoQcgfOW6cUGAhC2dvLDnwJ12M6kSt13Twy/PxunvLt3yN5U97/myV4QQsbuNVknq6l2Xe1U0CSjh+9VPE4HDbwdLKrdcdG0ypSsxX6oQsxmJhlm8ckpuIGDyoBMu8eCWGKKfbcfAiOaSFZduoz/CDTZCf22wSUFE8/+lnnxJ6/NjepfNzlYbjWox/ZqVHIL+z0yWi3S0ii54hY31jFYTtvZVC4KcLRH8KxBw0CMg+Zk0Qcm5Ew3yYmC3f8i3/nPkmZhMzMDGPjmiYjyExVxubRCGqE9gMgmWu/MI88fytBUKWvLD1A3/SpaqjWCEK1TKBl9sXNhnU8CqM5Vu+5V+//JufyDnml4iZuSYhi7pQQqXp2GgQuEXn+MFjYrDVdvBNQdg2Nbe47ijVCGxWOtzqOBobjnaDkJuI+BEcx48/ScjybL/nwF1A1SqBW4lyS0wsP1+PCNQcDe467j8kjl96Qsjyb2z8kpYvEfRPFyIpfxrHj5vf8ChQPf7WWpGYu1Mg4nqGzJLEDB1CYCgnoXPSCTpmJEt+0OVMjD5+0TAfJmbLt3zLHynfxHw9xm9iDrqcidHHLxrmY3jzF2/rKCzPOegvs7aBxwvkl5cJeYn92oKjVnb0WkT9wTaBmy7wp44/5vzaOiG3aqiX0Fm+5Vu+5cfzsWQ6N3vbsbROQBKHUc1RX2XWCFmqfferxP5LhwQer4FFXZENb3cSODmej2Xnudwy0SotMSuOWo2AAkvbfUK2syEkc/50jX/mTos4rBaJQZ/+zdTW45+7NUcgP65nKCcuZpyFeFCj64GuR98kknolEW8ZBAb48KBXnKSWQWBAUi8gGubDxGz5lm/5E5EPPUyv2MD0jt/E7MODXnGSWgaBAUm9gGiYjyExyw0S+CPstR380L5Clf6W1mQhi/+oCuVVAn9a1W6DKLRrRL5ZdzRqBB7vhz/m/EaZsHzLt3zLT8qXBVtyD3mi2XHwDVeDrRbT8Rw/eEi0GnVHJyLw0IxcueHAJizcrAUVcXJS/txiiXHLwq163VEtOzh/bnWTyK1VHefKn5bx4wEj8vCTt48JPNQT45dkla/1DPFAzACyiUvImykAZ73DgjSA+qBjRnR+9kz00gQNPDiLNKA/BaA+6OgRDfNhYrZ8y7f8ichPEs+0iC0pf1rGb2KOg16aoIEHZ5EG9KcA1AcdPaJhPoaXsvmBAwtbXSJfrhCFjRJRLTOleU9hdZEo1isOfix+oVkj8uvrDv5jmy3XHPzge1nysnzLt3zLT8iHKu40uwTKc/OrjtwKcVgrEkeH+wS2I2HhNzrYIXJF6r4p250gm42mAy+WKG0S6flztz7B8ILtGPInf/x4qKrOP37xJeIwqhOt1UVC52831gmtZwAJpWsszuhiS0fnxzNB0OVMjD5+0TAfJmbLt3zLn4h8yCBJPCbm9HwTczo6P54Jgi5nYvTxi4b5GBYzNmisVwg8vL4WVQlZvCqWHPxoAvzJFZpVIt9sEMu7fWJ2s+7gLR7y4PuNTeJ2p0NYvuVbvuUn5eeqLQdeqwAKZQeLZC5fIrCtSZTTbjm2e8RCp0/ggRuiH7DuHp1xo3pIzJR2HEtdTzx/bmGN0Pm5cpPQ+TO5FsOv7uAHkebbW8S0jx/58fFjcfuwGxHxfIwfetaSDqxzKkni1OBs0DEj6AuCWEKfDTpmZPTxi4b5MDFbvuVb/kTkm5ivdvzIj4/fxJyFMYpZHimAZ9bjj63VdHTbROWFbWJxKyLyHUfxYIuYLVeJPC9SoXyjVCFQxsJXsdciLB9ly7d8y0dZ5+MlCvJQT5aNiKreIZZ7fWK+2SawAHun2SPk0RnQGMp4zCSXnysfEDOFvkPl49agmdVtx/oekT1/prjlWHEk5U/v+OVBqmr8x0fHxMNX7xPIx6ND24N9YnB3z7HdIUYRMxhFbOmkixP1IOh4JpAQhHvS80XDfJiYLd/yLX8i8rV4plds0z5+E3PQ8UwgIQj3pOeLhvkYEjMeWC83NvAfm7xKvVJx8Mvj8p02sdDrEPnNimN5hbh5O0fIq9p5Kwf+jPH4+/rdbcLyLd/yLT8pHy+dnFnqOFg2M6VtR77tWO071vaI58r7xMxC23Gz4vjYquNO5FjsOKAxfjGD6KfYd6Tm52odQjZArW4Sc7mC4/Y8ofNnl4oOXor/eKtNTPv4kS83VtXbDl6cP37yGoFHhyK/fbhHDPa3CGwNO6xvEIOdHjGKnrOIDQQdT0X3DWI9OBt0PBNZ8kHQkRAN82FitnzLt/yJyDcxX+34kW9iDjqeiSz5IOhIiIb5GBJz9f42UdzbItYO+8RSv0NgYWq23iKW+10CG0BuLhSJ/PwtR7HoKK0TxWqZqNWAeyB+7aBHWL7lW77lJ+Xnt7rEbKNN3G53HFFE4JYq5N+O2oTOv3lr1pFfIWaXSg68qAMvtVwoOOrUvXmzOSCe2zggbmweEs9X9omZtV3GKfNG5YCQ3VVYNP6lRcetKpGeP+3j1/n5aMvR6hJYuAb5Vo84fu1TxNPPfoHAbWCDbpN4+mvvEV98/CJxPj1DWoHPArzbiKD7iej2IAj06DZBSEbQN4gN8B9B6L6iYT5MzJZv+ZY/Efkm5qsdv843MQchGUHfIDbAfwSh+4qG+Rje/LXddmy1CHmQHoMFq8Vem+kQs42IkAfQM/lCkZAH2ZdXiVqnQRT3uo5dh+VbvuVbflL+bLXh2KwSN0sbjo1NYrZaJ241W4TOv7myypQceSe2m7duOe4sErOrG45my8FStPws+dgahgd5zq3XiGi3T3QOd4nV3hYRHewRrWad+Ppv/xbx9J13iXc/fUwcvfCAiDoRkV3PWldon4RuqQkCiaABEUSdCFoGUafiP4IIAgN0S41omA8Ts+VbvuVPRP7liMfy0/NNzGgZRJ2K/wgiCAzQLTWiYT6GxIxNGdV2jZDbIfjheUK7SdwoN4jSfo/oPdwlsAwlD97jP9TaTkQUdjpE/f42Ueg2Ccu3fMu3fMufzPzZtTKBV1nI7VIMHieCjWC49Wu+6dh9eEBgifsb3/om8fSLv0Ecv/EGgfqXX7tPDAa7ROCnFKDzJILGZyKIOpGgyzkIAgOCxh7RMB8mZsu3fMu3fMs3MQtBl3MQBAYEjT2iYT6GxIybHDbu9YnVrRaBr8KtVovAFgYsW9X2e0R1u00UyiUiv7JMYKkEj+UrRDUHL3xhwcryLd/yLd/yJzMfC+C/XD8k5isNAi+36Ax2CTy0RPRcjYi5jQbRqlYclQ3i3TeOieOHLxNRt020draIuw8HBBbAt+4fEIGrCIj8+M03mSPH6284HjwiBu0acVhbJQbdyHGwTQQhJ4J/RmD8WJaP9raJVr/n4PHP3VlxfHyOiGo1QidczvhFw3yYmC3f8i3f8i3fxDypYs7XqsTSVofAogceW5/rdYnFToPAq99wU0Rxp0Pg9enY3IFf+exikcCj+1CTX1tzWL7lW77lW/5E5t9crxDP8y1Ycxt1AgJe7m0R87UmMVesELiNSlRdqBCtzU0CN1AdP3qFiGrVj2jUiVavQ0DzrX6XiHa3if6DA6K9v0UcP3mV+Mw77xDHbx05XnmVOHrxJUKU1ms7pOxIytfjR34rahEvPL5HDB4cOvihKMiHkj/ksscvGubDxGz5lm/5lm/5JuZJFTMWQ26urhP50hpRqG4Q2G5Q2+sS2ESARZV8pUyUDnuOvS4xW1wnbtwpEriNHYstC60WYfmWb/mWb/mTnz8z1/DMFSoEJIdHdd5pdAlIer7VJTqHOwQkNOh3PFE3cuxsExA5euUW14moXiMgS0ju7aMjx/HbBCT3zjtvO46PiXj+4KBP3H3hgMBicqvdIqJ6ncCn6Py7Dw8dj+4Rg70e8cLjuwTyI2pGsCZBrrTp2IwcYx6/aJgPE7PlW77lW77lD+WbmCdJzHjE/OoagYUOPDZPnhLQ3CTy3ciBDfq80QDLKUtdBx7tdmNl3VEsO/iF6vJSdMu3fMu3fMuf4HwsdAv82M6ZXNORjxzru0RuZcOx2WKctDoH2wTU+PTpV4jBYIeIeh1CXjrJi965xTXHguPDheIGMdjtOR4eEscvf9Lx6TeZt4hvfut3iW986/cI5Mueqa87nn7uPQLa08vReIVlPH+w03Xc32cOiBceOjD+qNd2bHWJ3FrNcSnjFw3zYWK2fMu3fMu3fMk3MU+cmPErxy91dmWNkF8wv9Ct0HEstJqMW/rARgMsqmBhBC8+W+hEBDYd4AsELN/yLd/yLX9a8mcLTKVKzCz3iOeK2wRknCtWHBDV0gaBV0O+/dYRAVFBXRCktMRzS5YdET+6ZHBvz8Eiv3tv38FLu1gKxlay48dPCOSLPrHsDDUK7GPOjJoOeUDKTo+I52OET3/1C4Qev86XkV/K+EXDfJiYLd/yLd/yLf+EfBPzR1Ye//hFw3wMibm23SJw4/liy5GPGoR8CbCxXoGFDpy9seTAr7wY1Ylar+ngl6vjdeiWb/kay7d8y5/k/NkqwwlY3MarJId0hWXe1U0Cyjl+9VPE4HDbwdLKrdcdG0ypSsxX6oQsJmNhmW8ckpuIGDyoBMu8eCWGKK3bcfAiOaSLZeeoz/CDTZCf22wSos9Y/tPPPiX0+LG9S+fnKg3HpYxfNMyHidnyLd/yLd/yT8g3MU+EmKuNTaIQ1QlsFsAySH5hnnj+1gIhSyLYGoBfeanqKFaIQrVM4OXnhU0GNbzKYPmWb/mWb/nTlX/zEznH/BIxM9ckZFEXSqs0HRsNArcYHT94TAy22g6+KQjbpuYW1x2lGoHNVodbHUdjw9FuEHITET+C4/jxJwlZ/u33HLiLqVolcMNSbomJ5efrEYGao8Fdx/2HxPFLTwhZvo6NX9LyJYL+6UIk5Y9j/KJhPkzMlm/5lm/5lp+Yb2K+nPGLhvkY3vzF/9u/sDznoN9cbQO3n+eXlwl5yfnagqNWdvRaRP3BNoFN+fgq4JedX1snZCu/ekmZ5Vu+5Vu+5T9r+dg2NTd727G0TuBFDodRzVFfZdYILAU/fferxP5LhwQe34FFaZEZb9cSsCErlo9l57ncMtEqLTErjlqNgGJL231CtrMhJHP+xY5fNMyHidnyLd/yLd/yx54/brHF86+JmGUDPX5JvbaDH+pWqNK1XpOFDr7ohfIqgUtf7TaIQrtG5Jt1R6NG4PFv+GXnN8qE5Vu+5Vu+5T+b+bIgTG4jDzU7Dr7harDVYjqe4wcPiVaj7uhEBB76kSs3HNiEhZu14EtOTsqfWywxbiG6Va87qmUH58+tbhK5tarjXPkXNX7RMB8mZsu3fMu3fMsfe/64xZaUP/Vixg3pC1tdIl+uEIWNElEtM6V5T2F1kSjWKw5+bHqhWSPy6+sO/mXMlmsOfjC6LIlYvuVbvuVb/jOZDxXdaXYJlOfmVx25FeKwViSODveJ1lqRwMJvdLBD5IrUfVO2a0FmG00HXixR2iTS8+dufYKZI8aRP/r4RcN8mJgt3/It3/Itf+z54xZbev40ixn/A3+9QuDh5rWoSsjiRrHk4FvX8SspNKtEvtkglnf7xOxm3cFbAOTB6BubxO1Oh7B8y7d8y7f8ZzM/V2058FoIUCg7WFRz+RKBbVmitHbLsd0jFjp9Ag8MEb2BdffojxvVQ2KmtONY6nri+XMLa4TOz5WbhM6fybUYfnUHP4g0394ixj1+0TAfJmbLt3zLt3zLH3u+iTl9/KJhPoY3f+GWczzTHL+MVtPRbROVF7aJxa2IyHccxYMtYrZcJfK8iIHyjVKFQBkLI8Vei7B8lC3f8i0fZctHzrOQP/OJhgMP9WSZiajqHWK51yfmm20CC7x3mj1CHv0BjaGMx2Ry+bnyATFT6DtU/sydlmN127G+R2TPnyluOVYcSfnjGL9omA8Ts+VbvuVbvuWPPX/cYtP510rMeKC5bHznX4a8artScfDLxfKdNrHQ6xD5zYpjeYW4eTtHyKu8+X/149eMx6PX724Tlm/5lm/5lv9s5uOlkzNLHQfLcqa07ci3Hat9x9oe8Vx5n5hZaDtuVhwfW3XciRyLHQc0udIjRG/FviM1P1frELKBi19cMZcrOG7PEzp/dqno4KX4j7faxLjHLxrmw8Rs+ZZv+ZZv+WPPNzGnj180zMeQmKv3t4ni3haxdtgnlvodAgsXs/UWsdzvEtggcHOhSOTnbzmKRUdpnShWy0StBtwD02sHPcLyLd/yLd/yn838/FaXmG20idvtjiOKCNxShfzbUZvQ+TdvzTryK8TsUsmBF3XgpZYLBUedujdvNgfEcxsHxI3NQ+L5yj4xs7bLOGXeqBwQsjsMi96/tOi4VSXS88c9ftEwHyZmy7d8y7d8yx97vok5PV80zMfw5q/ttmOrRciD1hgsaCz22kyHmG1EhDygnMkXioQ86Ly8StQ6DaK413XsOizf8i3f8i3/2cyfrTYcm1XiZmnDsbFJzFbrxK1mi9D5N1dWmZIj78R289Ytx51FYnZ1w9FsOViK054vGubDxGz5lm/5lm/5Y8+fdnGOO180zMeQmDsf+9kTwSPW8u0mcaPcIEr7PaL3cJfAMoU8mI1/kUH3U7H8s5L/hV8gkvJrOxFR2OkQ9fvbRKHbJLApo9quEXI7BEZ+xvFbvuU/y/kyXdphx9gOE/MU5McxMVu+5V9VvkyXdtgxtmNIzP/s3Yh49K9eJ1AGgRVOBb3K394kHv3B64SPIiwfvbLng++8eUj80ZffIr7Sfp6AnoWVZQJLJXhsXiGqOXhhCgtKuMlh416fWN1qEZiqbrVaBLYwYNmqtt8jqtttolAuEZZv+ZaPfJku7bBjbIeJ+QTQa3LygYnZ8i1/EvJlurTDjrEdJ4n5j193/FuHyOPfv054Q7g2/+vrxFDN779OoIxeL/3gdeLR9xyokZaWn5D/6DuvOzjfdwzQegaoET3zlDS7WCTwaD3U5NfWHLUqsbTVIbAoh8fW53pdYrHTIPDqN9wUUdzpEHh9OjZ3WL7lW75Ml3z83Z3nDeNCkK8UHybmD2tMzDZxW77lZ8iX6ZKPYG41jHMjXyk+hsQswvjJ6wTE8+jfMCyP3f/0KUIU8q9fd3zXITUsJ2mPvv87w/VP/q/PE2hp+Un5WMRGvvRC+z90xPUcB3q+cadI4DZ2LNYttFoEFuturq4T+dIaUahuENgOU9vrEtjkgkW/fKVMlA57jr0uMVtcJyzf8p/lfJku+QjmVsM4N/KV4sPEbGK2idvyLf8M+TJd8hHMrYZxbuQrxceQmB/9h9cdEMafMv+OYfFgefbRBwzqWSSP/ohh2UBOQNojk7c4Wf4o+Uli/hevNAiU9aawG8Wyg194Li8txyPmV9cILPThsXnylIDmJpHvRg7cQMIbYbDct9R14NFxN1bWHZZv+c9kvkyXfARzq2GcG/lK8WFinpp8E7PlW/4k5Mt0yUcwtxrGuZGvFB8niPnJDx1HHzhe+Z5DBAP+N4YXaUUkqOcl2SHx/PB1BxZj0dLyz5WPZW0tZvD+3VnCG5rQm8KgZ0xAAFMSJp3ZlTVCJiB+oVuh41hoNRm39IeNMFj0w8IgXny20IkIbIqxfLs+z1q+TJd8BHOrYZwb+UrxYWL+sN7EbBO35Vt+hnyZLvkI5lbDODfyleJjWMx8o84r33dg+5JsSsKiKxTCZanHAiyAirBs6y1F8MYl6Wv5I+enixnE9YzXlde2HXjwwmLLkY8ahExSuLFEIS8m47M3lhyY8opRnaj1mg5+ubrlW34QTlzXfJku+QjmVsM4N/KV4sPEPGX5JmbLt3xwVfkyXfIRzK2GcW7kK8XHsJi/x/uMWA/CDxhIBWutUAuWYVHP25pEM0iAbPRZ1ozlj5KvlawJrOwZEnNUI6qNTaIQ1QlsZsEyXX5hnnj+1gIhS3b8iAaZkkpVR7FCFKplAi8/L2wyqLF8y39m8mW65COYWw3j3MhXig8T89TkBz72BD72mJgt3/LHkS/TJR/B3GoY50a+UnwMi/lPXnfoW32wxIoyiJ2V5Vbu+4sLxVP5L/7rn/GcNR83Eb36gUNa8qMu5SyIJUgZxM5OUL7WNhJY2+WEzV8At0tpsMQNMWs9Y6tLYXnOQTNXbQOPX8gvLxPykvO1BUet7Oi1iPqDbQI3jWCqwvSUX1sn5FYT9RI9y7f8650v0yUfwdxqGOdGvlJ8mJhNzDZxW77lnyFfpks+grnVMM6NfKX4GBYzNIMbfgDkofWjdBIYl/jXf/hHnre+9u2A3/qf/xWha4YkHcsfGo8+ywzdeoQ2uj1AY9RPfj62iWFJHEvZaIzlbpUQFzNkHKxmeyBmuYEEk1Sv7eCHDhaqNJetyUIfT2qF8iqBqa3abRCFdo3IN+uORo3A4wkx2eU3yoTlW/6zkC/TJR/B3GoY50a+UnyYmD9sOQn5JmbLt/yJz5fpko9gbjWMcyNfKT5OEjOWVVGGGD5gWB5aw1qxcaBnLeO4mDVDksbnQkWQFsYDuGZIbGiJs6njl7OTmQ8Bf59BS72VjIWtlazRYsby9V9++10PxIwHJixsdYl8uUIUNkpEtcyU5j2F1UWiWK84+LH+hWaNyK+vO3iymy3XHPxiAFkSnPj8jz95PmC6xm/5k5Av0yUfwdxqGOdGvlJ8mJg/rEd7cFX5JuYx5wdWJqZr/JY/CfkyXfIRzK2GcW7kK8XHSWKGVCAYSIVrIGPoNnDqqUDJ6WLWDEkaY4ijRws1po5fzjJDG7J8YIBOu5x8PEgEMoae+YUW6Zu/ABa0IWYNJC1ixgaW9QqBh/vXoiohi3vFkoMfrYApqdCsEvlmg1je7ROzm3UHb4GRFwNsbBK3Ox1i8vMh4x/9TdWDmmkZv+VPQr5Ml3wEc6thnBv5SvFhYlaBATrtcvJNzGPONzFb/uj5Ml3yEcythnFu5CvFR/LmL5YKFlqh5IX+XeJ8YgZazxpkxkGvIUljyRfCg9J4m9Vnfu8ekTR+IBuycBYtdQ3SMuej5qLyh8SPzV/8aJGhfDyEJGFBG2LWC9pxMcsjF/BMf0xGraaj2yYqL2wTi1sRke84igdbxGy5SmARD+UbpQqBMhYGi70WMTn50G0SUPJX/yrvQT3yfbOAyxy/5U9yvkyXfARzq2GcG/lK8WFi/rAGaZnzUXNR+Sbmi80PnBpgYrb8UfJluuQjmFsN49zIV4qPITGLfqAKVshFKfmigGBknBAbyww1Uq/GPyQ2VS8KRBmaZH0++YlDcmL5ok/OQY3OlzYZ8lHW+VLGJq/U8Qc+DojrGTW4bnigv9z4wZORvAq+UnHwy+/ynTax0OsQ+c2KY3mFuHk7R8ir5nkrDaY5vB6gfnebmJx8qHT1D34u4PbX/g6hlQxwVnr96OcCcu/OE5c5fsuf5HyZLvkI5lbDODfyleLDxGxivoYTq4nZ8seXL9MlH8HcahjnRr5SfCSKWSt5csQMsKwto1XilBoe/2s/dUgNRAhBQoGQH8rQJ7d5+U8cPsr1TciXMmfqMjKlJiEfZannfNkshsXq7zgwfixoxzd/SUt+eKeuB1Ay+Er7eQJirt7fJop7W8TaYZ9Y6ncILNzN1lvEcr9LYIPMzYUikZ+/5SgWHaV1olgtE7UacC8MqB30iMnJ12KGjOPgrGZI1bCyqkdmEtN1fSx/lHyZLvkI5lbDODfyleLDxHyCOH2U62tivvSJb/R8yBJaDXzswVmNtzJhYrb8pHyZLvkI5lbDODfyleLjBDFrJW8+ecszOWIGWs9xID8pQ5m8EI0aEaGWKGTJLVFzVmShOy5mVq/Ol7ISs5TxgBGU+UYpETBunfoxwzdTYfxaxniEp64BnY/9LAExF7bbjq0WIQ8aZLCgt9hrMx1ithER8gIAJl8oEvKg//IqUes0iOJe17HruNr8//7oDz1DAoZiFUNnh90c4D3twbI2zs7/T/8NIWKe+Otj+ReVL9MlH8HcahjnRr5SfJiYTczXZGI1MVv+5eTLdMlHMLcaxrmRrxQfQ2L+N7/7mICYtZLBZIoZY4YIdTmOlq7Ij6XoG7h6JW8Qz0z6FJ0vNVrJkDTnD20B02Jm5B8NuGkKvf49w8vaEDNaQr3Skuu9j08Eko6DRxjm203iRrlBlPZ7RO/hLoFlQHkwIU9kQfdTGXc+1PjzP/xbD/SshSpWVrrFTVNxPaNGC1jXx8+iPMr44+AfUknXp7YTEYWdDlG/v00Uuk0Cm56q7RohtwPhyp/x+lt+er5Ml3wEc6thnBv5SvFhYjYxm5hNzJZ/hnyZLvkI5lbDODfyleIjk5gDI04IWswarcZ4jSauYaB7oZyO7+gR3Sbki27RRqP0LMvagMU8dOsUP7wTm8Jk0Zu3pEHAaC9lfpUkylKjpA4CK5wKesmnX2k+lAwN/2df+0sParxTCQgVZShZg7O6Bi291wPQHp+CMkYCMLbs1wdgsx4eCKO37Akry8TNW7cIPDayENUcvDCLBVvc5LNxr0+sbrUIqOhWq0XI6xx42ba23yOq222iUC4Rlp89X6ZLPoK51TDOjXyl+DAxm5hNzCZmE7OJ2bhi5CvFxyliDlw4IWBRHdvToOe/+T9+k/CmDNBSTK9BOY7O/09//JuEP+XxgSeiZfzGXziw9A1kcZtvlMI2LlEyT+KPvucYEjM2hX2XUbdU6XxM9+iLfKlR+dJLiVzasPiHapT40eulH7xOIB810vIS86FGLF//P//vjwiIWS9oQ5zYqIWyFjBqtLC1gLWeUQb6c1FG/kz754mk8evfL36WOFrPADWiZ1bO7GKRwKMlUZNfW3PUqsTSVofAoite25DrdYnFToPAqw9xU1Bxp0MUGpsENjdZfpZ8mS75COZWwzg38pXiw8RsYjYxm5hNzCZm44qRrxQfQ2L+j//2NwmIOXAh8Wf/538MCN5F4Qk6XjhxMUONGD/Kf/WD3yRQPitawzone/4JSsZWL4iW9Sk1fFY2fPHZl37igHikJT9IRPripimUAWtPtoChJiZF5KPmhHwlfumlxC81+BS0R18soV9pvhZkkpi1gONAtCh7H3v0Ji+kaeKfBTEnjR+/HYxffmr8vLEHxUDGcaDnG3eKxOxyicBi7EKrRWAx9ubqOpEvrRGF6gaB7U61vS6BTUxY1M1XykTpsOfY6xKzxXXC8tPzZbrkI5hbDePcyFeKDxPzCZiYTczAxGz58XyZLvkI5lbDODfyleJjSMxxJWNBG6TLOAmddj50mlayFjOWl4HWJ2pQ1rrV9bqsdZvUJikfaCUnAUXJpAw9owy5YkL/UwZSZ7Fh+RcbyqQeGsYNVCwDJEs+2iOTtyBdv3xsttKaBKiBkrVo4zKOg7Ma9EUmNIxP0f8U+JnO54izjl9fnyQx4zUkKOtNYTeKZQe/8H92peTAKxxW1wgs5OKxlPKUjOYmke9GDtwgxBudsJy71HXM1pvEjZV1h+Un5Mt0yUcwtxrGuZGvFB8m5qGyiXm68k3M0yi2ac+X6ZKPYG41jHMjXyk+EsWslaw5q561XFHOjg/xZBez1meSkpM0jL6oiePDCbTX+RotY0zBQxM3FKX1zBP3kx86jj5wvPI9hwgMoCUvAstEj3peMh3Kx0sktfKvUT6UjKVmrUyAGu9jz5CA8cgRhdTHxAz0p6AMMSfpOfv1wbK2FjN4X72+E+hNYdAzBAOgHEhldmWNEMHwCw0LHcdCq8m4pV1sdMKiLhZ+Zys1YqETEdj0ZPnxfJku+QjmVsM4N/KV4sPEfEI9+qImjg8n0N7E7MOJy8k3MZuYrypfpks+grnVMM6NfKX4OLOYweXo2Xcn4krWQM9amQDqhVChT4B6jfeuJ342CCdwFhpG8glKxtTMtwNBzx9ZikAN2vCNNK9834HtUbJpCIuiaMNlqccCKYDqsCys87Fx7BrlQ8mQJW5S0noG3r4nilarWit5qJ5b+hAi/o8AyPiDH36H0PXQc9L4069PuphBXM+1fsux7cCDNRZbjnzUIERCuHFIMbtQdPDZG0sOKK0Y1Ylar+nYaTssX+XLdMlHMLcaxrmRrxQfJmYBbTTxs0E4gbMm5svMNzGbmMFV5ct0yUcwtxrGuZGvFB8niDlwcArn03N2dN8sYtYS1aA+6awmqY3vHpyFhlGPskbrWSMyhqoxZaP8PYanb4EfHiLSwloo1IVlUtTztinRABIgA32WNXA98iFmKFkDcXr7BloF+izQZ7WYsXEMbXQZnwIlaz2jDETMCeNPuj5ayZrAyp4hMUc1otrYJApRncBmJSzD5hfmiedvLRCyJMuP4BDllKqOYoUoVMtErbZBFDYZ1Fi+ypfpko9gbjWMcyNfKT5MzEMktfHdg7MQMOq9jz2Bjz0m5lHyTczAxHxV+TJd8hHMrYZxbuQrxceQmO2www477LDDjqs9TMx22GGHHXbYMUGHidkOO+ywww47JugwMdthhx122GHHxBx/+7f/P7Wn7D2EzLbOAAAAAElFTkSuQmCC";
+const ASSET_SNOW  = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAogAAAKICAIAAAB8K5ztAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwwAADsMBx2+oZAAA/7JJREFUeF7s/VnQXdWZrgueqIi6O1EXdVEVURVRF/uiquJEXdRFxd7hOLH3duS2M7FxgsGi743BgBBISEJAusEm0zbuMGCbvlGD+l5IqO/7BglJiLTTaaf3PgabzuQug/E5UZH1rfEMDd41xprzn+tfa/3/WtI347mY/uY33vGtMcccrxhea/7/w7/54Ycffvjhhx9Dc7gx++GHH3744ccQHW7Mfvjhhx9++DFEhxuzH3744YcffgzR0WbMd/xo76QTSwnHv/vaZ4z/4/X/N+P/NfdK4z9uvTuhkfqr6BCBvzl2g8E5Of+nGf/O+P17Hxlvvfthxjt//LPx3gfwccbiKy82tu86ZLzxy//aEa6SmYkb9fpcffv9FuT/4b2PDL0K46ufq4PTbz4+3//cXxmZuPHm239JZOIGvfe3fu0RetFHoWp8aJs6Mjb97kPjH9b+MaHPyP1PHTbKq2WkjFdx6oOPjeX/7b8niGRpCc3c9dZHhvZYkjXvSJnJJ00i2dVtb35k7Ajo6IGOv45wNvgGV4d//rzw6gdGEjRUob/1xyW44vhLOOL/qDj+JEepr3C1v/UrXB1+/Thw4XBjdmMeuH7z8XFjBjdmcGMGFNyYm9evcHX49ePAhWMkjVnPywitgLiCJVcZ878sW2NknpHg6nvPfCdBBOPRnBKuamYJmaV+lpYYlfzm44Mxv/nOh4m33//I0MWoJE76dz9q8d6HBhHawh8CPAal/rsf/LnFH1sQQblcCsenT9tSv2TLmx8ZpSnqM9LcmMvMeo6987FR9q46asnAKNFjFU0qIVMjtEoi2VXqxJh3vPUJOp6MNvdX4wp3c/jnD2r8MygJGqj1q37WXqyXg0jzI7pxON78/bsZscfQ1/sffGz0Xv+5oR+HLxxuzG7MA89vPj5uzG7MGqFVEsmuUqcbM2r9qp+1N3pyOIg0P6InhyP5WSL2OABjG3X9OHzhGGpjLi0ZiKgBA3GFfGxYz/Xq//2Riwz6+sfvP2i88ff3Gqe+Nr0hGA8Gg0IJV6NFdalfBTpZR8aw6TcfH4yZjaA4iWUBYkli8d3yuxZ6FXhgWGjiIxHUeGB4PFSfR+id9z9B1TAAln6NQxP9rElH1A45T96TqLeoqgitND4+0Mn82OCOkEOPVTSphMwyAlUK5eiV9gyjPn/082pc6b1+1t7oyeEg0uSIbhyO5GQG/+zWSAlV1defNemK4dePgxgON2Y35kr6pd98fNyYOadfBVvSJ0WvVkWqzKxb0Mlc2eCOkEOPVTSphMwyAlUK5egxQ7JBNkZ9/ujn1bjSe/2svdGTw0GkyRE9ORxqOW7MTfTjIIZjBIw5c18j+W5HShvWcyCTuFqy0tx+SuPRq0S4SiaRbu2NfNo2YXj0m48Pxvz7dz80mNAsNyypLEkswRAXvmIhbn8kWrRFRF8XJlWgL/S1F87JiWq1+mSqJaDAF5foBZMjXgW2pE+KXm0S6RZ6hOTEBp8F2Fwlhx7rybrIKHNSQ4Ne9GoJFTKqOtpUS3x05w9tGXP00QQyoU2tVl/rj8tulwfmHd04HGo2WHI9mt+ErPmYZM3HJGs+JlnzMcmaJ+KAhsON2Y05Mjj95uPjxlxFaX56tUmkW+gRqBD4LODGPJHzh7ZuzFnzMcmaj0nWfEyy5mOSNU/EAQ3HUBszX8hKjpuhRqvWq+dAPnHO2b5GH2NWq+jWopobD5nd6pegoL0ow6bffHwwZl1ioFzmgMWa5bhcnprwzh9tbYobUET4+lXWkUFf2gsL3Dvvf2TwUwqWP64q1I8ZMM/RoXKtP+s0wXKcHhNDrzaJNEdHVcEeqAQ0nx7rSV10pMxJDQ3tsaTDeIYNZNqqDSv6SVHIbtyYTPz8QS3dAqOsn23qKv0/vGeunIz5k/rjstvlEd04HGo/J8/8zsi8py+gfO7pxwENhxuzG3MH+qvffHzcmLNOEyzB6TEx9GqTSHN0VBU35pKJnz+opVtglPW7MffCZOnHAQ3HUBsztoqhfu1XP0pohPPkwUZpw5wDlqxb4hhzaUXN7ac0nhKuktmtvkKrVGTSqYpnzcekSqcqnjXvSPPxKY2Z5bXJwoptsITVo/ol5GQdGeXCygLHovZegJ9PJCmjrJ95zrlWDuhzVWEJTo9JUoAmkebwSbUqoIYyk76aoG1LypzU0Ch7B0ZM62RUuUrblJxB/XoX0iSpQe9vCTlZRwZ9US2Z3c4fnUWMBlC5tsJ0q/SJAOZNflx2GxzRh+VQS4bSePpFcrVzTD8ObjjcmN2Y26jSqYpnzTvSfHzcmNHnqsISnB6TpABNIs3hk2pVQA1lJn01QduWlDmpoVH2DoyY1smocpW2KTmD+vUupElSg97fEnKyjgz6oloyu50/OosYDaBybeXG3AuTpR8HNxxDbcxYL/apNsx5ExsmghmXlgwYM8awZv32BJHMPxKaj/FovISrZHarr/lV1liVnwQzqvIHod98fEpjrlrmgDmjERbZeljgWCKBr2KBLn8KfZGvFZ59M19rq5DFTq+W9WvNLKmQijFSskHNLMG0VQVoEmkOFpLW/QRxQL/sReMlmllS5qSGBjUwGpqjYwg6hrRNyRnlVfTrmaz5o8qMhn5q8rFYtqxRK/UV3fRm1eXLXJyXR/RhOTI/NtRsSkpD6i+jqx+HOBxuzG7MbfmD0G8+Pm7MkJINamYhpq0qQJNIc7BeelSSKxvol71ovEQzS8qc1NCgBkZDc3QMQceQtik5o7yKfj2TNX9UmdHQT02+G/Po6schDsdQGzPGWRpteV5GSjMuLVm//JX8JgPbULsiojkYz6vTbhwTMrVtE31lFPObj48ac2lpJcyZLGhkK2lCc9BnsYP6HulLl2DqBH52opEqNa05rewJlFOyQeW0UjRHI2qfKaEremmbyutIvTI5ZUQp76Oak44kV2mVkjOqrtJLieZwfydy/jB6asn6eWnFiyxQe/9fPzYwYCLYNvAzqvg/328Rl93iiA5cHJkfG5nTOF0RhzscbsxuzG0MIr/5+Lgxo5ySDSqnlaI5GmH5hpTQFb20TeV1pF6ZnDKilPcxuXJmVFylVUrOqLpKLyWaw/2dyPnD6Lkxn6vE4Q7HyBiznpcRzksz5pyrJRgzmZwfOHwyo8p4uKrGw1W2ZEu4SiatmuiXjFZ+t+ODMbPQsNjpwlTCnNEIC2harYyqJbtb6IvlElBLK2mCeFX96PClnojUhrLm84lopWiORnT5TgldgUIWbEgqryP1yuSUEYXR0By9F4qOm+Yr5VVaqc7wzB9Gj3rKqjIRA0tmW1u3rKMxx/MW5MRlV47owMWR+XEic5rE6G4vw8Tox0EPhxuzG3Mb/c3vdnzcmFHWfD4RrRTN0QjLtxuzjpvmK+VVWqnO8MwfRo96yqoyEcONuV9MjH4c9HAMtTEnD07Wy3ly34zmZgzaig3t4yd/mVFlPFxtYjypoUEmrZrol4xWfrfjgzFXWZrCIsWcIcKSCmwVsmCVSxgkqYZoX8DyWurX149OaclEyrZ8IlopmsNo6DnG3K09q874yIrsSFUvXC0jCqOhOWpyio6b5gM16FXyYTjnDzWT39aKuRSgcoyZ7WvsGRt++72PDF45oqgxR++tODInTmAtkLlOXzgf9Bl/DjdmN+Y2+pvf7fi4MZdt+US0UjSH0dBzN2YdN80HatCr5MNwzh9qJr+tFXMpQOVuzN0yDPqMP8cIGDP2qSaq6NXMgxNkYr2amUTS1eQ3iSbGs+bmqw2uZq5jpIYGmbRqol8yWvndjg/GnK1HHdGFVZdUXZ6AxUuXMyCeydaQpmiCOMuokpp0hLaazwJN/ZqZPpSROk1oJqOh52rMSmrSEdXphazUjKpeynjW0NAxIUftTeH+0ioJJuir1Bzm+UMrPi91Rs4WY/ApMObSnkEjWDL2HL234sicOIGpNDGeXjgf9KPthcONOeLGDP3N73Z83Jg1M30oI3Wa0ExGQ88zP06kJh1RnV7ISs2o6qWMZw0NHRNyGL3s5hrcX1olwQR9lZrDPH9oxeelzsjZYgw+hRtztwyDfrS9cAy1MatxYqi8VATDVpIHJ7QVObp9DUnc6JcxQ5XxkEmrJvolo5Xf7fg0N2adM7qkKuXyChpnmcvEO6JLuUI8S66BVlnQ4FNwTg4RDLXsXfvlXCFekqVloJw16YpU3phkDQ1q0HPNJ8JoMDLEMbOq+0tO6iJBHFDLJo+hOlX6Ezl/yI+flyKlKkaGTK5GYw6m+9Y7HxuYMT+Owp4VvhQWfViOzIkzMncZk3pz6p3R1Y+2Fw435ogbM/Q3v9vxcWPmnBwiLLhl79ov5wrxkiwtA+WsSVek8sYka2hQg55rPhFGg5Eh7sYMjAyZXHVjHgSD04+2F46R+fJXFaXFEsHCSyPHnrHhEkylW5obD5lZ83Oe5uPTX2MGFlD+GF9aT1OEZS4T70jvCyvQKgsmkqzB5yJe9q796lWNNyEJJrKEhtQr6FXIEgytnHPN16uMDHGNYJPcU9AchTjQNps2CZ0tafKkCL1k4h0pPxHo56qHfM6poYkx68s4deOaOJZMnJd3RjcOR+bBGZmvjBusbnCGNyr60fbC4cbcRuYoDWluPGRmzc95mo+PG3OSNfhcxMvetV+9qvEmJMFEltCQegW9ClmCoZVzrvl6lZEhrhE3Zq5SuRszjIp+tL1wDLUxZ7vTRmnAxPXPWqgNc7UqghljCWoVSvKMRJZgNDceMquugl6tImtiZAmJLM3IEjqSNTGyhESWZmQJRvPxGZ8xp1U4kVZVo1xSibOIZ7IdYelk4dN+laxJDU3ysQrtkTjnSlW8+XIP2ja71JD6tkk8kSUYWnOWbGickWGUiOu5om0V4pBNHiNNHmN45o9mttUTjFlHjwoxZsCMMWBMGhtm+5rXj/BHIbHqzIMzMkfpkX4ZWxWjoh9tLxxuzG7MHciaGFlCIkszsgSj+fi4MQM2oz0S51ypiusy3QRtm11qSH3bJJ7IEgytOUs2NM7IqBnruaJtFeKQTR4jTR7Djbkkc5Qe6ZexVTEq+tH2wjFiX/7CUMdnw3qOJpEm9lxPaTygOUTI1Hi3JPGOZMnjIBPMyJIb0nx8xmfM2SWDZZpFlvO4hEFYyJosrLSF3hdWaJJPj5xrPudKVVyX6SrIKTNVR+NVlJmMlX4KSLJZPmg8pSXKHPQ1UlJ1lXjVVZSHbf5oJrVRFZXofSTCPykwZv3jFtgzkTff+VOLdz80zhp2i7fe/ouR+XFC7aSJIVW1bcL5ox9tLxxuzG7MbWSCGVlyQ5qPjxsz0CPnms+5UhUv7baEnDJTdTReRZnJWOmngCSb5YPGU1qizEFfIyVVV4lXXUV52OaPZlIbVVGJ3kcibsxNGB79aHvhGGpjxjKxUlBz1fMyUnVVLRnoJRuprmhiPEBm1vycp/n49MuYFV1eWVIna2FVqlppj2UOkRLNgdJuFa5u+d1HCT4daGZ9L+VVrV+pV4aqOKSGKUf19SqUrRSu1ufA8MyfMpPaONerxLFtjBmw5GjM8gct2OjGmAELByLNbam5PprNlTX/3NOPthcON2Y35oHTfHzcmLXHModIieaAG3PZSuFqfQ4Mz/wpM6mNc71K3I1Z8zOpjmj+xOtH2wvHCGxlY5yYaGm05XkZKc2YbXDOyeFnVG0/8gkvx9CIolerjEfBeMgsFUrKq+898x2DeAlXNZ+4RpTy6uD0m4/PIIwZWKp0oSSSpSU0k1cwao8lWfMxqWpFj6WNQeoug6u0otoqYya+6XcfGizcuj0LKCgoZ50m2DLF4FHuVh+oMBNPpI+QoCpGLLtkVLWCJFuTowzD/CkzuZtJJLuq46/2DHzhC6LNhDhfClO4+vb7LcjHTvQq/P69j4wkm+Aqm+S0SmUketFXHVoptB3++qPthcON2Y05Mjj95uPjxkyPWE52yUjdZXCVVlTLkp0aJoh3a5woZ50m3JhLNJNPpz2WZM07UmZyN5NIdlXHP/lHQo0B2yCOnShcHX5jA1optB3++qPthWMkjVnPywitgLiCJdcbM6ai1oJtQJmD8WhO5joJMrVtE30iUNpnlWUCkcnVbz4+3RozC1N2qQa2H8slVXV0SYV6W4JuK6FVFjToKwsmUncJvZoczijrIaImynlz41RoS7WcYwOcj09fq80+pqFXlaoRq2/F1XKU6pnc+UOmRmiVRLKr1FmOf/ISg23ndz/4s6FxJZrKux+1KL5EBrzmM9rMO5/AVfTZBCaCMiOTOjLGp68KJagNf/3R9sLhxuzGPHD95uPjxkxfWTCRukvoVTW5sh4ivRinQluq5dyNmfNs8hhUSI9VNKmETI3QKolkV6mzHP/kIgbGgPFoXMFm3JjdmONRWjIQUQMG4gr52LCe61V+iEVfbXYSUDtR2tIK44HMdQwytW3WJKE5oFcxS9B41sTQq0qWZujVPus3Hp9BG3MV6GTrqaGGkaZoR7qthFZZcEzqW1Etiy/WSFWAcbbZZ4BIc/vkKvr0S9skbqCsI9lEP32QjEGMFVcZmezSOEBHPy/o56LHKppUQmYZgSoF/ccE54x/8pIE1XKV+5slGJgTRhUtJ2zbYkjYDxFMCIt65/1PUDUqZG5oHJroa/6o1x9tLxxuzG7MHTL7rO/GXECrLDgm9a3KhYmqoDROIMLiQltArYSr6NMvbZO4gbKOZBP99EEyBjFWXGVkskvjAB39vKCfix6raFIJmWUEqhTcmBU35nESSwkHZpm5r5F8tyOlDes5kEmcXrbvOmSkv2aYyLwkwVWMZ/GVFxtYS5ZmJNcxyKRVE32FCrO0xPjqVwah3+34dGvMWbArWMigXEyBrSpy0hStIeuij1T1QoWc6xIMxFmqIoWJKlyNhHwdDSIsefSFvvbCOVVl4ka9vrblHKo+ey/0rpYmjzEx86fMSQ0NetGrJVTIvdP7RbXEq+aPWki75bRoi+gPgcTYVIG+0NdeOCcnqtXqk3lu1B9tLxxuzG7MkUHodzs+bsxVVPVChZzXL0yRYIqZXyY+cU0j5OtoEHFjhjR5jImZP2VOamjQi14toULund4vqiVeNX+wEGizmVrjcWNuXn+0vXAMtTHzhazkuBlqtGq9eg7kE+ec7Wv01Ziz34MbmYskuFoaD2imxsmkVRN9hQrL7WUi46tfGYR+t+MzMcbMEpZW0gSPB4spaH6aojWkLvpOqa8V6rlCKz4dC0ckWGObZYY4I/CJd7ZDJtvUWUcGfY1PX5dU1MpPhL5GeqEXtcmaP2VOamhojyWMv1bLyNNWR17RT4oCRtKcd/5o3hZfzUGkav7Ql/aCgfHyDX6qhL1xVSltEkar/mh74XBjdmOODEK/2/FxY66i1NcK9VyhFZ+OJSMSFuXmxglkVi1M9DU+fRYmN+bURUfKnNTQ0B5LGH+tlpGnrRtzFW7MkVhKOLBVDJU/XAEa4Tx5sFHaMOeAJeuWOMZcZT9qIcDPgbjarfGQSasm+kBVVJglJ8ZXPwxOv9vxmUhjZhlVyqWNzDQ5x0TbdkuVQhmnTq1WzxXasjDxGVkC6iGTJYblG3NlSSIn68igr7IVETQVzcQY1B7SB8w+F71oBKriVXSbr0zW/ClzUkOj7B3K8Wc+cJW2KTmD+rudP5nrZJCTdWTQF9WS+Yf3PjQwxfcC/GHKJGXo/MkEjdGqP9peONyY3ZjdmCODXljrqVIo49Sp1eq5QttuFyYyWWJYONyYlcmaP2VOamiUvUM5/swHrtI2JWdQf7fzR42nhJysI4O+qJZMN+YhPbBe7FNtmPMmNkwEMy4tGTBm7KS0H7UQcqDeeEDbEiGTVk30qYSqiJNJHLRtt/WTOTj9bsdnIo2ZhUwhDuiXvWi8RDO7pUqhjPPwUzMRPVfKtixS9bBM0AtgscBV1QT6KvNZEJUka+gyp8p8IvKJQPmJoCpeRbf5CjOECpU0eQz0y140XqKZJWVOamhQA3dQc9KwJxh5rtI2JWeUV9MkqYH7mG6xofNB77JCX+SrdfFiS7aCMTm9WmWTMFr1R9sLhxuzG7MbcyStqgb6ZS8aL9HMbqlSKOM8/NRMRM+Vsm22BnWk94VJ8zNXMJKsoQuTKvOJyCcC5SeCqngV3eYrzBAqVNLkMdAve9F4iWaWlDmpoUEN3EHNScOeYOS5StuUnFFeTZOkBu5jusWGzge9ywp9ka/W5cY8dAfGWRpteV5GSjMuLVm//KWmovajcYWrZDYxHiCzW/0yXqI5w6bffHyaGLMuf9mlhvTSlsevit6V6yNppUioJSSpRKkJ2UqU0ByWDJYh0EWkhL50CaPC0hKgVONT8InKfM0sP1cZqYJeILvUkF7aUmcV9crklBGlvI9p8DuOJ61SckbV1TRhMjSH+9vL/FED42dLGqlXg9GqP9peONyY3ZjdmLuAx6+K3pXrI7qwghtzVaQKeoHsUkN6aUudVdQrk1NGlPI+psHvOJ60SskZVVfThMnQHO5vL/NHbey8NmaWVBZTIMLCylLLFmUJV8nMLiWq9DUHmyyNVs/LCOelGXPO1RKMmUzOy3oUrpb1T+T4KKOS33x8mhszy3d2qSH1y189PH5V1CuTkwUTSSShV3VJbSN8eaSq31KHBUgVqpbsbqEvlhtArdQHFjtV4FOQX9VK8+lR0auKXqWXc2P+pIaJKoPJhtEgk1aar5RXaaU65Z3S/ObQV5o8qWY1MyBezp+S0ao/2nA43JjdmAee33x83JgVvcrD3AE3ZkGvKnqVXtyYyaSV5ivlVVqpTnmnNL859JUmT6o5czWDeDl/Skar/mjD4Wgz5mxf0Xjj7+811E5Yaku4Sma2Y2mgk4kbxDUTY8Y4kwcn6+U8uW9GczMGbUW/VKX1QH39Ezk+JVkTI0swJle/+fhgzPXLE1dZWLtdXuuVm8DjV09VL1zNgomqq+XCATFeYcxEVJMlCdhqa9MpSFINKetneSr1q5ZUaia/rVX4jEDlWUOj7F3Rq/Rybsyf1CTB/dUcNQmFTFppPlCDXiUfhnP+KKNYf7ThcLgxuzG7MXcBj189Vb1wNQsmqq5WLRwxHuyq7JGIag7/wkTN5Le1Cp8RqDxraJS9K3qVXs6N+ZOaJLi/msNdSIOfIJNWmg/UoFfJh+GcP8oo1h9tOBxtxpyttgkWVhbQbOVNcDUuwQ2W+3qwydKGMVFFr2YenCATTc1MIukqn6Xb+id+fACdrCNj2PSbj8/4jFnJkjPqlZvDQ1hFVS+aU8Y1wgPM8sFSwuOtkMPDXypQA/G0Hhlqb4BOJm4QV8166EshzjKkpCYZtOITJSducbYYI34KiZQKZUTjjEw2bRKpYUdomwXHgVZVUtVLGc8aGulGG+QwntnNNRg9WiXBBH2VmtyR4Zw/yijWH204HG7MEa7yWQZnPP0aH0An68gYNv3m4+PGDCwKLBwsKNmqYZDDslsqUAPxtCoZw7ww0YpPRJ2Rs8UY8VNIpFQoIxpnZLJpk0gNO0LbLDgOtKqSql7KeNbQSDfaIIfxzG6uwejRKgkm6KvU5I4M5/xRRrH+aMPhGKcx61VdWMkk0u3yTT5t2WpW48RQeakIhq0kD05oK3J0+xqSuKHGDM3rn/jxacLw6DcfH4xZp7XCwwbZpYTmlFQpNweFJmQNjSwhoTksB8DCQRzb0DjwqJc6SdzQJUlRndRpps+yrspV6AgrxLPkjpDPJ4pFSlVqnOXVJGKkrjOopL4ezSlBJ2vSFamYMckaGtSg55pPhFHijhOP4yljpfeXnNRFgjiMyvxRVGFU6o82HA435ogb8+D0m4+PG3O5QBBnwdU4sOyWOkncGJWFifxoJBQpVTECZJZXk4iRus6gkvp6NKcEnaxJV6RixiRraFCDnms+EUaJO048jqeMld5fclIXCeIwKvNHUYVRqT/acDjG+PIXNF9Yyex2iVewT8w1+W4NpcUSwcJLI0cfGy7hE3Vb/0SOD6CgvSjDpt98fDDmux/dbGSz1uh2okN6QhJZQkPqFfQqZAlG/VVdGiJh+eAqC64uGfxJCa6Wmqkjo2phAlVL4inCsq7KVXBftF9ofr/I55wadDQYAa7G4uUqcFVJZSSa1wNZcyNLaEi9gl6FLMHQyjnXfL3KHSeuEWyGewqaoxAH2qYJk6GzhXON0Esm3pHyE4F+ruaowqjUH204HG7MbfCJBmc8vY8PoKC9KMOm33x83JjbCAsHV92Y3Zi1cs41X69yx4lrxI25RKtNxafIRNYfbTgc4zTmEq6SyYLb7fINGCTGXFIaMHH9sxZqw1ytitAXdUJyi67qn8jxoVUqMulUxbPmY1KlUxXPmnek+fioMX99/nFDJ+74pjto2+xSQ+rbJvFElmBUxTN3+YSwcJDD52XJiGtKyOFqqUwEWFyUqBAolyTiLOKqWQW1YZzar5I16YhmttUTPim9cDUWnwaqHXJKUjGGqjVB22aXGlLfNoknsgRDa86SDY1zLzAk4nquaFuFOGSTx4jjHxie+aNo26x4IxVvDE/90YbD4cbsxtxGlU5VPGvekebj48bcRlggyOHz6sJBDldLZSKQrUpGVAgMz8KkmW31hE9KL1yNxaeBaoecklSMoWpN0LbZpYbUt03iiSzB0JqzZEPj3As3ZsiKN1LxxvDUH204HJXGzELJax9YWDVewlUyaaXxEq6SCbrJzHlpwxjq+GxYz9EkQo9lPUSyshOaPzHjQ6TKGqvyk2BGVf4g9JuPT2nMas860XkY0pzuCDllpupovIoyk4ewXOySbJZfReYoGbo08CmIcJUlhqtlj6mMLA5UjgLnuiSVvVdBW+h9YdJMaqMqKtH7SIQllWpLyFRSMYaqVUFOmak6Gq+izBzf/NF4SkuUOehrpKTqKvGqqygP2/xR6tvS47DVH204HG7Mbsxt+YPQbz4+bsyKLg18CiJcZVnhatljKiOLA5UP28KkmdRGVVSi95GIG7NS5qCvkZKqq8SrrqI8bPNHqW9Lj8NWf7ThcLQZc1pzM1hY19x89ZiQmTUfE2wY6wXMErBSUHPV8zJSdVUtGeglK6krBj0+o07z8cGYMWPsWdFJXC6XCle3/O6jBI8NaGb9w1Ne1UdRqVcGvcrDXw8LB/mqoHEo9YmU8RLU+BTa+8QvTGWmflK9SjwuplJzCfklozt/smAiNUw5qq9XoWylcLU+B7gX9KIjP/HzR2nednjqjzYcDjdmN+aB03x83JgVlgzyVUHjUOoTKeMlqPEptPeJX5jKTP2kepW4G7OSGqYc1derULZSuFqfA9wLetGRn/j5ozRvOzz1RxsOR5sxr1m/3WAZfXXajYkyUkVVW5SrUGPGLLFPwDiJl0ZbnpcRdIgA2+Cck0MNWWEdqfqMGqmiqm3WxUhT9Rk1UgXG/Mz2Ux1h6vPCvKqFlfim331oxIVbtqcgvXUvUf9QsWXKAo1yt/rw3gd/DnycUf4RdfT1c2k95WcnXkbKeBW6PAGRLC2hmXw67bEka96RMpNPmkSyqzr+Onrw1rsfJhjhUZ8/VJiJJ9JHSFAV9yi7ZFS1giRbk6MMw/xRum07DPVHGw6HG7Mbc5+p+owaqcKNGdDXz6X1lJ+deBkp41UMw8JUZvJJk0h2VcdfRw/cmKmKe5RdMqpaQZKtyVGGYf4o3bYdhvqjDYejgzGXy2vzhbVspZpVqDEnP06UxqznZUTbElew5F6MGcpPynk9ZatM9pyh/KSc11NvzDwAUC6sRHQR5Lz5wqfQlqWNc5ZRzsen/+4f/2y8/f5HRuYiCTTLRUEf8vKzEy8jZWY9bN/95+/8P7uCUaLHKppUQqZGaJVEsquMUjn+Op6M9rsf/NnQe1HWQ4TxH875o9XqmIBeVaghCxr1rbhajlI9zJ9y9qqOWhpQIT1W0W0l42s1ufVHGw6HG7Mb80AoPynn9bgxo1kuDfUPOfEyUmbWw8KU+e6Y9GthIlMjtEoi2VVGqRx/HU83ZmrIgkZ9K66Wo1TP5BqbMr5Wk1t/tOFwtBnzgcMnE+NbWMtWqlkF1quGSgTUPoGI5gNxhXxsWM/1Kv8goK+ssBrKT8p5PWWrTPacofyknNeDMT+9/ZSRubLB8sTixdLGdAcWvrblL0Ck+fLHVfR5YGibxA2U9eFsoq+GoehywHl6VhN8Rn3U9WpVhFYaL8lc1rh4yf/buO7VT48JmbT69zP/XYLelSaVkFlGoEqhHD3GPxtkg7vA1VGcP+kjZzA+WXBM6ltxlZHJLo0DdPTzgn4ueqyi20rG16oKdLLijf7WH204HG7MbswDofyknNfjxsx5elYTfEZ91PVqVYRWGi9JfpxwY06TxyDS5P4CVwcxf9JHzmB8suCY1LfiKiOTXRoH6OjnBf1c9FhFt5WMr1UV6GTFG/2tP9pwONqM+fjJXyZ0QxKyX7Z0pC0/KKhmFcmDExrP3NdIvtuR0ob1HMgkrj02ZyLHZxQZ3/hEY952qkVhz7oEAxNal7NyEVTi8gfF8keEJZW+0jOTeuGczatM3GiijwL59MJDTrwKHmx91PVqk4iSPNhobsP1oANVJp2VkVHmpIZGk6WNkWRUdbQZf+KjO3+0Leego6TxXuhdjfsF3BfQT8RnISd9hBqyLmroNr8kFW9MTP3RhsPhxuzGPBDGNz5uzFWUD79ebRJR3JhHcf5oW85BR0njvdC7GvcLuC+gn4jPQk76CDVkXdTQbX5JKt6YmPqjDYejzZiz90IYurDymka2HHmBIhDhquafPPM7IxPsCr6QlRw3Q41WrVfPgXzinLN9jT7GrP1SeZP69fNO/PgopRF2CwqZbI+ofpPxaTNmYe7O00Y2jw2mOw8MC1kkLG1tS54sc5+sfe2QyTZj1pFBX+PTV0tQnfS0p/qzThMsAbQFvdokAv01YyW5cobac1ZMRplDBBgBvap0GM8w8rRVG1a4GvODQiS0bX5/gcxBzx/UytFAXyO90ItaaWbAp6Nyrb9fxqZ0m69MVv3RhsPhxuzGHHFjJtONeXwkJ85wYwb6Gp++GzOkLsak23xlsuqPNhyOMYxZl/smCyuZtOrFeLBMbBVD5Q9XgEY4Tx5slDbMOWDJuiUejTn8wQZ6p/Im9U/W+ID2Du89851xozooZ92NA62wyfhgzGxcs5WNMS/YfdrI5rHBdNfHhiWsHjLLJZIllZysI4O+ylZE0FQ0U5dUdDjXyrUVVxUWAtqqAjSJYMmZm/aRzI8zsGetp6TqU4AuhQojpmPIqHKVtik5g6t6F9IkqYFM+tWZMOj5o7OI0SjHhF40AlXxKrrNVzCq7OMYZbXNLQ20bT3d5iuTVX+04XC4MbsxR1QH5ay7caAVNhkfN2ZacVVhUaCtKkCTiBtzCVf1LqRJUgOZ9KszwY0ZJsvYlG7zlcmqP9pwODoYsxpG1cLKebmwkkkrFErqDQlLxkSxXuxTbZjzJjZMBDMuLRnajFnsuYrJHR/tEdRctV9oHlEd1e+2Wo1otfRSPz4Yc7TkAJvY/FmLbB4b5XRnka2HBS4ufAGWSNDlT6GvMj97eo0ka5TLtNZc1SolG9TMokBbVYAywpKhkSbGnLlpH+mXMTMamqNjCDqGtE3JGeVV9OuZrPmjyowG+USg/ERQFa+i23yFuUeFCnFAv+xF4yWaWU+3+QoVZsUbqXgjlZT1ovESzSyJNhwON2Y3ZjfmtoVSlz+Fvsr8tJ4mkqzhxgxuzPRV5mfFG0nWcGNWNLOebvMVKsyKN1LxRiop60XjJZpZEm04HOPcyuZcF1bOyaRVJtUQNWaMM7lsFqm/Wppxacn0VRpz8/rJnJjx0b7URFFWtHeNVMU1Aqrfr5rpq3581JjVkpsbM2QraUJzWPJY7EAXwRL60iWVpTOtp0ZaT40qNa1Z8wHllGxQOa0UzdGILh9EqiwZy+Sqgok2J2tuJD/OIJ+qSqo+l1Lex6rx5yqtUnJG1VV6KdEc7u9Ezh/uKSZR5mtm+bnKSBVp8hjZpYb00pY6q2iiTE6TzCp6aZsVnFGvHG04HG7MbsxtEVD9ftVMX/Xj48aMcko2qJxWiuZohIdflwDMMnNlA7NMbppIjtuQrLmRnDiDfKoqqfpcSnkfq8afq7RKyRlVV+mlRHO4vxM5f7inbsxZkwxymmRW0UvbrOCMeuVow+HoyZg1wsJKJq1Up9zwrAKbLI1Wz8sI56UZc87VEoyZTM7VnrWqqvonZny0F8xS9QF9pSoO9a2UXuxZK0etfnzUmPnCV7fGzAKqC1b9EtYc+mK5BNRKfWCxzkQMdPhST0Raoaz5fCJaKZqjkfLhxyyrzDj5q8HV5NwNoZXqqD5XNUdrU6o+l8JoaI7eC0XHTfOV8iqtVGd45g93lvyqVppPj4peVfQqvWD/KaErUMiCDUmldqSJMjmjWH+04XC4Mbsxd4grbsxAX70srICOG3NJ1edSGA3N0Xuh6LhpvlJepZXqDM/84c6SX9VK8+lR0auKXqUXN+Ys2JCs4Ix65WjD4ejCmFk6qxZWzsmkVSbVEIwZ40wenKyX8+S+Gc3NGLQV/VYZcxUTMz60xSDppYQcoBdMrh4ytW0mm6B3crLyauh2fKiqtGTQScwUZ7oTYUmFcqswrVyJJNUQ7QtYXkv9KksGdEpLJlK25RPRStEcfeDLq2qQnGOQRDKXHTeoAfqgvRPRapWyciIKo6E5anKKjpvmAzXoVfJhOOcPNZPf1oq5FKDyrKFR9q7oVXrB2Lq1N9pmwa6gknrqe+HqKNYfbTgcbsxuzG7MjdC+oNuFFdCJK6k2DJGyLZ+IVorm6KNeXlVr5ByDJJL567hBDdAH7Z2IVquUlRNRGA3N4S60jWRAx03zgRr0KvkwnPOHmslva8VcClB51tAoe1f0Kr2MorEBV0ex/mjD4RinMXNeLqxk0iqT6gpssrRhTFTRq5kHJ8hEUzOTSLrKp+jdmPs1PqW+KgMRcpLjGv/j/+H/Oiaar72U+kBOL/XXjw+VZH6c0EnM5Gai65KqyxOweOlyBsRVs570XCWIs4wqqUlHaKv5LNDUr5npQxmp04Rm6qOepRlqkJxnntoXkitnlL1rtUoZzz6IoWNCjtqbwv2lVRJM0FepOczzh1Z8XuqMnC3GiJ9CIqVCGdE4I6PGpqSGHaFtFhwHWlVJfS9czcpOZMkZ9crNyQrOqOol2nA43JgjXOVTuDGX+kBOL/XXjw+VZH6c0EnM5Gaip1W1tSSFpWo4F1agreaz1FK/ZqYPZaROE5qpj3qWZpTWmHlqX8j8OFH2rtUqZTz7IIaOCTmMXnZzDe4vrZJggr5KzWGeP7Ti81Jn5GwxRvwUEikVyojGGZnMzxKpYUdomwXHgVZVUt8LV7OyE1lyRr1yc7KCM6p6iTYcjg7GrF9E0oVVl1EWVtCFlUxaoVBS/0UnYKtZjRND5aUiGLaSPDihrcjR7WtI4kZzY57I8aGVbmITSeJGclYj892uUB3V1x7LDW2ttox0Oz70nvlxQiexTnRdUpVyeQWNs8ypchU8TtovVD1mVdAqCxp8Cs7JIcKCUvau/XIOmgPYIWRu2kcyP87QGqiKyhXq1/P0EQwijAYjQxwzq7q/5KQuEsQBtWzyGKpTpT+R84f8+HkpUqpiZMgsryYRI3WdQSX19WhOCTpZk65IxYxJ1tDQSrJLCc0pqVJuTipvTLKGRrThcLgxR9yYVUf1tUc3Zu0XiGfJNdAqCxp8Cs7JIcKCW/au/XIOmgNqipmb9pHMiTO0BqqicoX69Tx9BIMIo8HIEHdjBkaGzPJqEjFS1xlUUl+P5pSgkzXpilTMmGQNDa0ku5TQnJIq5eak8sYka2hEGw5HF1vZTRZWMmmVSdXAUg7YJ+aafLeG0mKJYOGlkaOPDZdgPJAV2ZHBjY8qqxo6nGNjmb/2BZTLHmF8nwKd+vGh38yPEzqJdYpXLazAAsofGEjraYqwzKlyFfroKsSz5BpolQUTSdbgcxEve9d+Ob/mvoUdwQ4zH63hif/law0hP/PgGqqMmfpBI+nDGnqVkSGuEWySewqaoxAH2mbTJqGzJU2eFKGXTLwj5ScC/Vz1kM85Naj11hszcFVJZSSa1wNZcyNLaEi9gl6FLMEgPrr1RxsOhxtzG27MgHLZI4zvU6BTPz70m/lxQiexTvFRWViBVlkwkWQNPhfxsnftl/PMjxNuzOQoxIG22bRJ6GxJkydF6CUT70j5iUA/Vz3kc04NarpuzMRHt/5ow+FoZMxrbr7aaLKwkkmrTKoGNWYMEmMuKQ2YuP5ZC7VhrlZF6CtuXJcUdZYMbnzI558I6BDhHKvDxjJP7Qso00vZO1URycrO6HZ86Dfz44ROYp3iaRVOpFXVKJdU4iziqlkFjzoLn/arZE1qaJKPVWiPxDlXiGPAa3afNlbvPpXgK1eYYvLdjMxrDfJpW0+VMvEqsOf074aELqnZxzQ0zsgwSsT1XNG2CnHIJo+RJo8xPPNHM9vqCaaroxeLb3flBDklqRhD1ZqgbbNLDalvm8QTWYKhV0ex/mjD4XBjdmPuAMpuzMBD3vvCCk3ysRntkTjnCnGMzY2Zc0XbKsQhmzxGmjyGG3MTtG12qSH1bZN4Iksw9Ooo1h9tOBzjNGbOy4WVTFplUmOim8yclzaMoY7PhvUcTSKlPTevn8xBjI+aIqgmBpa5ad+hl7J3oMKs7Ixux4ceMz9O6CSun+Is0yyynMclTBasJgsrbaH3hRWa5NMj55rPuUIcY8OM1wRW7jhtYJ+Zaxrjs+EmoKZ9EVEw5pW7Thordn4Cn6L+k+o5o6SRkqqrxKuuojxs80czqY2qqEStiAj/pKDaEjKVVIzRxNjIKTNVR+NVlJmMFeOm8SSb5YNeLasqScVnmaqj8SrKzPHVH204HG7MbsyV0EvZO7gxK1nDGprk0yPnms+5QtyNmUhJ1VXiVVdRHrb5o5nURlVUogZDxI05S8hIxWeZqqPxKsrM8dUfbTgcfTNmzsmkVSZVAzaM9QJmCVgpqLnqeRmpuqqWDPSSldSQwY0Ptqc6QAQDy3y079BLVQ39NWbO6THz44RO4voprujyqgsTi1eWnEEr4GHTfpWs4ZhUtdIeyxwiCmb22LJdBsYMVTZ5+F+3GsSTm2ZgnP+fa8aGzKx5QnvnXKHtql2njNWBbyzcZPCJso9plOOgY6VXoWylcLU+B4Zn/pSZ1Ma5XiUe/zEhNZeQX1LalcLVLb/7KMGnA82kKq1NKa/qiCn1yqBXR7H+aMPhcGN2Y66EXqpqcGNWsoZjUtVKeyxziChuzKBXoWylcLU+B4Zn/pSZ1Ma5XiXuxqwRZTjrjzYcjr59+YtzMmmVSdWgxoxZYp+AcRIvjbY8LyPoEAG2wTknhxqywsZkcONzbhuzqmmEHjM/TlRNa41XwVKljwqRLC2hmbyCkYdZ+1Wy5mNS1Yoey8cYaKXWxTlm/N4Hfw58bGCNyY8NLDm5ZgY2id3+j/+7/6Ermpg0NZTG/Na7Hxrv/PHPBpvw5afjPBsKg1FixLJLRlUr4Gp9jtL7/NEeS7LmHSkzyzmpV6MxB958+y8ZjLyOP+Ops13VgPim331oqL6aPQoKylqnwpY7Bolyt/rQr/rRyRoaWdmJftUfbTgcbsxuzJXQS1UNbsxK1nxMqlrRY/3SUFqXG3N2yahqBVytz1F6nz/aY0nWvCNlZjkn9aoaQ+bKRnLlNP6Mp852VQPi3RoPylqn4sYM0YbDUWnM/Hip+cLKVTJppWol6fdRhhpz8uNEacx6Xka0LXEFS+7dmKl8cOOD7aFA2yRoYGCZj/YdetF+tZJ6Yx7f+NBj5seJ8iGpevyqYPuxXFJV599O3GfowsqDSk56GjNUoQm0yoJG1aIAGJXy1H3fSmy/5tKE2iFf8koemcAax2fGVdSbtNozOVqzfpbsYxrZUCSqRqxqhIGr3d61JvNHZw5QIT1W0aQSMjVCqySSXaXO0hjUnt9+/yPj3Q/+bKhJlPUQURPivLnxKLRlZDjHxjjvXb/3+qlNFUr6W3+04XC4MbsxV0Iv2q9W4sasqEITaJUFDfrKgonMqww1MzU5NUI35hKudnvX3Jh7MR6FtowM527M0YbDMRTGjPWqoRIBtU8govlAXCEfG9Zzvco/COgrK7IGKh/c+Lgxl+gjwTJUPn7jA52//OQq49/+f9sTRMhJa19Huq2EVllwTLAoNTA4fPPVGRgkFghqkJgiOZmz9gWU6UX71XrIwZK18he+9g8Z9cZcRf0Ic7Xbu1YFOpkfGyy45NBjFU0qIbOMQJWC/mOCc+xB7RmolqtYC5qA8bTZT4BIc/vhKvpUSNskbqCsIzk+/V7qTwNoYMCKXqVtEjdQ7rb+aMPhcGN2Y66EXrRfrcSNWem2ElplwTFxY25O/Qhztdu7VgU6uhADCy459FhFk0rILCNQpeDGPL760wAamSsbepW2SdxAudv6ow2Ho4svf+kymlbVFGFhJZNWmVQNyYMTGs/c10i+25HShvUcyCSuPXbLIMaHq9gerUowsMxH+w69ZF0nqLDJZ2k+PvSY+XFCHwYWI410iz60PDzRmMNWdvTmcE5OWgFryLroI+hjUdjVom981/jlV6/vCLZXtYnN1cxN+w69ZF0bbGhzNSs7kVzZ4FP3d4R7V0uTx0jrr6FLLYs4fTUh6yKjzEkNDSrRqyVUqPZMnGqJY+HA1eQlLQoTUqL9QMhPQ2EQwTLpC33thXPGLRM36vX7Vb+2Un0i1E+FZGo+5+OrP9pwONyY3ZgroZes64Qbc0nWRR9B3405G5Zx07tamjwG8wd0qWWBpq8mZF1klDmpoUElerWECjEwNRKq7ZexRUJ+GgqDiBtzpNCPNhyORsbMElwuo6ARXazZzMwEu4IvZCXHzVCjVevVcyCfOOdsX6NfGjOVN6l/EONDJn8ooh5sLHPTvoBy1l1HqDb7CIlux4d+Mz9OpGfAYDHSSHPKxRR4PKI9Y8xiz2kFrCHrqI9gTphxacm6FQzYHpvGmS8a/4/P/F+MzEf7Dr1kXRu6lV1VP+h2PSOQDcu46eV+1c8fFmUgP02PMUlddKTMSQ0N7bEEG9BqsQfaqo0pXI35Z52pRWjbZjkhzghwtYRMtnmzjgz6Gp9+afPQbf20SrIZZFJ/1WjX69fXH204HG7MbswdQDnrriNUm32ERLfjQ7+ZHyf0AeCR00hz3JjdmHu5X27MtG1uPECmG3MSTIyMMWOZ2CqGyh+uAI1wnjzYKG2Yc8CSdUt82IyZnNS8Bmws89S+gHLWXUeoNvsIiW7Hh34zP07oA8Ajp5HmsLDykCg8bNGYdUM7QCv6rSLrqCuqFDAk3drFtJIrd6TKFAFTJCdz076AMr1kXSfIycpOJG829LNX2XO3499tvlI/fzSTXqD3+VPmpIZG2TuoJQBGxVXapuQMrpJPWyykHjLpF+PBnLA0crKODPoqWxFBU9HMJv+woFUqsiO0KvWb1A9lKyJoKppJ/dGGw+HG7MbcAZSz7jpCtdlHSHQ7PvSb+XFCHwAeOY00p35hdWPuHZTdmOkFep8/ZU5qaJS9Q2kMGBVXaZuSM7ja3NiATDWeJsZGX2UrImgqmnleGLMahi6s5TKqEZZdMmmFQkmVIQGWjIlivdin2jDnTWyYCGZcWjKUxlzPoMeHVmTWk7lp38m66wjVav29jE9zY2aZ00hzaMtCBphxCZbMOW151KtIXYyDKoUqY64H28u8MGMQ9oxavSUDmVnZHdHP3i9j7u/8AeJAPWVVGi/RzJIyJzU0qAET0pzMDwwsgau0TckZ5VX068FmovEEsCjgqmoCfZX5WfFGkjXqbbJ5/ZozWfVHGw6HG7MbcyVZdx2hWq2/l/FxY86ChhuzfnY35jIC1FDaTOYKBpbAVdqm5IzyanKyGibL2Eqa1685k1V/tOFwtBmz/th8fAsrmbRStRL0QeNqzBhnctksUn+1NOPSkumrNOY/vPeR8fsA5394v4XWSWZ/x4dXyavaU4//wkhSWQQby9y0L6Bc9lhGqLZf40O/mR8nmL66/BHpFtom9+0Ilgzalsevil6qQkEjmBB/0hH4I4m8lKMe/qwF5pc5oqFfClN7hsxrx0TbqiVrLwqZfKUrKztB/Wv2nDZ4LlbuOhU4aZT2XI5eFdyjXu5UL22ps4p6ZXLKiFLaTJUlcJVWKTmj6mryswzNwXKwMVATKqEvtTTqrKq/Xg2a1E+ETM1Hv6xfM0EVeqk/2nA43JjdmDuActljGaFaN2bopSoUNOLG7MaskFNGFDUbqDIGrtIqJWdUXU2ulqE5GE9pbJqj0FcvxlbSpH4iZGo++mX9mgmq0Ev90YbD0WbMPAAYEi83r19YWUx1YSWTVr9/90PjD++1QK3Uf/ePf87AJkuj1fMywnlpxpxztQRjJpPzszUHY25Q/yDGR9WwwBKuYmOZp/YFlJvUQLVafy/jQ7+ZHyeYvr0sixC/2BXI/NiIl3DlcK5t6T09kx3RfKXJVSwHMCfMmD/Pd3bONJ2fWGDmi4nSnoFWzdG2pXIJrVbuPGnU158tDgajATpWTcaW897nTy8KtKWeKrImifJqapJQswEMQC0ByKSV5ivlVVqpTmk5mt8c+qJarbnUB8wyE8ko6wc+BRAh82+uf8jgXGeXopllPmrUrGTFG2X90YbD4cbsxtwBlJvUQLVafy/jQ7+ZHyeYvr0sixCtN5C5shEvuTE3RtuWyiW0cmOuImuSKK+mJgk1G1CTU8ikleYr5VVaqU5pPJrfHPpKrpxqbm5sJWX9wKcAImSWRluimWU+atSsZMUbXRhz9u6IBAvrvyxbMyZk0ooIW5qQBDM0E2PGOJMHJ+vlPLlvRnMzBm1Fv1VVgV5V+js+5AAGVsJVbCzz1L6AcpMagMqrICcNQg30O+eJbUbmygbTl8cgzeaGpFKN0no7GLOgbZssrORkBRhczYIJHmw2eJVsj9dYveuU8Y452VmwsWjYYmxYO0aYuWOiNFE12iZo2yaWzLa8foqq+rFqPsWa3acNRiAbIkOXxRId+fq7UE/VnW0OCtRQRVUvXC0jipoNqMkpZNJK80HrJEI+lFu1STaRpBpSVkLlpX4TS66qPyUkMNdsAewKFJiB2mO39UcbDocbsxtzB1BuUgNQeRXkpEGogX7dmJXkxwk35myIDEYvG9KEjnz9Xain6s42BwVqqKKqF66WEaW0H+xBjQHIpJXmg9ZJhHxwY1YGbsxv/P29HWFJYrOxHjKz5uMAmyxtGBNV9GrmwQky0dTMJJKuZmU0ZBDjQ2YVGFg2P/oOvWRdZ2Rld4TMbCg6Qo9NjBl4/NLM7khZZ3RcjLlELBmr1raoaQ0lVVVpjsZ5pDEYfhSU/V4oA3NiazcaWIDtbiLkAMr19gzNTVpz6s0Y6J1PRz3YbZP6lWwoDDSBkdSxLcdcI03mj9JtfhVaQ0lVL2U8a2gk70wmpPagYBK0SoIJ+io19dUZpT0rxDPZGuhLIY6NKalJDfX1k9O7JStV9pwVbxAviTYcDjfmCFezMhoyiPEhswoMLJsZfYdesq4zsrI7QmY2FB2hRzfmzHsysCg3ZkATGEkd23LMNdJk/ijd5lehNZRU9VLGs4aGmhA5bsxl/eScU8asX9VhS5OIbm/SiggkqY5oJrDVrMaJofJSEQxbSR6c0Fbk6PY1JHGjNGatR+Ml/R0fcrY+d7fxL1und4Sr2Fg2P/oCyk1q0E9UBTlNxod+7350s5G5ssF0L9HlmL7g/v/4H4zNX7nM0Hqw29yPz75IJNuHN7QtaihrX1lJRnreEnqVmkGtJXMdo+pFlWzzKmwFY2yaqfoY5L+f+e+MzDszsNt6siYZ9EKP/OENrQRjblJ/PYyM6uvY6phXQWZ2szpCfhbsCu1RIa5kDQ3MRs81n4i+ZoQ4ZoBNgtoqOamLBHFQS1NUp0qffxZk4h0pPxEQz5LHRBXK+snJFr2+UN7N5vVHGw6HG3PEjVlBuUkN+omqIKfJ+NCvG7OSXNnQuFoauDGjrGOrY14FmdnN6gj5WbArtEeFuJI1NHSJ51zzibgxgyqU9ZOTLXp9obybzeuPNhyODsbMEglEWHqaLKxk0qoKMiG7ZGCfmGvy3RpKiyWChZdGjj42XFJVlZKKT5n9Gh+uAvn1YGPZzOgLKGfddURr5lPoVf1cTcaHfktjvu07y4y0imX8bMUug14+Xvl4Qu2TSpR6e4asiYEaytoXcX0g9ZGjTuKcJ39KZHu2GZgQPxPia1PvffBnA0vDzN774GODSPKtBBvIgFlCE5Nujpox0COfka99Qbf1ZwOSQY7qr2l9X6ztJ1VV8E8Ejei9U8o72wRaAfr8VIx+tU7NVAUWd13iOdd8vYoVEdcINolVg+YoxIG2amwKBswfeEh+nCL0kol3pPxEoJ+rOapQ1k9Otuj1hfI+Nq8/2nA43JjbqKpKScWnzH6ND1eB/HqwsWxm9AWUs+46ojXzKfSqfq4m40O/bswlGI8bcxXkqL4bM3GNuDEDOdmi1xfK+9i8/mjD4RjnVjbLKGiEzKx5V2CQGHNJacDE9c9aqA1ztSpCX1kB46Bf48NV3URNIhmag5ll82PcoKb6WdcJzWnyuZqMD71jwyUYcBX0gk2qJUO5oQ1qw/q1ryzNQEE11Z6J8FjWw3KcPNLAVNJ+tUEEMgdKYGNs//K1qfc/+NjA2DQTHZTLLWU1UWhu1aUNg+rrJ1XGVz8QAc0E9Pl5Ff+UwQiJMP5t8G+dcM6LP7NbNibZCmuwKGdpRnyxaKwHV25VlaV1RJf4tO4nNK4b2sT1XNG2CnFILp5QkystmTj/CMhkO8LnombtV8majIm2zYo3GM9s6esL5VfAICuvI9GGw+HG7MbcBmqqn3Wd0Jwmn6vJ+NB75seJzIkz6MWN2Y0ZfQzPjZm4G7PCeGZLX18YiDHrqx70xRcsOvULK1fJjArF0pbEW1dFn4huMnNe2jCGOj4b1nM0iUR7LurJijeIx6uS36/x4SpfqgI1P0VzMDMmRO+gpvpZ1wnN0c8VP924xofe2Yp8FJZ+QubECfT/bcvcRGnMUGXP9ZSWDGrMas/RDMKfW1ix8xNY+lmOMQ81mCao/fz+vQ+NN9/5U4t3PzT4ARVbxORkzRNqnApVZS47JplIDej3Xn8VtIL68V+547RBBGPmroFmEkGNuEZQZiEuIb93fe2FRVwXfdA455ixRkqqrhKvuooyJse5WjJfAWtizLSFwRlzdslgJDNP7SPo19dQEm04HG7MbsxtoKb6WdcJzdHPFT/duMaH3t2Yq1DjcWMuoRXUj78bM1RdJV51FWU35irQr6+hJNpwONqMmWWxCl1GOS+X2qxJQ7BhrBcwS8BKQc1Vz8tI1VW1ZKCXrKRxwAj0Pj76hyLU/BTNoVXmr+OmlxrqYQSajE805mDGnIOa8fp9pxLYoRpklTEr9SZdZcbKGMYctis5Z2lm2VXUSEowKr4YhY1xHiPyBy14QQf50K0+NkC1UF8/dwSjrYJMFAZdf5V+Vf1smAM6vAqUeohAVBN9NJvcX4VN7JgvcSLNx79c9EGXeCJqe3oVylYKV+tzQO0ZS3ZjLu9RVkBHog2Hw43ZjbmNXmqohxFoMj4s+m7MVcYQI27MUn+VflX9bsxlK4Wr9TngxlxS3qOsgI5EGw5HmzGztcKXEZRyYWVJrVpYmVIKU6pKX40Zs8Q+AeMkXhpteV5G0CECbINzTg418PBkxRvUr2agdDs+WfMEV6vMT9EcWt3x9yv7Qi81ZB8nwdXex6dq/mCHapBNjFnBhpuYsUIvuoVOnK8yKRgAm7R86Unh6tvvtyAfe9CrgHkk2QRXXf/c1mf+66Kv59kqb2B12F52yahqBVytz1HUnoFIlpbQTF7hyVfAtF8laz4m9W35j5DMTfuI3peqGkqiDYfDjdmNuY1easg+ToKrvY9P1fzBDt2YXf/c1mf+66Kv59kqb7gxV7UdMWPGfuLmSbTS1sLX7cKqX1hQNSj11ZiTHydKY9bzMqJtiStYcqUxBxuuqj/ziUS346Nbsrr1p9ZIvpqfomq00nqq9JvQSw2ZVELVmoyPfhaFu6B3BCPky2i9GPP4oBftl0q4+uY7Hxpsfr77wZ9byNYo5/oDod+/+1GLsGVKhEz4Q4BlWudntrs7JmyZDk6fr+zV6zMygxufc1Vf5z9Lv5Kt8gnsOQsa9YbBVcwyu1QD29elJauOWjJQITn0W6IKTahqRWTQxow+96V5/dGGw+HG7MbcRi81ZFIJVWsyPvpZFO6C3hEs0I25OW7MMTKC+jr/kx8nslU+4cascSKjZsy23n1imS0473ZhZepgcihE5Qp9rFcNlQiofQIRzQfiCvnYsJ7rVf5BQF9UXlV/5hOJbscn8y0j+1WJoQZZwlV6b2LAmXgN5KPcpIYm+uQ3Hx96LynnDxZYGrNuLA8O7RHUmFlkWYLfef8TWLLZ9uQc2N6M/zMsxCzKzMbM/zKyXw3VQP5E6vO5MCTsh0i/xof4qOizTJc019f5z3m9MVdBv1kwwdUmdtIEdNSMgU1scuixim4rqWpFZNDGDG7MEeIK+W7MmXgN5KPcpIYm+uQ3Hx96LynnDxboxpy5Yw3kT6Q+n6tfxhb/58jqs0yXNNfX+c+5G3NJVSsiI2bMPKLcbIXlsjlYWptaWFKr9JMHJ8jkPHNfI/luR0ob1nMgk7j2CFX1Zz6RyD7+mGS+NQ60d6xRyZLHQX/1s48/Jtq70nZHAlggdogZK91+mas5KNNLlTGzvOrCykKvi7Win0stIbljIvPCcTCR+mxu8/MqIm0/lGo8Porq84WptshQ6rNA8yKOEq4219fZogaQrfXjpnc1rAhKM4Ymm9hK1kUNVfmMVeagA0LvS1U9SrThcLgxuzF3oL/62ccfE+1dabsjASzQjblbJlLfjRlYmjM/TnC1ub7OFjWAbK0fN72rJVc23Jir6lGiDYejzZgxJNAbr9smq1q/gv8krZUZTIsclk5yymW0rZXEq/T5QlZy3Aw1WrVePQfyiXPO9jX6GHOT+jOfSLCZrOjVzKUS/DmBKjQz80XjXNLPhs7Qq0qaPAbmp68EUXtWs8RESyslgk5JVb7G9Sq9az3ovPNHW1vjYsqCCyy4xMv5zzYmmZnnJfSPOpRoZua7xkTqY8mPB87as7lOMp6xx0e3hWmr+rychBysazj1WZozP84gp7k+c4b5gw1ka/24oZIs2JDSjEHNGMinryakLsakKp9Ryhx0QNBXKr5jPUq04XC4MbsxuzF3oCpf43rVjVlRfTdm2rI0Z06cQU5zfeYM8wcbyNb6cUMlWbAhbsxAX6n4jvUo0YbD0dCYWz9qOmtaSmsROZsDrczU0ECN/CRuaE6pj2Viqxgqf7gCNMJ58mCjtGHOAUvWLXE15vr6M59I1JsKVqRG1QulsY26PtSPIaTJY2B7aoSAQWKWSmmlgNGiBlXWq+jV0pIBNZZRFtm0qhq6cOv8P7v0Q2uBxurUCHsBtYnU5zNizI8v220QAUaD/DQ4ho4PPzpiZMrxIee9AJlEALXJ0tdFGSvip0Rqxhohh/wm+uTo/MEMshXfQDML1tBtvoIxY8MKn67MpC89r0Lb1lOVz/hkDjog6CsV37EeJdpwONyY3ZjbmHh9qB9DSJPHwPYyLzTcmOspjXPQ+nxGN2ZsyY25zKQvPa9C29ZTlc/4ZA46IOgrFd+xHiXacDjajFkNidvMLce0iChkak5qntDFVOMolPpYMiaK9WKfasOcN7FhIphxacmgxqwVgtaf+URD1HIAc6pH8zPBDM2ETKojmp8JZmgmZFId0fxMcNzofcH2Mi9MVJko6FXAjEtLhiw5I+s6QYW6KcoyypKKAbDQs9XJ4gtc1WVX5yfmV48+X4PQP7tB3TLaev2zb6Zs5RBReh+f4dRnIU7um0wXMGMgogs0bev1tX7uHXccM1A1QDML1oBNZsGG0DZ92ARxoJ6yKo2XaGY99JIFDcYnc9ABQV/N6482HA43ZjdmN2Y35q713ZihSp+F2I1ZIQ7UU1al8RLNrIdesqDB+GQOOiDoq3n90YbD0cGYucGcr9lz2uA8/oGH8Eq/8irQFsjXiOZwXuqrMWOcyWWzSP3V0oxLS6YvjJkaUqlGWX/mE+Omv3Z1/sA9wvD+ZdkaAws8ee+tRnJEQze01WKJ69WS5vnEtV+thAqplhdHsKSy9HP+/r9+bHDOz3J40YRe1eWYtsxG8on0Vx9cf3z6LMFqyQoWla3IGSzoVfpEONf6Wa9Yn1FQzSbGAMk7OxpbE3ppS51VNFEmpyqTkckcdEDQV/P6ow2Hw43ZjXlk4B65MTMbu124m+uD649PnyU48+OEG3M91FlFE2VyqjIZmcxBBwR9Na8/2nA4OhizGhIRhbhe5Vy3fDXCF8SIkF+vj02WRqvnZYTz0ow552oJxkwm5/X1Zz4xKWQ7xh3pxfgzqY5M1j8smCFNjBmSp2b2CcQzrzXUkrMmBvGqq1XGzMYjCygLLhEWfYW4XuVctzRZms+etyCniX62I90RZvv49InrVc77VT9xvcr58OizBLNNnbmyUb80AwqsP93Wz70DjEHtIesooVebVFhPLwq0pZ4qsiYZ9b0zGpmDDggdeSUrKRFtOBxuzG7MbWRSHXFjrrrqxkxcr3Ler/qJ61XOh0efxdeNOQs2hLbUU0XWJKO+d0Yjc9ABoSOvZCUlog2Ho82YuZ1VxsmXRIhjV3r1rI2FVgVnW7Wo18eYMc7kwcl6OU/um9HcjEFb0W+sqoB45hMDBfPLHNHIfn3UETIzwYxB6KNZkqWNG+6CGvN/fe7nRvLFhqh9Zq6cKDObQ1WlMccFXRZWllqWVL5kdDaztRzrVWzgbWv4Xut9FxlnW32iz1hljmtkv27qCJmlPl/40ldswiDqJ6IKo6LPcsxSiz1DWn8z2NwGNRV0Sv0m9Zfrs1ZVooZRbx711JtiE1CghirqeyEnCyYYh0H/EQv06SuVnaiqP9pwONyY3ZjbyKQ6QmYmaKBZkqWNG+6CG3Pyg8TZVp/oM1bJjxOZB3eEzFIfG3ZjzsSNs61asByz1LoxdwsK1FBFfS/kZMEE4zBixqzmqj+fULgK2aWOxMxAc31ssrRhTFTRq5kHJ8hEUzOTSLqaFWNQD/VnPjFuMt8ysgQj88Iaql6EmQlmaGY9zfWzD5XI0sbN/f/xPxil+SnEyamy1eZ220ShSSXYM9uhLJ38/EZfuAh8zYccIrr4Qjk/Wb5VP/PaGqpetElfqKH/6NJdBmbMC0PUmKFJ/RpR/X6Nz+Tqsxxna25HMGONsHBzjk7V/W1ev86WsrbkFqlfjdRbYEm3+VVoDSX1vdRnMgIY56ChL60HquqPNhwON+YIV7NiDOpxY26in32oRJY2btyYoZyf5cKtFluPG3NqaPSuz3KcrbkdcWOuQmsoqe+lPpMRyBx0QNCX1gNV9UcbDkeHrWzAirBPNpn5Ir6aa7zfIXPlztMGkbarAvF4tVafrWY1TgyVl4pg2Ery4IS2Ike3ryGJG2rMscL24o3MJ8ZN5ltGlmCoBULabe4IOfWaSpJNZIIZ5DTXHwRqzKVlqkESKXPq+cfvP9iRLM1Q5dKGQXMwZrYiWTRZalle2YTkhzpxy5QcPIBF+Z2PDZbacn6SqfpqsZB2sztCDmrox96FftWPeSTZxLmhz3KcrbkN0eUbnar72239uj6jDNpjFWSWFUIqPl3VSLegkMpLEFeyhkaWkECBHM4zBx0Q9AVZSUYqOxFtOBxuzBE35kwwg5zm+oPAjRljKOcnmaqf/DiROXEGOaihH3sX+lX/5BrnoPVZiLM1tyG6cKNTdX+7rd+NmRzOMwcdEPQFWUlGKjsRbTgcbcaMQXLzeDg1gmUqxDFXzmmlpqvxJvrYJ+aafLeG0mKJYOGlkaOPDZdQVVX9mU8MFLXD5iQfNTLBDHKy5mOSxI1McAKoN2YobZJz4uVVyJw4Ud9WryapRGnMzHaWS5ZOXqnIcs+S+tY7fzI4Z6OSxZecuODKoqxqLNBE1G6bk3zaqNcnMrj6iYyiPgtx1XYlVF1lyUZB1x/V76X+cn2jr3qogdqyX38ZxLX+9HEaQiugx9JfiGumKnC1CnQ0UupzXo6PxtWtygiaCnF06Le+/mjD4XBjboOqqurPfGKgYH6ZL45Jck0jE8wgJ2s+JkncyAQnADdmWjUxHsw1890xSa5s1OsTGVz9REZRn0XWjbk5tAJ6LP2FuGaqAlerQEcjpT7n5fhoXN2qjKCpEEeHfuvrjzYcjkpjboNawzk/dqJjuoytQg7lkkmcyNn8sfUxSIy5pDRg4vpnLdSGuVoVoa9YVYP6M58YKGwXqxGWZE26YtD6gwBjLi1ZI2qWSko2iJCZOXFCdTRORCET5ara1JiZXSyUwELPgsuPYVhYWVLjchxyWI5pRZztTb4WxDKNDr2o0Zb0ok8O0JZ4v+pP4sYo6rPUgtow5xoBzefe6frT3/pL/SbrM3aSuXKCq/opFP2kUJVf5S9ZWkfq6+d80P5Vr58VnBFtOBxuzG7MlWRNJh035ubGQC+ZE2f0ok8O0JZ4v+pP4sYo6uuCqzacXDlFQPO5d7r+9Lf+Ur/J+oyVZn6cqDJa0E8KVflV/pKldaS+fs4H7V/1+lnBGdGGw9FmzEgjt3LHaYMIopQImkmEr24R18iKnZ+grUp93WTmvLRhDHV8NqznaBKhxyb1Zz7hTDD8OAeTK81PI1VoZmmuoPGylZo0EAfNBKpl/jC7mP9vvf0X4+zC2oKvFLHQE2dhffv9Fny1h8WX5ZXIm+/8qcW7HxrayvWHQZ87nq2/HalafwZXP/ppccvmp67PmCg/7sr82OD1KeSQX66f2YdNkD8x/kIrIF4/PkR6Gf9u6482HA43ZjfmkcGNub8Lh+sTGZw+dzxzo45UrT+Dqx/9tLhl81PXZzfm8Y1/t/VHGw5HB2Ougv9IR1Tj2g3nMRL+c55zhkZbKdgw1guYJWCloOaq52Wk6qpaMtBLk/ozn3AmmCpjbk5psaUZE0lNjNJukysn9KpCtVXzn4WAx5hNSH2wQZcJzmMkbFeSz0altkLZ9YdHv9v1c2Lqp69yfqp+acyYMRDHaFFGs/n6D/31F62fcRj0/a3Xb1J/tOFwuDG7MY8Mbsycx8iQGY/ra6tSv9v1c2Lqp69yfqq+G3Pv49+k/mjD4WgzZv4jnS8LKHTPf/LzNQS616tAceQoXK3SV2PGLLFPwDiJl0ZbnpcRdIgA2+Cck0MN46ufq4MbH666PvpYXWmWzck81cgSuqJKhwqjMYfFgq0tvgwCgxgfWilcdX3XH5++GnP2Ha4EOdhzJm7U63N1dMeHq73rRxsOhxuzG/OI6bsxp2FJcHVixj/JJrjq+ueqvhszVwetH204HG3GrP/pzbl+Qf/379p/3Ztu6z/5iZAJ/F/fdPPmO5/A1Xc/+HOLCn015uTHidKY9byMaFviCpZcZczjq3/Q4+P6qs/mD4anRqhU2baaKGQJRpaQoZn0kiUYXKXCuFUlm2wawZ77Oz4xMrL3N0Zcf1L1MVql3pgBY26iz/nojs8g9KMNh8ON2Y15xPQxNjfmqvGJkZG9vzHi+pOqn7my4cY8aP1ow+FoM2a+9k2X/Gc758B/nmd3K0FBdE8mRVAiylX6WK8aKhFQ+wQimg/EFfKxYT3Xq/yDgL7GVz/QKv7PMNDxloR4L+MDtIr/8zzWP2tpLarsuTTmzDsNvQpZQg3kay96lar4cgfVxi+ngNTPeX/HB4XRvb8ouP5k6bOe8yUvJfPgjmDM9fpUOLrjg8Ig9KMNh8ON2Y05Qqv4P4dYX43NjXnixx8F1z9X9VnPM1c2Mg/uiBtz/J/j0o82HI42Y0Yo9ZRRdcOAq7EI/aK5dFylnzw4QSbnmfsayXc7UtqwngOZxLXH8dVf0qYWaIu4fs/6WBpghKUZK2qcRMp8zdGrGofUJEG+WnLbJnaw5LaIkIYl0TYa4xqfetrUXL+gTe080y/XeX4WVb5GtARjntz6M6mOtKkNjX604XC4Mbsxd6BNbSj11djcmCd+/OtpU3P9gja1IdMv13k35onRjzYcjjZjpgHQgG74z/byhpWQ8wf7b/YWdNwCnXp9zmnLf+bzhazkuBlqtGq9eg7kE+ec7Wv0MWZqODt8/ak/ZoYfp7s+5/3Vx9h0WxvUVqG0Vc3Rq9BcQfvFele13iTQbswBDBs0PrjxIe76tE3irVauX6HPGo4ZA6bbxJjJwZ4nq/7YagT1ow2Hw43ZjXmE9TE2N+aq8SHu+rRN4q1Wrl+hzxruxjzx+tGGwzGGMXOTgK/Lc6vUjDVCDvl0hhpFJHFDPxhfOqdowDKxVQyVP1wBGuE8ebBR2jDngCXrlng0Zhvfs5VQFVBtt/WTzw0gx/UHoY+x8aOjs6bYQs0S+1RDLUmOW5MDpRmfrQFalRABbJiqkisbmjO48SHH9V2/uT62ykqe+W5DUKjSh9EdHxiEfrThcLgxuzGPsD7G5sZcNT7kuL7rN9d3YyYCqE2MfrThcLQZM6l0ibkm902mC5gxENEbo8as/1Gv+nwACuU/8ykOS8ZEsV7sU22Y8yY2TAQzLi0ZojHLdoTSbf3AVfLPvrnN9QeljykmV05ge2qiChaL3ZbGXBqwovqYMTUQUarMGAXaDnp8XN/1m+s3MWauVuWgwDyf+PpHVz/acDjcmN2YR17fjXlyx9/1zyV9N2ZlIvWjDYejzZjpsrRkpepmKNwYviYea7X/un//I/SJcP7+v35scE6+GjPGmVw2i9RfLc24tGT6wpipIVYbGF/9/JBcr3IDiES1gOv3V58/G8efV2NRWLPntME5YIeQeW1HVKFbffI1ojmca/2DHh/X1xzOXT/+T9Fn9c6W9ES5/pdfCiu/AjaR9RPhfLT0ow2Hw43Zjfkc0e/WODMP7ogqdKtPvkY0h3Otf9Dj4/qaw7nrx/8p+qze2ZKecGMmwnl/9aMNh6PSmNmmzlzZKG9DCQps3/F/gPOf9uhTkP7HvoJNlkar52WE89KMOedqCcZMJudsKcSBi+fd1U9cr3KuWxaur1c575d+csFkfpyn/WRDI+VPm9RQiSjE9SrnSTxofhKp18+KN/hc+uk4H5XxJ65XOXd9IK5XOR8e/XpjLmG1z4IGOsx/1R/18RmcfrThcLgxuzG3QVyvcj4q+hge9G6cRBTiepXzJB40P4nU62fFG3wu/XScj8r4E9ernLs+ENernA+PvhvzZOlHGw5HmzHTQG8M9gxpxDPY3AC1bXT4eTUdx4Lkg/FR+QD8n+QYM8aZPDhZL+fJfTOamzFoK/p92wp7r1VwRvP6z2a2hluvchtc/2zmYPVZDjDCaIdimbwgUyEOVcbMF7XOpvVHv6r+UR9/1ycyivpVRltFvTEz/1V/1MdncPrRhsPhxuzGfA7quzETcX0428r1x9Z3Y87EjbOtBqsfbTgcbcbMf24zoNkodwQz1ojeJHTiAhS6R58i+Pq4vpAM+L/BscnShjFRRa9mHpwgE03NTCLpKjXogFJtt/WTQ0TVygiZrp8SsgiZveirfZYwP1k+1Fyrfv7EVcgudSRmFvrDMz6unxoark+kym5LyNT/JOO8l/WfHCLjq38U9aMNh8ONOcJVaqgauOb1k0NE1coIma7PWIGOGCPZy/hnTpnB/HRjTglZhEzXTwlZhMxzT19X8nrIdGOGXvSjDYdjjK3sbuEmATosT5SCvpbCx2MTgC+a85/8bDWrcWKovFQEw1aSBye0FTm6fQ1J3FBjZnCpWWlef8yhYch8652PDdefXP02sxT7BOLxagB7ZhObH0qpucaG0XRPG6oTrwrDPz6u7/q0LV1ArVfRNV8tWWd+qT/o+kdRP9pwONyYI27M54M+s7HKOInHqwE3ZsX1zx/90gXcmAetH204HG3GTAcMa9VtgKqr3B4UWNS4MRSKPkUQ4ZVmlMtHwj4x1+S7NZQWSwQLL40cfWy4hKp00LXaJvW/9c6fDM7Z6ECHHFq5/vDoMz+xUgy4KoIlK8R1ntNKTX3Q9bu+6w9CnzWc9VzX9rTUG7gAcaCVzn+ei1KfyOiOD5H+6kcbDocbcxtUNVk3xvVpNZH6zM/ShstI5soGcZ3ntHJjdn0io6vPGs56rmt7WuoNXIA40MqNeXz60YbD0WbMdEMqQwxqw5xrBDSfm8GixlLF/22u+hQKFEocg8SYS0oDJq5/1kJtmKtVEfqKwx1qYICoijjbF83r58v03BiGfnj033z7L8bg9Ed9fNBn9raB14ZzfuyEMbP0RPMOOcNQv+vTyvV719dVvQnxH6bhSeG5mNz6YVT0ow2Hw43ZjXlk6p8YfWZvG27Mrn9e6uuq3gQ35l70ow2Ho82YzzZo8dbbfzEY4mz0O8JXY8jn9hB5850/tTBXOPtns1SfyDvvt9BNZs5LG8ZQx2fDeo4mEXrk/7pncBk+Is3r5//SZ6A18+33WwyDPsYMo1i/tnJ913d9IoPW5x+drOrAOs8/TImU639z/VEfn37pRxsOhxuzG/PI1K+tXN/1XZ/IoPXdmCdGP9pwODoYMyABRNjEY9C5AXobuDGcA/85T6H8h3wSN1QfG8Z6AbMErBTUXPW8jFRdVUsGemGYGLI4cI3rJ8ImBvkpzYhqQ6DPnyHBmAehr61c3/Uhqrn+OaHP2l61/veuT35KM6LaeTD+0YbD4cbsxtw3fW3l+q4PUc31zwl91vaq9b93ffJTmhHVzoPxjzYcjjZj5j+9+T+lFbrnP8n5v6mR06tAceRgALve+sjg5Z1EkmxCjRmzxD4B4yReGm15XkbQIQJsg3NODjVo/QqVV9XPZ+92fBSu6vhrj9CLvurQSqFt7/XrXda+uNq7fn/np8JV13d98l1f4arr1+tHEw3HX8IR/8e4DjdmN+a+1e/G7Prku77CVdc/t/WjiYajz8as/+nNuX5B/Pfv2n99W92t/yQnkv6r3OD/+uZj6NJcGnOJGnPy40RpzHpeRrQtcQVLrjLmWP87n8CnywrO6Hp8Cv13P/hzCxl/lMtxG5++KpSg1nv9VMsdH4S+jg/n45yfru/6ru/6Peu/+8f/zYj22dfDjdmN2Y3Z9V3f9V2/a/0JMma+9k2X/Gf72e5b8J//8X+GQimRuC7EwAJ97J2PDV5CQmRHYMvvWpCJ9aqhEgG1TyCi+UBcIR8b1nO9yj8I6IvbwyeKN6n4RGX9StX4MCFKfaYIIw+qxrjtePMjQ+PQRF/zB10/1XLHM9lE7+ODQrfz0/VpFf+n67u+6/egjyW7MbsxuzFHUBj0g+f6ru/6US1Aq/g/z3v9CTVmCj3bcR36kXTZxUKABZrtTV2yT33wCcSTByfQ5zxzXyP5bkdKG9ZzIJO49sgn0i+y87mwtKr6sbo0CIaqlZG2L8rLjU/NDfpCX3vhnJyoFqjSJ3Ni6keNO05fKNfr19ev+uRkU7EjbWquX9Cm5voFbWquX9Cmdl7qR8tscNR/EexPcsRQONyY3ZjdmF3f9dtoU3P9gja181I/WmaDow/GTEFAQRSh2wJ/sP/ef6/13/gGmbrgLv9v/91gaQZdrDlX+GNhtCqXb76QlRw3Q41WrVfPgXzinLN9jT7GzGdk6LUGwGay4o36+pvAnwZjbIlsefMjI+vIoC/tJd6p8OP0YahfzT5NAKPU1/lT1s8cO/tgfKJPfmzVeH66vuvTNom3Wrm+6/egHy1zXAcb4NGNw4F+vBwON2Y3Zjdm13d913f9LvSjZY7r6Jsx86Vzij5bOrQ+ADksuGyZ6qKsyzTnihqDbrdimdgqhsofrgCNcJ482ChtmHPAknVLPBqz3b+zn5TPAmzLq+UoVfXXo/ol5GQdGfSl9qbjPwz1ay9pAhgoa2Y5f7R+IsBsJD9NTqPb+en6rp/EDdcH1Fy/uX40yx6O0pjRj5fD4cbsxuzG7Pqu7/qu30g/mmUPR9fGTCl8JD4AhfKf+TQGrpLPa8lYcFmCMQ8WZV2mOVcwBo1gyZgo1ot9qg1z3sSGiWDGpSVDNGbZ7kj+YWBFWqFS1o/J1YOBMUrAn5cAtTeFvsjXCs++GW7y69fKuePMB6Ceqvmj9Su66URkfPPT9V2fiOsrrt9cH5es/zJXkyO6cThKfQ43ZjdmN2bXd33Xd/1PZBOqj0tOgjHzkSid8/f/9WODc75Wzg+x9SofgGVXF2tggS4NAMq4GjPGmVw2i9RfLc24tGT6wpj5RHwKqLc0qPpcmZMlNAd9zAzqe6Sv5N+GVjsM9aOmlqwzgaqq5g+R9OQYzLf4P99voTmco8B5/fwkEtUCru/6rh//p+tLWyj1o032fERPDkeVvhuzG7Mbs+u3/qcR1QKu7/quH/9n0I822fMRPTkcVfodjJmC9D/2FeKQPCChC3EkfPmoygDKODZZGq2elxHOSzPmnKslGDOZnOunwGy0tpKyfgzsk49/diNXI5rfHPrCDgG1NPgJ4hNfP2rkl62yIg2dUbqlw2Q9e96CnG7np0ZcH4jrVc5dH4jrVc5dH4jrVc7PB/1okz0f0ZPDUaXvxuzG7Mbs+q4fIa5XOXd9IK5XOT8f9KNN9nxETw5HlX6bMceC5IPxUfkA/J/kxHV5LZdgiPEKYyai8dvv+paBMWOcyYOT9XKe3DejuRmDtqJfKm9uaVo/lgZsNbeNQ0GSaoj2BdhzqT9Z9aNGflurMAcAZWaOzi4eg7dt4r3X+r1/BrOu+fxkuru+68PZVq7v+uPXjzY5roOvjHFETw5Hlb4bsxuzG7Pru77ru/4Y+tEmx3VETw5H9ORwVOm3GTP/OU8SXx/XF5IB/zc1CyuLLEu5LsfAoox5qAHoIg5Y8sqVG42///bjBjZZ2jAmqujVzIMTZKKpmUkkXaUSrbMKrT/5maH2A4xDNjgG8Uy2Bu0RiGPDSmpSg+r0q37UuOPoRM4mG/TC/AF9PEAjzEamb/P5SQ4R108NDdcn4vqck+n6KSGLkKn60Sy7PKInh4NIdOZwoE+cw405wlU35l7qR82N2fXJIeL6qaHh+kRGVz+aZZdH9ORwEImeHA70iXN02MrWUvh4bALwRXP+k58llYWbRZkfybD4pjXdwCpYstMKbhDBCJ9+cqGBJQNbzWqcGCovFcGwleTBCW1Fjm5fQxI3MGYqaWLP1A9qaYqOQ3KmbHywsUy8I9pjSZY8Jtq2X/Wjxh2PItKKGUImV6MxM+nf+djgYeDh4fFQms/PmEND13f9gOu7fu/6vFAzWmYPR/TkcKAfL4TDjTnixpwVb2idTepHzY3Z9V3f9ZNs4tzQnwRj5gOQROm80oxy+UhvvfMngyWV5ZWllmVXl2z984Us2ZyDWrJy9Q3TDcw1+W4NpcUSwcJLI8eeseESraTenvlEUGVsoKORBidFsLFMvCPaY0mWPCbatl/1o8Y5OU2MmYeHORYfGHmodDY2n5+cs5Hl+q5P3PVp5fq960fLDEfcoQ5HDDU+ojOHI4bC4cbchlbixgxabSo+RdyYXd/1ibs+rc4H/WiZ4YieHI4YanxETw5HDIWjzZj5GHRMoUChxPkyemnMLMpxOYawHOtVzjE8/aoXRoglX3ThpQbGXFIaMHH9sxZqw1ytimDGt1xxuUG/ZW1EqFzhEwHmpMQRCJSWRrz5Jvbif/6t8YsP/rux/PUW2jtkTcZE22bFG6l4o3n9qHHelh9mgl5FgVkEzDEeAGYdjwHbR3ztImY2mJ88eDxa8XFqoN98/rt+Ejdc3/XPN/1omeGInhyOGGp8RE8ORwyFw43ZjdmN2Rcm13d91+9CP1pmOKInhyOGGh/Rk8MRQ+FoM+azBbV46+2/GETeeb8F/5c4hbJE6tLMskuEhZglXq9yjtVhe4Ax6yYz56UNY6jjs2E9R5MIPd5+9TUG/zjQ2qgWa6R+IFIVZ3OYEeA8WhSE8dHRK0EHM4Yvrz1paIQcHdsqyCwjVfHx1a+V0JZWZOpVIlg+c4mvZjDpeTyIvPnOn1qYK581Zqifn8SZyW+/36KJvrbqm77UrK1cf4L0B31/Xf+81I+W2eCoN+zoyeGIoXC4MbsxuzEP8sGWmrWV60+Q/qDvr+ufl/rRMhscfTNmoEQgwiaAPkgsviy15aLMOXAVk8OGgQg2jPUCZglYKai56nkZqbqqlgz0gjHrhnZZp5piEzA5RgN7w9LU2LImGTeuPGzcvO5V47aNp40ZG04aVyw4aGTJfafb+snX+05bzssZgm3rjOKRiA9G2G7iQWKjSfOr5qc+eBDVwmOWxFuRQl9b9a6fPlRCW7l+Jm5oq971B31/XR+i2nmmHy2z5yN6cjhiKBxuzG7MlXRbP/l632nLeTlD3JhdX9FWvesP+v66PkS180w/WmbPR/TkcMRQONqM+f6frTP4P70V4lXosgtZQqI0PLaO1ZgxS+wTME7ipdGW52UEHSLANjjn5FAD9kxVWieV8ykufXKvceGPXmnx441G+oAdUevC3rKEhkx5ca9xxfyDxjWLDhl3bThpTJm337hm+QnjinmHjStfOmpcvew1475dvzEun3vYmPL8AaOs/9Kf7zauXnLcuG75KePLa04bWjlQPxBRfSLMh3JWgF7FaNkez9Zogy9cAA8YP7jSHOYnV9mSIp/HSa8CD2eSTXCVTSpaKVztVp8KeX2pVp5kE7Ttb/30pfSirzq0Umjbe/2jdX8Vro6WPiN8Ls3PiZw/0TIrjvrta47oxuFAP14IhxuzG7Mbsy98Y+irDq0U2vZe/2jdX4Wro6XPCLsxJ3Gjef3RMiuOPhvz7/7wZyPzA2PXyT8kyPnnNz80fh3Ikg3NVLA3/TFSaczJjxOlMet5GdG2xBUsuYkxlz+a4lNkH9ZIg5M+9fjGR6Ht6X953yA/EzG++NRO4zMPrTD+y4NLjE//3Xzjoh9tM7DhK186Zly38pRx/crTxp2bf2lMeW6P8YXHtxg3r33duGbZCQN7vmbpCeOKeUeMC3+40fj89182sF5Q/SteOmgQ1w3tzJWN5MoGG9oYs26S66PFttK7H/zZ4MFjKdEcpvXv3/2oRdiSIpJ2pQy++sFj9uY7n8BV9NmkipFwrj+Q6EJfaisXvpKu9RvUj3LZ7/j0VaEEtd7rp9oRuL+jri9jey7NT9QGPX/wSqyXg0jzI7pxON78/buJeDkcbsxuzG7MvvCNoa8KJaj1Xj/VjsD9HXV9GdtzaX6iNuj5g1dGTw4HkeZH9ORwdGHM/y2AGQDxf3nrwwS2AZoJ5Jdgb1gdYIFYrxoqEVD7BCKaD8QV8rFhPdermDHcfeNNBlVpnWrMgxsfQB9rR41WSdxAGXtmO/oz31ppYMlffHS7cdGPt7Z4pMUlj+8wprxwwMCGL35qhzHlxX3G3Vt/ZVy37FWDje5b1p0xrl32mnHpE3uMC7+/0ajSx7Yv+tk2A3vGejNXNpIrJ/gSGSbNeWnPoPnZpQQPDw9SfOTCthUPJI8fER5CHlF+UAEosG0V1QK0iv+z0M/KMFggqJbKifDptvyuRdbEqNJvXr+q0S//9NE4NNHX/EHXT7XDeX9HXT8bRoO7eS7NT9QGPX/wyujJ4SDS5IhuHA615Dd++V+NmBQON2Y3ZjfmtgcPBV/40Nf8QddPtcN5f0ddPxtGg7t5Ls1P1AY9f/DK6MnhINLkiJ4cji6MWS3hdNhEJaL814CaBGAeXAXy1XKwN/1SlRqzgk1ynrmvkXy3I6UN6zmQSTy5coKqtE4q5xMNbnyIoE8rItoXbZOsgT1fs/CQgYle8vjOxJTnDhjXLD5hXLusxaVP7TU+//DLxhcf325gxtcuPdFixWvGDateN8j88rozLVadNlT/wu+vNy766VbjlpdPGJfN3WfQCntmW7vemBW+VsajxQJBnCWDczasNAf08Wt/5Fq0RfSHEPLgkRMf3VpUTftliQEqpFoqJ8I/QYB4ff1lpKr+1NygL/S1F87JiWq140Mm4z/o+lEbtvs76vo6buf2/KTt4OZPtMkuD8w7unE4Skt2Y3ZjdmP2hc+NeQza1EZcX8ft3J6ftB3c/Ik22eXRB2P+7VsfGWyTYgOlbYDaA60wDzK5WlIaMxHADmd95ZYENlllz6AWCxrJkg29ql/4AmqgnrLOQY9Pt/rvfvC/GVg+9nzdspMGX8vip1OXvXDQuOTnuwxslY3oC76z1mA7+pKf7TK+9OReg59dkX/14uPGNUtOGDesfM1AHzPm5Sc3LDtkXDNvl8GmetzofmSbgT3Dytf/1eDhKeHhwZiB5QM7LxcLHj+I+fL4sQ3FA8bLAdj6O/v42VOXHrwWLMfkx1bhgSSu24a0Vf30tBtUorVptZwrfLqy/uZo/UR40WnWkUFf2kv8pMX4cFUpl1Hob/3DeX9HXT8NtcFI6tjqaHOu9Pf+Ehnc/Bz0/Ik22eUR3Tgcasknz/zOcGPukO/G7MasDx75sZUvfIIb8+jqp6E2GEkdWx1tzpX+3l8ibsxdGzOWgD2oJShqDBgPkSzN0Ew0sT2sTn+MBFxVYwY1zhLsFqMFrJd4ljwm1KC1US3xQY9Pt/pYMhGuYs+ADWO9gGUS5wUjnF+58Jhx+YuHjGsWHW8Rtr6xara7Me+rFh4z2LK+aUGL657Znvjc99YZaPLSEqz6kud2G9hzeg4TPDBsRgEPEld5XDmvevBolZ5Sg4eKB4yH6r0APy8hAjyc5HMOuvDRiof27KOb69MvlWhtWi3nCp+Oz0tblph60sfsCDlZRwZ96fJUNT5JyuCfRzrySn/rH+b7O+r6jBsjqWOro8250t/7C+RkHRn01cv8HPT8iTbZ4Ig+LIdaMrgxdwE1uDG7MfvCB27M5Iy6PuPGSOrY6mhzrvT3/gI5WUcGffUyPwc9f6JNNjiiG8uRubLRhTE3sQQgs9t87I1t4eTHmfllrpzIHLTv0LtWBVTL1W4/72Tlk4M9Y7psa18xvwUb3Zc9t8u4avEx40s/32Ow+axGDmxrf+nZfQY/oLr4p9uMaxceNG5Yccy4bslh44tP7zTQv3bhUePS5/cYX/jRRuOyn28zSnvmsVF4OLnK48p5+eBpK33kWJ54tHiFHltV6XlL6KYWEZY8FHhQaYtylT69Uwn1U6FWy7minw5YBOthHOgFeLkp6Cgp9EU+1UI5Pnq1ahmF/tavlTNi6eYa1FM1/lq/0q/7O+r6jB4jyZjrnNRzpb/3t7zLCn2RT7VQjo9e1fmpynyiNHkM8qvGR/UVHX9cki9zcV4e0YflyPzYUDNWokQ43Jgj9K5VgRuzGzNtUa7Sp3cqoX4q1Go5V/TTQbbGdYRxoBeYmIWvpL/1a+WMWLq5BvVUjb/Wr/Tr/o66PqPHSDLmOif1XOnv/S3vskJf5FMtlOOjV88LY87WdyM5QUItgUh9PpB/5WXXG1gd28VYsoIFqiU/cPsdhkYyT+0Resz82KAeqqVy/aSQfUwjDY5BpD4fyNdMyNKMJG4Qqc/HntlevuSxHcZFP91mXD3/gHHxYzuMz35ruXHhwxuMSx/fZbDpjSVfteiYceW8owY/lLrgH9YYcYs7RND/fPgJFsZ804qTxgUPv2z8p/vmGp95cJlx7Yu7DOyZH1Ppw5OeZIMHTJcGzvWR03wePF4UwOL1/r9+bPCAEUkrl8HPJOL/fL+F5nCOAufkV+nTu9YDVKufQqmKZytdQnNYkliMQBepEvrSJZKagU+kkXo16G/9qA3n/SUS1QKjpc/o6XjCuTQ/URjc/Ik2WRzRgYsj82Mjc+KMKBcON2Y3ZjdmX/jcmN2YR35+ojC4+RNtsjiiDxdH5spG5sQZUS4cXRgzZqBfaIIyU9EvN6kxg9oz55giZglqyUrmr12h+tovqCVDE2PufXySbEIzu9Xnx1TRmMNXsbDPT03/mXHx49sNXj9ywXfXGp/++nzjr7650GBb+/LnDxn37fmNwY+m4le6wqtF+DoYxHj4qtd/vv9FA31+WPVX31hsfGrWk8aFP1hkoI8984DpIwQ86jxs+uDxyFU9eAqPHNtWuiUVH7x43oIcHk4eSCIoKMQh687QeiLyo6+0giTKOJ9aFcpPqvnNoS9GW8c8+wgGcRbTTCSjv/WjRn7ZKivS0DsyiPurkVHUz4bL0PGMnEPzE4U0ebKqMhFDR6zJ+EeblCM6cHFkfpzInDjBF8GiaDjcmN2Y3Zh94evwKdyYNTKK+tlwGTqeETfmMFZNxj/apBzRh4sj8+NE5seJMYy5tAeWeMxDLQS4qpkKcVphJxihGh7UW2Ny0ETm0InMfRNZcwNl7RFKSwZa8an5XMAnTYNjpMExdBw4V4jTivGhFXEgM4kbSdxQHc4xY+DHVNGYgyXz86fP//AV47pVp4wvPbXXuOjRLQYb3XDhD18xLvnpTuNLz+432KC+5OldBl8io+2lT5jfR8v/wo83GWyAo/+FRzYZf/O9NQYb3Vc/v9NAv2/GHBYX0E0wFjIePx6zt21Fe6/1PoEMHrz4QMrCpwp8SYR4eraNtkqEGK9Y+IhonM8LfIo2nYIk1RDtCxj5Ur+5Jatm7/WjRn5bq7M310CZkR/c/WU5Hl39NDmNtpEUYjyMqt5HvRca7/3+1qN9QbfzEwXy21r1af7gktF7K47MiRNYL2SunECfw425DTdmN2Zf+NyY3ZiJaLz3+1uP9gXdzk8UyG9r1af5g0tGB644Mj9O9GTM2ANLvJoBEY1X2YNCnJdm6B9mKDe0AVPEpDnXCMZJZvLXhtBKdRTti0yFass/LJEGxyCi8V7Gh3gSN4hovNTHjE+HF39iyWrMmCvGfOWiw8YXHtlsfPahlcbnvvuywVY2fPbbyw02qPmzFlOeOWBc+MMNBvGrFhwz+MMY6GPMN6x53cC20f+rbywx2Mr+/MPzjYt+vNxAB3vWxwl4qPRx5ZzHVR+2+PgFWDjSqpQ9fqARHjkeP7aziPDzCX0hH/A1EJR5yOkxK96gHqrVT6GfBVAAPhHKgE4mbhBXzXq0RyDOMqekJjWoTr/qR20Y7i85REZRn5Fh/BmxbPANxvNcmp+0Gtz8id5bcWROnMB03Zg7QCvVUbQvMhU3Zjfm1NA4nxc+RXX6VT9qw3B/ySEyivqMDOPPiGWDbzCe59L8pNXg5k904Ioj8+MEptsHY2a5r7IEJXmDoZkax3hA9dUyS7DJ0kqTg2ZXq+JVkMl51nWCCpdsO2mU9TMC+qnTsCTIBM3UeBqcHvVPB0smU+Nqz1Ne2Gtc9LNtCb6udcH3Vht/+6MtBl/LwjK/9Mxe48oFx4zbN/3SuPS5PQab1XDF3MPGrRt+YaB/WfizGarP6z//+u/XGLxm5Nr5e4wvPLrZuHPdcQN75uHRx14fUc55OMtHjp9JkMnV+OCxqL3zscHDxuLF46ewVaiPIssfm4T80IItL5SpkB7pnUpS8QbV6qcAIqBLnqI66WNm+ixDqlyF9liSJY+Jtu1X/agNw/2NOTQcQf3zc36SOej5E31YjsyJMzL3rSHacDjcmN2Y3ZjbHjxf+JqgbftVP2rDcH9jDg1HUP/8nJ9kDnr+RDeWI3PijMx9a4g2HI4Oxqz2kFzByFwhQSbWwnlVRPXZIobMETPUbkFtFYjUx5Wsiwytbdn2Uwmtn080uPEh0i99jPmz315mfOabSw3M+ItPbTW+uuaoccuqQ8Zl83YavHrzxrVnjKvmHzOw4Uuf3m3wmk9eOcLGNdvanwt/xIIXeWLJU57fY1w2/6Bx+8uvGTeuOWXcuvGkcdWSIy2CPsbMK0d4tEAfSz3nsW/y4LF48ciVixqPHHEWOI3wykPasuS99c6fDJTphR7pPa1Hhv55O61cI1C18IGqJfEUYZRUuQrtsSRLHhNt26/6UeOcnMm6v5yzUTyK+ufn/NRMahjE/IluHI7MgzMy3x2TaMPhcGPugNbmxuzGTFtduFGmF3qkd6oCFiauauUagVFZ+BRt26/6UeOcnMm6v5y7McOozE/NpIZBzJ/oyeHInDgj890xiTYcjjZj1gW9uT2U+cS1FXEgH9srjTC545hgsWrYShMDVsoaOF++45SBMWv9gx6f/upjzDcv2W/cMH+ncevqI8bNyw8Y17+wzfjKsv3GrauOGFPm7TYu+NE649MPLDA+NeMJ44LvrjY+/8jLxmf/fpnxt49vNG5cc8a45NndxpQXDrSY3+KS5/cYbFnzas8p8w4Yt2x83bhu8X6DV4Fe9MOlBvasYNU8TuWDp4+fXtUHD3jYeMB4CHnM2J7iazUsczyK5ABtifNjFTTphR7pPdYDoSq9yrlGgMVLiQqBcskj3nyTkDFkPJe/3kJ7h6zJmGjbrHgjFW80rx81ztvyJ/z+YnIszeiMlj5jwigxYoxeHE845+anZrbVM4D5k3lwRua4DYk2HA435khZA+duzG7MtCV+Pi98irbNijdS8Ubz+lHjvC3fjdnnZ9GqRDPb6hl1Y2YRZ4nXH/BU2YNaApSWUP5AiExsr/wKGHHQ+CCo6ouqiK/YcSqh9Q96fPqrjzE/uOeMccfaV40Zm08ad288bty66lCgZckzNr1m3Dh/l3HV4xuMz3/zKeOKn6w1rn1ic2CTcdVj61s8us645PkdxtQ1R4wbVr5u3Lj8VeO6pUeMKXP3GdcsO2ncsPyYcVn4gtiVz2w3PjXjZ8YXfrjJuOTxXYHWH8ZgS5zHlUdXHy0WCB48lgC9SoQlgwePr8bwUPH4EXnznT+1ePdD4+wD2eKtt/9iEHnn/RZ8JYQHFU16oUd6J8JCQIV6lXPgE0EZZ/MQBc7jEgNBX3svQYfRgy+vPWlohJyythIyy0hVfHz1ayW0pRWZepXI4O6vZr79fovR0j8/56dmUtug50/mxwm12/qfSAGtcGEON+YOfbkxuzH7wqeQWUaq4uOrXyuhLa3I1KtEBnd/NdONuYyP7/4q6OhsdGPGhTnajFntgUUfe1BKM4DkBAnUSrhaGiFoPLlmhuY0IWue0JyqGtSYtf5Bj09/9THmW1YcMm5eut+YtvygMX3NEWPmhhPG13aeMR47/htjzrYzxtQFuwK7jVuf2WJc/cOXjCk/WGHc8OIO47a1R43b17RA/6InNhtfeHyLcfGT2w1+ZPXlNaeN+3b8s3HFgoPG1S/ubDF3l4Exfzq83oQXnlz0+BbjupWnDH1QebSAx4/zqseSBw945OKDF7YTWcjYyOLBAx5RIKKbhFDfO+fA1bTiNITPixrLH0ueLnxZk4wbVx42bl73qnHbxtPGjA0nDcY/S+473dZPvo4bbTkvR3gQ95f8lGZEtbBMJ/FWZCj1dTTqR49z4KreiyZ0e39L+js/J3f+lJZcRZV+tOFwuDFHqmpwY3ZjJuILX7d0Wz/5Om605bwc4UHcX/JTmhHV3JgLur2/JW7Mqh9tOBwdjBnYFGXRV5P4lcDVqu3TepbtOGU0N0glOWtDsuaJqr5opZYMWv+gx6e/+hjzXSsOGXcu2t9i4d4Wi/a1COezNr1mzNn6uvHAjjeMR47/xpi15ZQxe2uLGWuOGvesf9WYtfmU8dhrvzWmrz5m3DBvp3HBw2sMXirCj7I4v3rJceO65acMTPrvDvyz8ZWNJ41rlp8wrph32LjypaPG1cteM2bYs7rx9OVzDxs8fjxawMOm6FUePLbX9PEDvtABPGBsUvGlD4Wr2nbT7z40tK+sDEOvUjl/COTSJ/cajAk/KuN1LuX40Eph+QMi9+36jcH4qD6vcLl2vp3svWlBiykvtrhi/kHjmkWHjLs2nDSmzNtvVI1/lf4g6iei45YNqaFXu72/xLOba3CVLWXyWS71KmB+STbBVZ0/qYxEL/oo+Pysn5/0qJ8r+8iGXh22+RNtOBxuzB36olXmyobWP+jx6a++G3N63hLlg+ELX/3CN+j6iei4ZUNq6NVhW1h1/qQyEr3oo+Dzs35+0qN+ruwjG3p12OZPtOFwVBqzmgHnpUlw3sQYSmjLCy+TgxpqkGqciuY0IWue0BytIfPjRFn/oMenX/oY833bzxjfOfwrY+b6E8bUpQeNr+9+w5i9+ZSBPc/edMqYsfaYccszm42vPLXBuPoHLxm3PbfDwObvWX/cmLP9deP2tceMOdtPGZc8ucW44MfrjCvn7zauWXbC4PG+ZukJ44p5R4xLHt9ofP77Lxuf/rv5xkU/2mbwGPMTrKoN7eypM9JTZ7BhxYOnm2zp2TPYVnr3gz+3CFtSRDRH4QsjKGtfWRkGcaql8utXnjbu3PxLY8pzeww2/G9e+7pRNT4X/nCjwfigA4zPlS8dM6546aCB/r0H/sm4Zd2rxnVLDhi3b3rd4Ct4LH9TXrSTfV98aqfxmYdWGP/lwSVGOf7oM/6Drp/44O6vxpW4aL77UYuwpUyEtsBXq1hG33znE7haNX94qUXqyBifPm19ftbPT/od3fkTbTgcbswRrSHz40RZ/6DHp1/6bsxNHjxf+OoXvkHXT3xw91fjSr8W1nL+uDHr/UXfjbm8v+hHGw5H5Ze/WPoxA5Z+zgFLACJN7AG4qvpsay/dftJQg1TjVDJ/HZOseUL7ogZeJwKZKxtV9Q96fHrR589BYsx3rTxsYMN3rT5qzNx4ynj46K+NOZtPGGx0f3PPL4x7N58y2O6+5ektBpZ8x9ydxm3Pb09Mnb/LQP+uDa8aNy3cY9y68pDxlcB1y1412Mi6Zd0Zgxd/XvrEHuPC7280eOS++Oh2g59LXfCdNcYlj+8w+MMYPH48WtlTZ6SnLsGXUHgIOS8fv3pKhawLIyvDIE61LFu8eoVl7uKndhgsQHdv/ZUxvvG56JEW6F+/7KBx5/Yzxo2rDht3vHLSQP/yuXuMC3+8ybh+6RHjsrn7DbYrP/OtlUaVPuM/6PoHfX/1zxFu+V2LLMHA/Fgo45IatiVZcFleibDIsgTzgyVQNSpk6dc4NNHPmnSkHIE0OIlsGA3i59L8HPX5E204HG7METdmN+YqSoWsCyMrwyBOtefGwjfo+kd9YQVVo0I3ZvTdmOvnT7ThcLQZMwu6WkJa5ROlSQAvweAqkJ/8xiBSpY8dVpm0kvnrmGTNE/QCvHST3kHtuUn9wGfnqtL7+ABtk6yBPZf6WLL+2cdotIv3G1Pn7jLumNcCM75306kWW1vcv+MNg8wHdv+j8bUdZwxMeur83Qk2tGe/ctJQ/Wt/vtG45olXDL4OdtmL+4xrV7xm3LDqdePSp/YaX153psWq0wYPOS8YgSnPHTCuWXzCuGzuPoNWPH5sW9U/eApfS9HHj7g+ckT4YgiZtCJehdZAVVRI/VOe32dcu+yEQf2ff/hl44uPbzdY7K5deqJF4/G58PvrjYt+utW45eUTxq2vvGbctHCfceMLu4zLn95hsNgx/pfN329cufCwceEjm4xrlh5psfCQUT/+g65/0PeXOEswcJVMXV51SS0jbT90kYU1NTfoC33thXNyolqgSp9Mn59N5ueoz59ow+FwY3ZjdmN2Y3ZjdmN2Yx5WY2ZxZ6HHBkrbAJZ+jIFWxMlM3pDRXB9rVMtUm8z8dUxohQLU63NV6bZ+8gc3PuSX+qf/5X0DM1ZLnvrSHgNbPbsRvSMQNqIX7DGmLdpv8LOoqS/tNWZtfM2Yvemkcf+2U8acLaeNacsPGXevPtpi5WGjSp/Xdl771GYDe+ZnD/wRyasXHzeuWXLCuGHla8Z1y04afK2Dn0bw8k7y2dSKG1mPbDN4/GDl6/9q8KiU8PDw4AEbjDyu+rAR6ZAvD2rJ6l/+ydB6tP4Lf7jBYFmh/gu+s9ZgO+6Sn+0yvvTkXqPJ+LDY8XKGG5YdMq6Zt8u4acE+4/IntxuX/XybgT69f+HHm4wp8/cZn//hK8aUF/a2CNuVVy7Yb9SP/6DrH/T9zZoYXI35xfLaBP50IxuYRPj6VdaRQV/aCws0L5fgp1As31xV1BJUJ33YVH/WaeJ8mJ+jPn+iDYfDjdmN2Y3ZjdmN2Y3ZjXlYjRlLYKFXS1BKYyCSpRmaieb49NUyFeLRO4O58uMrzrPkhLbCmIlkaQbx3usnkqUZmtlf/dKYMWAsE/vUF4zcs+G4MX31EWP2htdahK1prPqOeTsNzJuXd87adMq446V9Bsr1+rwE9KYFu41LntxqsPXEo852GQ/nVQuPGXFLLSwTPLrwue+tM4jz0gMexUue223w+GVPjsEDw2YU8CBxlUcrJWcRMrUtainZ0I1BXj4at9Sk/gv+YY3BkkGcFzhwfuXCY8blLx4yrll0vEUxPiyOjA/6LHPXPbM9wZKHZjk+Fz+x3Zjy3N4WYeuSpfBzD68zmoz/oOufmPurcFXvMhZYT7a2ZpCTdWTQF9WS+Yf3PjRYlN8L8IcFk5SBPagxoMO5Vg7ocxXOn/k56vMn2nA43JjdmN2Y3ZjdmN2Y3ZgjjCpXdbRLuKp3IU2SGvT+KtGGw9FhK1uXeAUDADKr8jUT6vOheT6WqWDGTSy5Sb5WAvX1QPN8zYT6fGieT44aM6/SnLHumMFG9L0bXjVmvnLCmLZwn6Gb2wrb2tOWHTDu3XLKmL7isMEmNqZer3/901sN/ojkZ7651NDHiW2oLzy22eAHGJc/d9Bgk4pFgW2rLz6902Aj69qFR41Ln99jfOFHGw02x8rHLz1vCV28ygdPI2UrbQv0eNX8fcZl8/YbF/90m6H1f/HJHcYV8w8b1H/Zc7uMqxYfM7708z0Gm286MsD4fOnZfQbjg/61Cw8aN6w4Zly35LDB+LCRiD7jo/oswQrbhk3Gf2LqR39w91cpr7LI1oNNpslg8FUsUBNV6It8XY7PvtmxtZWNSetVlvJSh/PyU0NKNs6f+Tnq8yfacDjcmPM0QyuB+nqgeb5mQn0+NM8nx40ZsqfO4GHgavloaaRspW2BHt2Y+1U/+qO4sAJXVRPoi3y1Xjdm1c8mp+HG3PZKTkhOkFBLIFKfD+RrJmRpRhI3iNTnA/mZvxpqxqCWTKS5vmZClmaQCUTq84F8zYQszUjiBpH6fMCe+YnUXSsOG3+39bRx+9xdxg2PrjRueXKjcef8PQab0lgy29f3rH3V4CdSGDY/tSLClnW9/uU/WmVc98Rm47PfXmbwSF+16JhxyVO7WoSfQFz04y1G3CILEbanPh9+wsGDd9OKk8YFD79s/Kf75hqfeXCZce2LuwwePzbxykcOeJDKR0sjmg88Qro9yB+to35+IsKCovXHLbXHdhgX/XSbcfX8A8bFj+0wPvut5caFD28wLn18l8Gmoo7PlfOOGqiV+owP+jo+pf6F32/Bph9LHtubWn/V+A+6/om5v0rV1WwlTWgOlskiC6WJKvTF/AE1YH42o5EqNa1ZPy+gfH7Oz1GfP9GGw+HG7Mbsxtz2aGlE8+F8XvgGXf+oL6xENEehL+YPqA27MaPvxszRhTFjBvqFIygzFf1yU5JNaKbrJ9mEZvaijzFjn1c9PM+4fd5Og9eDfPmJ9cbVP3zJuPaRJQbb2tNXHDEeO/Vbgz9rwVe6MGO+DgZ3LNhnNNH/24deMNjWvvCRFnetP2rwowi+ssHDxtdJgK+isHz85/tfNC5+fLvBtthffWOx8alZTxoX/mCRwbYYjx8PgD5ywKNSPlpE+NJNRFqhhvLlzx8yvn3iNwb1xzrD8lHWz/Lxqek/M6if1yNc8N21xqe/Pt/4q28uNKgf/fv2/MbgRynxKy2FPnH0dXxK/f/53mcNfgxz8U+3GzM2nza0/nL8VX9w9U/M/VXKq7RSnaolu1voi2q1ZjVjIM5inYkY6Pj8LPVHff5EGw6HG3OHTOXc0Hdj1gcDqh48Ir7wVekPrv5RX1jroS+q1ZozVzaIuzG7McejtAdd3IEc4KpmKsRphZ3QijiQmcSNJG6oDucKcVq5PucKcV7MiTHz8yc2qOfsOGNMW7zfuG3udoONaLjlmU3G1AXmvrunLT8YaH2la/raV434Ja/FB4w7F+0NtCy5uf7lP1ltXPvkJuP6F3cYn3/kZePKBUcNvoTypaf2Gpc+Yc9zfOT4+QQbaNetOmV84ZFNxt98b43BRtbVz+80LvzhK8b4Hjwi5ZJHhOUS5Ut+utPgT9exBFzy9C6DL6GU9fPzEjboqJ+cix7dYrDRB9SP/pee3W+wQYd+OT4seejr+JT6jNJnH1pufP4H6w3+tF99/ao/uPon5v4Ccb1KPrAhjE65sEKSaoj2BVRe6ldZMqDj87PUH/X5E204HG7MbZkKcVqNrr4bc7cPHhFf+Kr0B1f/qC+s9WhfQOWlPnNMMxV0fH6W+qM+f6INh6PNmLEHlnU1g7TWp3iVPSjEeWlG+YcZkrhBROOun8QNIhpvrq8/msI479/5hoGt3vrMFuPmJzYYbDXDDY+tNNi45s9aTFtyyLijtWu9h/jMdScM/nBFNO9x6X91zWHjhhd2Gn/z3ZUGG1NXLThm8LICHk4evBvWvG7wWH72oZXGX31jicFW1ecfnm9c9OPlBjo8fjweCo+HPlpAhAUOeHR55FD77LeXG9fO32PcuumkcdGjWw1eg8CGG/XzMgTqZ2G6ctFh4wuPbDao/3PffdlgKw/Qp37+bMCUZw4Y6BNXfRZH9HV8vvDDTUap/5/un2tQJ382oL5+1R9c/RNzf4E4pPXUwN5YWMvlVSGeydagPQJxnWmQmnSEtprv8/PcmD/RhsPhxuzG7MbsxuzG3IeFtR7tEYjrTIPUpCO01Xyfn+fG/Ik2HI4OxsxyX2UJSvIGQzM1jvGA64PGB6fPJrYaM3+UYtqKIwavB2ELOhrkc9sNvvZFZNrSA8Y9644bDx38lcFPp9is5g9XzFh91Hhw/z8ZvejP2nbK+Mqy/cZff3eVgUl/8Ykdxo0rXjV4qT0vFuCPorMFx4P613+/xuA1AixJX3h0s3HnuuMGjx8Pgz42PFr6eJQRQIGvjdDjdYv2GTcsO2Z8edVxg592sBnIInLF3MOG1k/lWv8F31tt/O2Pthjos2R86Zm9xpULjhm3b/qlEX86EjbrAP1bN/zCuDr8UQHGB9jiQw19vlZDjxf8cK1x0c82G2X9pf6g60efylW/v/cXiIMuqYrqoFzqY4qZeEe0x5IsuYaqfJ+foz5/og2Hw405opkaH119N+bxPXhlBFDwhW9w9aNP5arf3/sLxMGN+Vyanyhr/aMyf6INh6ODMas96HKfuUKCTKyF86qI63NeFemvvloy2868NoTXg2CZs1450WLL68b3jvzaeGDn6wav3nxg9z8aM9cdN7BhznkNJ68cYeO6X/pfWbTf4I9e3LxwnzFl3m7jop9tMT4XXjvAiwB55KY8v8e4bP5B4/aXXzNuXHPKuHXjSeOqJUdazD9m8ODxSgHdBuTRSs+bUUZohcJViw4avNrw9u1nDPRZ5i59erfBS/N5JQIba5c+vcfgtSq8lJSl54tPbTW+uuaoccuqQ8Zl83YavHrwxrVnDPRZhtDnNYS80gF9tvW+GF77wPiw5F29+FVDxwf9r646bEzdcNxgzPlnkNav+oz/oOufmPsLxKFqYQUWUP6YY1pPU4ReMvGOaI8lWXINZb7Pz4lcH4A49Gv+RBsOhxuzG7Mbc9uDV0ZohYIb8+DqH/WFtR7tsSRLrqHM9/k5kesDEIeBGzMLOkt8c3so84lrK+Lg+sS1FXHoXf/0v7xvqDE/sPMfjXvWHzfuWnXImL31tHHPKyeMqUsOGDPWnzBmbzltYLf84Qpe1Xn9I8uNO1/aZ/DaEP4c5Iw1x4z+6t8wb6dxzROvGF9euMeYuv64ccmzu40pLxxoMb/FJc/vMdiS4tWAU+YdMG7Z+Lpx3eL9Bq/6u+iHSw0eP4VHMT1vBpEszUD/mmUnjdu3nTH4wwC86u8zDy4xLvzhRoOfdvDn6ni9/mXz9hg3L9lv3DB/p3Hr6iPGzcsPGNe/sM1gG//WVUcM/jlywY/WGZ9+YIHxqRlPGBd8d7XBT8s++/fLjL99fKNx45ozxpUvHTN0fC56aqtxAVuCT24x0L9j/avG9S9uN3hVar3+xNQ/MfcXdGFNq3BCF9ZySSXefBNbZ9Ty11to75A1qUHVFJ+foz5/ggnHw43ZjdmN2Y3ZjbkPC2sVOqPcmAc3P0d9/gQTjkebMbP0s8TrD3iq7EEtAYhrZvkDHjJdHwatjzHzk6dHjv/GuH/7G8aD+/7J+MaeXxizN59qESzzwX2/NPjqFl/UuvLheQY/fJo6b0+L8EpOtqxve3arMQj9qx5b3+LRdQY/qZq65ohxw8rXjRuXv2pct/SIMWXuPoMl6Yblxwy+AHLlM9uNT834mcEPMy55fFeg9Uo/trz08UtPo8HXSb6y7oxxzbITgZb+rev/0bhh2SGDL8KoPg85ryTkVf4X/WizccnzO4wH95wx7lj7qjFj80nj7o3HjVtXHQq0lqQZm14zbpy/y+DFpZ//5lPGFT9Za1z7xObAJkPHB33GZ8qLu41rF+03+qXP+E9M/YO7v7oIEqmKsznJIsu5Lql8hadcWBV00nQyvrz2pKERcljcs+YZpZrPT9WfmPWhvCNV8fHNn3+Tw4055sC5p+/G3PzB4xx84SvHf2LqH92FVUEnTSfDjXnQ83PU58+/ydFmzGoPLPrYg1KaASQnSCS/yeCq62eyCa72Vx97nrXppMFXt3glyPQ1Rwx+BPW1nWeMx47/xpiz7YwxdcGuQOvFnBgnrwfhhSF3LT9ozNn+unHf1jPGIPRvW3vUuH1Ni1tWHDIuemKzwSsRLn5yu8GPKL685rRx345/Nq5YcNC4+sWdLebuMnjwPh1eX8ALDS56fItx3cpTBo/f1UtOGHx1Bf3L5x0y2ARD/1tHf218dfNp4/M/eNm45Gc7DfR5iQEvNED/Sy/uNLR+vtrWy/hM+cEK44YXdxjl+KDPi05vWrjbYBNy2vpjxkN7zhi0uvbJjS2e2mSw8F34rWeNJvqDq39w97dbWGR1eWVJ1YU1a5Jx48rDBn948baNp40ZG04a1J8lj4nPzybzc3TnT7ThcLgxR5JsIpNNcHW09N2Ymzx4vvC5MStuzKM4P0d3/kQbDkcHYwY2RVn01SR+JXC13D5VnSpcv57+6mPMfGnrzkX7W4RXfPCjJs5nbXrNmLP1deOBHW8YbE3P2nLKmL21xYw1R4171r9qzNp8ynjstd8a01cfMwatz5fCLnh4jcFLA/hRB+dXLzluXLf8lMFD+HcH/tn4ysaTxjXLTxh81eXKl44aU+buN+7b9Rvj8rmHDV7Ef+mTew00+VEHL0BA/6sbTxkssrN3/LNx9bLXDPS/+OQO46InNhno37X2qHHTS3uMUR//QetP/P3lRzV6f1VfF01geQUiVfq8wuLa+Xay96YFLaa82OKK+QeNaxYdMu7acNKYMm+/UdbPvKqv3+fnuTR/og2Hw43ZjdkfPF/4hkJ/1BdW1Xdj9vmTpk2ifv5EGw5HpTGrGXBemgTnTYyhpNRxfaXU6UUfY75v+xnjO4d/Zcxcf8KYuvSg8fXdbxh8RYvHY/amU8aMtceMW57ZbHzlqQ3G1T94ybjtuR0Gjxk/kYob2gPWv33tMWPO9lPGJU9uMS748Trjyvm7Db4Cw+NxzdITxhXzjhiXPL7R+Pz3XzY+/XfzjYt+tK1F+NEIP+Fgw+r6laeNOzf/0pjy3B6Dl+PfvPZ1A/2bVh83VJ+foKD/76f9xOAVDfyog5+gsOE26uM/aP2Jv79seOr9LfX1/qYV1mCZRv+Klw4a6N974J+MW9a9avAnF2/f9LrBV5CwZ/7s/xef2ml85qEVxn95cImh9au+z8/zYf5EGw6HG7Mbsz94vvD5wurG7MY83MbM4s7Sjxmw9HMOWAIQaWIPwFXXz2QTXO2XPn/KAmO+a+Vhg8fgrtVHjZkbTxkPH/21MWfzCYONpm/u+YXBn3Rku+mWp7cYPBL66k2YOn+XMTH6d2141bhp4R7j1pWHjK8Erlv2qsFG0y3rzhi8OJDtvgu/v9HgkePVgPHnIo9sNS55fIfBqwl4zC5+aofBA3b31l8ZTfRZ8q752StG/DnH4y0mcnxGXX8i7y8G2fz+qj4/p0GfZff6ZQeNO7efMW5cddi445WTBvqXz91jXPjjTcb1S48Yl83db7Ad+plvrTSq9H1+ng/zJ9pwONyY23KSuJHJJrg6KvpuzL08eL7wTbz+6C6sbsw+f5rrl/Mn2nA42oyZBV0tIa3yidIkgJdgcBXIT35jEHF9IH9w+liyvpgzTvTF+42pc3cZd8xrwcNw76ZTLcKrQu7f8YZBJn9q4ms7zhg8JLwABNhQmv3KSWMi9a/9+UaD13bydY/LXtxn8Gfbb1j1unHpU3uNL68702LVaYOHhBcIwJTnDhjXLD5h8EfXaXXJYzuMLz6+3eBhu3bpiRYV+tcsPGTwZRNegACTNT6jrj/o+/v5h182mt/fUp/XdLDhecvLJ4xbX3nNuGnhPuPGF3YZlz+9w8CMqf+y8Gf/r1x42LjwkU3GNUuPtAjzp3n9Pj/r9Udx/kQbDocbc+Tc03djrn8wwBe+4dQfxYXVjdnnT3P9LoyZxZ0NUmygtA1g6VdLIE5m8oYM1yczCWb0rq9/vkItmT+qyLQ+uxHUeh1m3AhasMeYtmi/wc8Spr6015i18TVj9qaTxv3bThlztpw2pi0/ZNy9+miL8HLNydJnO+7apzYbPH787IE/QscfZr9myQnjhpWvGdctO2nwtQt+GsHL+eIfrQuPTdxoCq8zZLvpkp/tMr705F6jSn/KCzuM21YdMfjZxjCMz6jrD+7+8gf5m99f1Wcx5eUhvPzymnm7jJsW7DMuf3K7wR/kR58/ufiFH28ypszfZ/Cn/vnD/myHXrlgv9G8fp+fTfRHa/5EGw6HG7Mbsz94vvD5wurG7PNnWI0ZS2ChV0tQSmMgkqUZmomm6yua2V/90ph5AJiyTF/9gT8v0Zy++ogxe8NrLcLWEI8Kf96Rh4eX883adMq446V9BsqTq89L/m5asNu45MmtBltPPCpsN7E4XrXwmBG3pMJjxqMFPHLEeWkA57wE8eInthvXLDreQvT583M8/F9Zut8YtvEZdf1B3F9eEME59/fyFw8Z5f1Fn8UX/cvm7jOw4eue2Z7AktFk/vDFLv6wP/NnynN7Wzy/z8Cq+fOLPj99/kQbDocbsxuzP3gdHjxf+IZHf1QWVjdmnz+9zJ9ow+HosJWtS7yCAQCZVfmaCfX50DxfM6E+H5rnaybU50PzfM2E+nxonk+OGjOvspux7pjBRtC9G141Zr5ywpi2cJ+hm0sK20rTlh0w7t1yypi+4rDBJhIP1eTqX//0VoM/EscPQvRxYlvpC49tNvgBw+XPHTTYpOKhYtvqivkt2Mi6duFR46rFx4wv/XyPoZtXyl9/d5XBH3X/6qrDxrCNz6jrD+L+XvbcLkPvr24OK+h/6dl9BvoX/3Sbce3Cg8YNK44Z1y05bHzx6Z0GG5XoX/r8HkP1+RGOwra2z0+fP9GGw+HGfM7quzHrg+EL3+jqj8rC6sbs80eVofn8iTYcjjZjztZ3IzlBQi2BSH0+kK+ZkKUZSdwgUp8P5GsmZGlGEjeI1OcD+ZoJWZqRxA0i9flAvmZClmYkcYNIfb7aMz9RuGvFYePvtp42bp+7y7jh0ZXGLU9uNO6cv8dgU4hHgu2je9a+avATBR4YfupAhC2jydW//EerjOue2Gx89tvLDB4J/ijeJU/tahF+qHDRj7cYcYspRNiS4icoPHg3rThpXPzYDuOz31pufObBZcalj+8y2NRiyeOP1t28cJ/RS/2jPv6D1u/X/b3op9uMq+cfMPT+XvjwBkPvr+pfOe+ogRqG2u38Qf/C77f43PfWGVgyf5SQ+uNPaHx+npfzJ9pwONyYx8gH8jUTsjQjiRtE6vOBfM2ELM1I4gaR+nw35m4fPF/4hlN/+BfW+vmDvhvzZOkP//yJNhyOLowZM9AvHEGZqeiXm5JsQjNdP8kmNLMXfYyZ6XvVw/OM2+ftNPh5/pefWG/wR86vfWSJwbbS9BVHjMdO/dbgtfJ8pYKHga9jwB0L9hnDoP+3D71gsG114SMt7lp/1OBHKXxlhoeBr2MAX+Xgqzr/+f4XjYsf327weoELvrvW+FT4I/P/YcZPjc88uNS4ad5u46EDbxijMj6jrt/L/WX5+9T0nxnl/f10+CP5f/XNhQbbkpc/f8i4b89vDH70gj72qfrE0a+aP+j/z/c+a7DtfPFPtxszNp82qJ86y/pjvz4/z+n5E204HG7MHTKVc0PfjbnJg+cL3/DrD/PCin7V/EHfjXly9Yd5/kQbDscYX/7SxR3IAa5qpkKcVtgJrYgDmUncSOKG6nCuEKeV63OuEKcVxszPD9ggmrPjjDFt8X7jtrnbDTaC4JZnNhlTF9js3z1t+cFA6ysV09e+asQvWSw+YNy5aG+g9UgMj/7lP1ltXPvkJuP6F3cY/JG7KxccNfgSx5ee2mtc+oStp3HJ4+crbEBdt+qUQc5Fj24x/vqhFca14VV/qj+K4zPq+uO7v/x8hQ3k8v6yUQkX/vAV45Kf7jT404psIF/y9C6j1GfJRr9q/qD8+fAqx88+tNz4/A/WG/zpQL4yhj5fIiv1fX72S38450+04XC4MbdlKsRpNer6bsxNHjxf+EZFf3z3d9ALK/pV8wdlN+Zh0B/O+RNtOBxtxow9sKwnJzDSWp/iVfagEOelGeUfZkjiBhGNu34SN4hoXPV5DWcmbpDPn7JQY75/5xsG0/rWZ7YYNz+xwWCrB254bKXBxhGvlZ+25JBxR2vXaA/xmetOGLw4Pj48Q6n/1TWHjRte2Gn8zXdXGmwcXbXgmMGP/VkcWfiuXHTY4LH5wg83Gf/5/nnGhd96NjGR9bt+vX7z+8vCyv39wiObjc8+tNL43HdfNtiKhM9+e7mBDn+WYMozBwxeQ6H6vIyCxRf9G9a8buj8KfX/0/1zDTZI+bMWFz261UCfeKnv83MQ+sMzf6INh8ON2Y3ZHzw35vPi/g56YUXfjXm09Idn/kQbDkcHY2a5r7IEJXmDoZkax3jA9UHjvevPXLDD4GdRZBKHjz7+Xw2MmZfCT1txxODn+WwBxQn63HaDr10Qmbb0gHHPuuPGQwd/ZfDTBTaLeHH8jNVHjQf3/5MxzPqztp0y+OkIPyPhIfziEzuMG1e8avBHBS762Tbjwp9sMPgzedc9vcW48tGXjcmq3/Xr9bu9v/Euhy1K7vLf/miLwdd2WDq/9Mxe48oFx4zbN/3SiD9tCpvJcMXcw8atG35hXB3+aAEvpgC2KFFDn6990eMFP1xrXPSzzcaXVx030GeztNT3+Tk4/WGYP9GGw+HGHNFMjQ+/vhtzE/1uHzxf+EZLfxgWVjfm0dUfhvkTbTgcHYxZ7SG5gpG5QoJMrIXzqojrc14VGZ/+rAU7DIw5SRnoz1m6x8CY+dk+P89nys565USLLa8b3zvya+OBna8bvPqOP1E+c91xg8eAc16Dx0/+2ThiW2n49b+yaL/BS+155cKUebuNi362xfhceO0DL+277pmtxi3LDxhfXXPUGIb6Xb9ev/7+8loJ7i+L6Ref2mpwf29Zdci4bN5Og1cn3rj2jHHV/GMGy+ilT+82eE0jr4xg45ptSV4rwYsYseSrF79qXDb/oHH7y68Z6PNqzKkbjhvUjA2gzx+9UH2fnxOjP7nzJ9pwONyY3Zj9wXNjPi/urxsz56N7fwetP7nzJ9pwONqMWRf05vZQ5hPXVsTB9YlrK+LQrf60n79s/HDZAYN84uTPnL/dwJjvWX/cuGvVIWP21tPGPa+cMKYuOWDMWH/CmL3ltMF058XxvCrv+keWG3e+tM/gZ/v8ObYZa44ZD+z8R2NU9PlD8dc88Yrx5YV7jKnrjxsXPbHZuGH+TuPW1UeMm5cfMIatftev16+6vzcv2W+U9/f6F7YZbGPeuuqIwXJ8wY/WGZ9+YIHxqRlPGBd8d7XBT2v4c4p/+/hG48Y1Z4wrXzpmTHnhQIv5LS56aqtxAVvWT24x0L9j/asGf1iCV0XW6182b4/h83Ni9Cdr/kQbDocbsxuzP3huzOfF/XVjnpjxH3X9yZo/0YbD0WbMLOVYgv6Ap8oe1EJALQHKH/CQ6fqQBmcc+vwU6tZHlhgYMxFy+NrXXU9uMDDmR47/xrh/+xvGg/v+yfjGnl8YszefahGm7IP7fmnw1Qm+KHHlw/MMfngwdd6eFuGVeGwZ3fbsVoOfNIyW/lWPrW/x6DqDn0w8uOeMccfaV40Zm08aw1y/69frN7m/d288bty66lCgtaTO2PSaceP8XQYvbvz8N58yrvjJWuPaJzYHNhmqf8nzO4ypa44YU17cbVy7aL/RL32fnxOv32T8+zt/og2Hw4055sBo6bsx96Lf5MEb5vpdv16/yf3t78Lqxnwu6TcZ//7On2jD4WgzZrUHTAV7UEqzAVopyW8yuOr6mWyCq030sd7pz24yMOav/mSpQXzGi1uNe5fsNjDmWZtOGnx1gp/kT19zxOBHCF/becZ47PhvjDnbzhhTF+wKtF6Mx8Tl5/n8YP+u5QeNOdtfN+7besYYRf3b1h41bl/T4pYVhwy++jEq9bt+vf4g7u+UH6wwbnhxh1Glz4seb1q422CTc9r6Y8ZDe84YtLr2yY0tntpksHDzepAm+v0an1G/v4PWH8T4V93faMPhcGOOJNlEJpvg6jDouzH3rj+IB28i63f9ev1B3N8mxunGfG7oD2L8q+5vtOFwdDBmYLMUA1CT+JXAVTKT3xiqA/yYRyP91S85H/S/vfaAMWvxLgNjVmYt2mU8tO6ggTHzpYk7F+1vEX5iz48KOJ+16TVjztbXjQd2vGGwNTRryylj9tYWM9YcNe5Z/6oxa/Mp47HXfmtMX33McH3Xd33Xd/3x6UcbDocbsxuzPxiu7/qu7/qTrB9tOByVxqxmwHlpEpw3MZ7SmGlLnPNe9Etoyx944HwQ+oOuX3VUn81qfgo17cn1RubKxoy5W42ZL+0wMOb7tp8xvnP4V8bM9SeMqUsPGl/f/YbBVySYXvxZ8hlrjxm3PLPZ+MpTG4yrf/CScdtzOwymKT9RiBtKru/6ru/6rj8u/WjD4XBjdmP2B8P1Xd/1XX+S9aMNh6Pyy19YAmaAtXAO2AMQqbIffsAz/dmNRqk/a+Euo0ofW4Uq/RKuoq9tS30gMj79QdRPPvqoMYaYMecPLN9rzF60y5j+/GYjc2XjrqdeSWDMd608bDCN7lp91Ji58ZTx8NFfG3M2nzDYqPnmnl8Y/Ek1tmtueXqLwZTSV9/B1Pm7DNd3fdd3fdcfn3604XC4McfI+PTdmHViub7ru77ru/749KMNh6PNmDEMtYTkIonShICXYHAVsBA2e2cv3GWggD5X735mozH9+S0GV2cv3mXQql6ffLU0NDEwQJ9MoK0qQxN9IoOrnwhqtKIXrBobRp8/TUHmnGV7jcyVDX5GxYY2xhwnyuL9xtS5u4w75rVgMt276VSL8FP9+3e8YZDJq96/tuOMwSTjB/jAhszsV04aru/6ru/6rj8+/WjD4XBj7kKfyODqJ4IarejFjdn1Xd/1Xf/c1o82HI42Y8Y82Iatsg3AWtRyiGMh2BLcM3ebwbnq60YrFoKd1OtTCVcVDIxNXcwSZTSpCgWgVXN9IHNw9fOPCdWhcq0fY57+3GZj1sKdBobNCNMW7pm3vUUYf4yZaXF2I6X1Orq4kbJgjzFt0X6Dr/Xzp8j5w+OzN5007t92ypiz5bQxbfkh4+7VR1uEl9vxR9Nc3/Vd3/Vdf3z60YbD4cbsxuwPhuu7vuu7/iTrRxsOR5sxYzkYCRZSgj1gJxgPEc3BJADr4hz9aKLBWrBSftKDnTTRB83E0rBkNNFHE2OjFb3XU+ozJhNTPzroa+Xaiv9rYMbzWwxaMcK0hbuf22ww/hgzU4rppT+Q5yV201cfMWZveK1F2FphqvHn1Zh8vHxu1qZTxh0v7TOYmuD6ru/6ru/649OPNhwON+YOlPpuzMMwcV3f9V3f9c9V/WjD4eiwla02oGAJQGZVPjlYBabFOfmY0OyXdhhsxs54brOBnTTXB2ySV23MXNCCP96APproY1FYXT1UqL1oPYOuHx30q1rxWfQTMcK0BTaxGX+Meca6YwYbKfdueNWY+coJY9rCfYZuzihsy/BHxe/dcsqYvuKwwSYMk5JXzbm+62fihuu7vus3GZ9ow+FwY+4AFWovWs+g60cH/apWyZXTJ2KEaQtuzOD6ru/6rj/8+tGGw9FmzGoDoGYAajlE6vPVMDChGXO3Gfct3m2wDXvH46sMcprro8YXr+L29TMbDdVHE/1pP3/ZID95cAZXMTz0sWEgMuj60UFf8wFl+tXtblopMSfoY8x8xf+uFYeNv9t62rh97i7jhkdXGrc8udG4c/4eg00bphTbL/esfdXgK/5MOH4qQIQtHdd3fdd3fdcfn3604XC4MbfBVTfm4Zy4ru/6ru/656p+tOFwdGHMWIJ+oQnKTIUvN2EV2M9XH1liYBu8/mLqz9ca5GBXgEKVPmaJ8dz97Gaj1EcT/a/+ZKmBjalOqY+mUqU/iPrRKetk/FHmnw5sVpNJKyUVb2DM3P6rHp5n3D5vp8HP27/8xHqDP+J97SNLDLZlpq84Yjx26rcGr2XnKw9MJr7OAHcs2Ge4vuu7vuu7/vj0ow2Hw425g37ys0SVvhuzTizXd33Xd33XH59+tOFwjPHlLywBcwVygKuaqRCnFVbBz3vYgL136R6DyF3PvGJEOwnbudOefNnAhEp9LC2qBTODGAn6qAH6GBg0qb9ef3D1o0Od5KfBN9BEH9Mlk1aK6mPMfH2fDZY5O84Y0xbvN26bu91gowZueWaTMXWBzZ7d05YfDLS+8jB97atG/BLE4gPGnYv2BlpT1vVd3/Vd3/XHpx9tOBxuzJX11+u7MU/8xHV913d91z9X9aMNh6PNmHWbWs2AiMaTNxsYA/ajkI+RqFXwBxg454/83/nzdUZylAQWiI0pxGct2GnwQkp+IqX6qkOFUNZPnVnxBvEqfc4HUT9tqROoBBhPvm6mnyt1mlB9Neb7d75hMC1ufWaLcfMTGwy2YuCGx1YabLzwWvZpSw4Zd7R2XfYQn7nuhMGL3ePkc33Xd33Xd/1x6UcbDocbsxuzPxiu7/qu7/qTrB9tOBwdjBm7Ki0h+USCzJkLdhj8LIpM4oAVRavgdRzh50Z8cSnu4gajSo7Ska+t3G/MemmnQf705zYZM+dtNx5Ysc9QfW2LdWXFG1pn+phZ/RhhqT+4+smnQq2KiI4nn0t/kFaCPsbMS9WnrThi8PN2tlCYKF99brvB1xaITFt6wLhn3XHjoYO/MvjqP5s5vHh9xuqjxoP7/8lwfdd3fdd3/fHpRxsOhxtzJH3MrH435uGZuK7v+q7v+ueqfrThcHQwZrXn0hhKZi3YYWAPyc8M/uSDbizzEyN+6oOlYUWzFu82kpd0BBujL14zOXN+C/TZtlV9bVtlzKDVpuJTBCMs9QdXP/n0C/zjgE8xZ+lugxwiaBIpQR9j5mfv/LydKTXrlRMttrxufO/Ir40Hdr5u8Oo4/sT3zHXHDaYR57xGjp/Ms7HDtozru77ru77rj08/2nA43JjdmP3BcH3Xd33Xn2T9aMPhaDNmNaTm9syrLrEB8omTz59n4CqGNGPeVmP24t3GzIU7Da5i7ZyX3P7YSoNNYF7rgY2hP2fpXkP1ta2aHKTijfLzEscOq/QHVz/5qj/9hS0GNkycc+0Rfc4V9DHme9YfN+5adciYvfW0cc8rJ4ypSw4YM9afMGZvOW0wXXjxOq+au/6R5cadL+0z+Fk9f85sxppjxgM7/9Fwfdd3fdd3/fHpRxsOhxuzG7M/GK7v+q7v+pOsH204HG3GjJViUf/8Zgu1K66CWtetjywxsAEi5GCBdz25weDqt9e2mLNkj8HXnTCY0mZK+GHS9Gc2tQgv1mBLGf3Zi3cZqq9t+ckQlqb9UiHnfFI+F/XzWar0B1c/+ejfv3yvofVzlR5RIII+5wr6GPMjx39j3L/9DePBff9kfGPPL4zZm0+1CFPqwX2/NPhqA19kuPLheQY/DJg6b0+L8Eo5tnRue3arwU8CXN/1Xd/1XX98+tGGw+HG7MbsD4bru77ru/4k60cbDkebMeuLNdjgxZ4V3fjF2LAZbIA/FEGcl2bcu2S3wdVZi3YZcUM4XE2uZjQxNvTvDC/0UP17F+8xVF/bzgo/Urpv6R7jobUHjHuX7DGmP7vRoFpq4LMDxlylP7j6yefqPfO3GVq/9kgm448+EQVLjvqbThp89YCftE9fc8TgS/xf23nGeOz4b4w5284YUxfsCrReLMfE4ufz/KD+ruUHjTnbXzfu23rGcH3Xd33Xd/3x6UcbDocbsxuzPxiu7/qu7/qTrB9tOBwdjBnY1MWA1aR/JbD1OmvxLiPzAwObeWjdQYMIX3qa3vrLCvGrTECPqWFH2Ozlq0xYo+rfM2+7ofralq9czVq007h3sbngbn5EpPWrPQORKn3N7G/95FMzP8rS+umRfwRo/ein7jKwZ750cOei/S3CT+D50j/nsza9ZszZ+rrxwI43DLZuZm05Zcze2mLGmqPGPetfNWZtPmU89tpvjemrjxmu7/quP1r6D955iTHj2v+YGK36J0Z/6rLDxqDrjzYcDjdmN2Z/8Fzf9c9TfTfmJvpDZMxqxpyrSWNa2EzVJio2gwkRYQM5+VkCm0kNa2ArmC89qX7cEA76X1+139BW9y/bY/AVKuyNc63/zifWGWxf8+kmq34y2b6e/sJWQ+unr6r6U0cJ9DHm+7afMb5z+FfGzPUnjKlLDxpf3/2GwVcYmF78We8Za48Ztzyz2fjKUxuMq3/wknHbczsMpik/IYgbMq7v+q4/IvpY8rFV3zWe/84tBufY8/DXP5H692w6aQy6/mjD4XBjdmP2B8/1Xf+803djbq4/FMaM2WDJmLHaFecPLN9rYA9st2Z+YGA/QCQ5WYIev7n6gJEa1oDa3c+0Xs2RxA2+xsWfl8DGtBX69y7aabARXdY/7Yn1BmqlPjpZ8cYg6idzxrztxqyFu4zm9dO21MeY71p52GAa3bX6qDFz4ynj4aO/NuZsPmGwUfPNPb8w+JNkbNfc8vQWgymlr6aDqfN3Ga7v+q4//PpYMgaMGSvEyRnO+ide/9bndxiDrj/acDjcmN2Y/cFzfdc/j/TdmLvVn2Rj5mdCLP1qyZgQNsCXjPjyFJlzlu01sASFn/GwYUtEzQyabwIDJoSy6s9euKtFNKpWVeRjUUTq6+fHSKqfOjWofCLrn25lh+K7qj/2IvpUiDHHibJ4vzF17i7jjnktmEz3bjrVIvzU/f4dbxhk8ir2r+04YzDJ+IE8sCEz+5WThuu7vusPsz52+78ceMRY/vNpNZBD/vDUP1n609ceNwZdf7ThcLgxuzGPwIPh+q7v+r3ruzGPT3+SjZnNahZ3TFoNiQjGEH/AE/7oIYZRWhQ/Abpn7jaDiJoZsNGamowJP3aKL98Q/enhjypie+ZkBvnoY1Eznt9iVNU/Z0kL9Gmrnx0msn6UoXn99II+FWLJ/NExpsXZjZTW6+LiRsqCPca0RfsNvtbPn/LmD4PP3nTSuH/bKWPOltPGtOWHjLtXH20RXj7n+q7v+sOszwa1WrKeK2UObSe3/snVv/XFncag6482HA43ZjfmEXgwXN/1Xb8XfTfmXvQn2ZixBBZ3ln41JIj2HLZesQpaYQO0hbuf22xgLUTIwX7QT8kN4UdEvJpD9YFK0Cefc34ydM+8bcbsl3a2KOrH/NCnrX5qmMj60eec+lGoql/1qRMwZiYQU4rppT+Q5yVz01cfMWZveK1F2FphqvHnyZh8M8PL52ZtOmXc8dI+A2XXd33XH2Z9NqVL6z0WvvBVnmsObSe3/snVv/nJrcag6482HA43ZjfmEXgwXN/1Xb8XfTfmXvQn2ZhnLthunDWAHYbaEpYMaieYNzZAW2CTVk2lihnPbTZQyy5lsJGLsurzqg3qZyOXfDZ7Vb8EC5zx4hYDfdomb0sQLxlE/Yy/1o9CKjtB/arP/aJmjJlXwc1Yd8xgI+XeDa8aM185YUxbuM/QzRmFbRn+6Pe9W04Z01ccNtiEYVK6vuu7/nDqsxGtdnuswoD1nByNoJOJG6M+Pk30p604bAy6/mjD4XBjdmMegQfD9V3f9cen78bcu/4kGzM/0WGJv2/xbkPNGH771kdG3HQNloAx00qJOWGLmAj6vEYDfXLueHyVMe3nLxupeQ0YkurH7V+pH0p98mPbUD/bvzPnmzvu4Kq2JaL6g66/Sp+25Me2Ur9e5U6V9sxX/O9acdj4u62njdvn7jJueHSlccuTG4075+8x2LRhSs0M2y/3rH3V4Cv+TDh+KkCELR3Xd30fn2HTv/xvvmCo3QIRtV49LzPRmfj6h0H/tvl7jUHXH204HG7Mbswj8GC4vuu7/vj03Zh7159sYw72wBLPn32E5MoGrxzBWtiMrTJmTAJiJOh/9ZElBtbC6zWm/nytwR94SM1rUGW4+9nNhtaPIZX6tz223ND6H3r5oMGPjrC6shfVH1z9XK3S52pV/Vylfu4UxgwYM7f/qofnGbfP22nw8/YvP7He4I94X/vIEoNtmekrjhiPnfqtwWvZ+coDk4mvM8AdC/YZru/6rt+L/tU/3Wws2fjrMWmur8asf6yCSL0xk08Enfr6GZ+rH91oZAVnjG98musr3eqX9/e2eS0GPX+iDYfDjdmNeYgWJtd3/fNZ3425X/pKt/rl/Z1kY+bnNyzxpSUT4SUk05582cBUqowZNTXLGAnmce/SPQaRu555xWAjNzUfk6gW9IEIVzFmUH3Q+vmyFdA2fgmrQn9w9ROv0k8NO0L9etdKY+br+2ywzNlxxpi2eL9x29ztBhs1cMszm4ypC2z27J62/GCg9ZWH6WtfNeKXIBYfMO5ctDfQmrKu7/qu363+NU9vN9RI/uXN/++YaP7if/7tmGCrarScq0mXZsw5bTPBjmhVWcEZmpmJ1KCtMsEatFU5/k3uL1vZg54/0YbD4cbsxuwLq+u7/qTpuzFnIjVoq0ywBm1Vjn+T+ztExowBA9vXGDAbtnwdiQgkh0jMWrDTYIuYCPr8AQbO4x/5//k6A2VIIjWofnRWqV+NWUGf+rFAfmI044WtBm2JV+kPrn69qvpEVL+sP/37ycCegXunxnz/zjcMpsWtz2wxbn5ig8FWDNzw2EqDjRdeyz5tySHjjtauyx7iM9edMHixe5x8ru/6rt9YXzeuMy/piuQ6NVQZc5Nz2maCHckKa0gmUkPWcByg0+39vX3xAWPQ8yfacDjcmN2YfWF1fdefBH03ZshEasgajgN0ur2/k2zMvM4CG+CLRXGXNRgABszXjsghguERKZk5b7vBeXxdRvg5UKmvyk3gDz+g/8CKfYZe7UWf/FJ/IutXVJ+fqwHWO3PBDoO7UNoz/7TCmHmp+rQVRwx+3s4WChPlq89tN/jaApFpSw8Y96w7bjx08FfGzPDVfzZzePH6jNVHjQf3/5Ph+q7v+k30f/HBfzfqzeadP/454w/vfWS8/X6LLLkhWCymq9ar6FXyM5GGZMUbvdevZOKG6r8TyJokGHnuQpP7+/XdvzAGPX+iDYfDjbkD5Jf6E1m/ovpuzK7v+qOu78acJY+DTNxQ/XPKmPmJTjSDYDlY0azFu41vrD5gcBUw5lkLdhgaV9j45Rx9DKbUT00MtmfnLNtrVOnzShD02RbWq1X1z1m621B9bQVnX5OZ609u/b9+80NDLRnQL42ZTPQxZn72zs/bmVKzXjnRYsvrxveO/Np4YOfrBq+O4098z1x33GAacc5r5PjJPBs7bMu4vuu7fr2+WvLBk28bahhqKu998GcDyyH+3gcfGxp5/4OPDVUo+Z/+9h8Sx8LXu/ijFJC5sqFXyVeFTDyDqvpbv0KrbvXf/eOfDdVh5NWe6+/v3ateNQY9f6INh8ON2Y3ZF1bXd/0J0ndj7rZ+hVbd6o+8MWNIGMPsxeZeu2cu3GlMf2GLMfOlnQZxLBkzIP/2x1YanCv8eQaMAf0Z87YapT75xLGTGeEPS1S96hKbRH/O0r1GlmBU1V+vz2s9Sv1B11+lj8X+y1sfGtizGrPqqyWTjz7jf8/648Zdqw4Zs7eeNu555YQxdckBY8b6E8bsLacNpgsvXudVc9c/sty486V9Bj+r58+ZzVhzzHhg5z8aru/6rl+lrz/4wRhADQM7wUiwGbZn33r3QwObwXi+/7MlHbl12myDPziBlX7hx78z/mH1/2r89dS9BnYLasOgV8mnLTpook9fZe9QXz+fETBa4r9/76MW735oYL3okNN8fJK4QVsdZ0aeewHcnar7O3vL68ag50+04XC4Mbsx+8Lq+q4/cH035nrjJO7GzNFmzN9ee8BgiefrSPcv32vwkx6sgjjGzKYu+frDHuWuJzcYGAP6c5bsMVSfTNXH8unl1keWGKU+vaPP1rFehar6+eqWZqI//ZlNhsZVf9D1l/oYLQaM0QL2zE+h0EeTCDl87Qt9xv+R478x7t/+hvHgvn8yvrHnF8bszadahCn14L5fGny1gS8yXPnwPIMfBkydt6dFeKUcWzq3PbvV4CcBru/6rl/q37zkoMGWafLjhBoGpoL9/P69D4033/lTi3c/NLAZLHDr3v9q/P73/z0DU+SrW2rMCnYLvIZT0atZQwNN9OkrK8CgNq6W9WO3b739F4PIO++3+MP7H7UIRquZb7/fgtFoMj5V+jrOjLwac9zQrri/d284bgx6/kQbDocbcwR9N+ZBLEyu7/rns74bcxPjdGOONhyONmOetWiXwYYqC/0987cZs8IfFrxv6R4DswFyeLFlaTyAJdy7eI+h+uUrNUp9Bavj9Rp3hhd6aFtoUv9Daw8YXP3nNz9MoA/olxVOZP28ShNjVpI3J+tl/FFAnzgV3rtkt8FdmLXppMFXD/hJ+/Q1R4yZ4Uv8X9t5xnjs+G+MOdvOGFMX7Aq0XizHxOLn8/yg/q7lB40521837tt6xnB913d91b996QHjtmWHjCbGjOVE4wnbuRgVm7HYDMZcGqHaIT9zqjJmBQPGaKvMWEETffrS3rUqrpb1AxYLRNjEJj+lGXE0gg2nwWlFKsYHSn0dZ0a+NOaq+zvzlVPGoOdPtOFwuDG7MfvC6vquPxB9N+bmxunGHG04HG3GzJeeprf+skL8KhM/2uEFF7MW7TTUZth6nbV4l8FmLK2wAT2/Z952g0gJG7MY5K8E7IeNXDUnTKuEqjhHuayfeLf6KNO2pF/1V6FtUUNZxz8rycDmH1p30OAu8KWDOxftbxF+As+X/jmftek1Y87W140HdrxhsHUza8spY/bWFjPWHDXuWf+qMWvzKeOx135rTF99zHB913d99G99Yadx0zPbWzy9zeDrRcmPE2oYmBNfZVIwGDZpMWaMEPNTyMeuMFHAdEvrJfLLX/3CqLoKqoY+X7/S3svayvpppXCVLWutX69Ck/FJsgmu6jgz8mrM3J1bFu4zJmv+RBsOhxuzG7MvrK7v+n3Wd2MmUtaf/DLBVTfmaMPhaDPme5fsMb6+ar/B4j79ha3G/cv2GHyFCovinJ/isIl95xPrDAxAYWOWDVU1G8wMNc4xG84xOc7HZ2xl/UT6pU/bwdWvaFvU2KzW8efTKfwzi/HnXty3/YzxncO/MmauP2FMXXrQ+PruNwy+wsD04s96z1h7zLjlmc3GV57aYFz9g5eM257bYTBN+QlB3JBxfdd3/aB/9+ojxpdf3GXM2HDCaLKVjc28+c4nsG377gd/bhG2ZDG8W+78jqE/EPr9ux+1KL4kBRiqmi5gulXGDLSt1+erW9RPbdTJVa0/RsJ58/pVv358YqTQ13Fm5NWYuTsXf/N5Y7LmT7ThcLgxuzH7wur6rt9nfTdmN+Zu50+04XBkW9mtP8+gNjZr4S7jm6sPGPcu2mmw0f3A8r0G9sx28bQn1hsYAK/OiD8HCkx/dqOhNoN1oY/ZYGxqb2ybAznJn4zkWxlcRT+5lFHqA5Hx6Q+ifvI5J5MfQWHGnJfjr58UdPy5L3etPGwwje5afdSYufGU8fDRXxtzNp8w2Kj55p5fGPxJMrZrbnl6i8GU0lfTwdT5uwzXd33XR//2ZQeNO1YeNb6+6w2jiTFjP2zkYkKYCj/4ASyHbVvOgVbxfwajwqKIl8aMDW/Y/LKBMXNe2jNt6/Ux1MHV37u+jjMjXxrzdY9uNCZr/kQbDocbc4yMT38Q9ZPPOZluzK7v+qOl78bc3/rPa2M+u9C3rHf6MxsNLJYIV/mSF6+cJK5/CgID4Ac8wGbv7IW7DGwGS8NgVJ+r6NNKrY7XTGJvanLJzww0MTBAn0ygrSpDE30ig6sfVI1esOom468w/mxoc1/iRFm835g6d5dxx7wWTKZ7N51qEX7qfv+ONwwyeRX713acMZhk/EAe2JCZ/cpJw/Vd3/Vp9ZVnthk3PLHZuOnZHUaVMYPaRtsPgcR4MCo1myrU0kpLBgwYS1ZKYwZ0Sn2+kNUW6Wv9vevr2DLaasnA3eHLek3u7yDmT7ThcLgxd6FPxI25amK5vuu7Pq3cmDnvvX435n9jUxSz0Y3QuMQ/v8XAGOIPkMIfJcQw4tK/eLfBqy0wJ15+yTnmxDZvqY+dYEhYl1oacawreVsCAyvrRxNjQwFo1VwfyBxc/fxjAh3iVK71V40/I0xb4CdqjD93h2lxdiOl9bq4uJGyYI8xbdF+g6/186e8+cPgszedNO7fdsqYs+W0MW35IePu1UdbhJfP8UfNXN/1XR/9Lz+5xbjusVeMG5/aalT9XArUPP7wnrlOMp4WGAyGBBgScd22pS3bvGRWGTNxtq+V+vxS/53wcg9qOGuf/ay/d30dW0Y7c2WDu3PnqmPGZM2faMPhcGN2Y/aF1fVdv8/6bsz9qt+N+d+wNOyNpZ9zfnLDcj/7pZ0twtY0Vs2ijznx8ktMArAuzrG0aKIV+tgPtoSxEcHSFM3E0sr60cTYaEXv9ZT6asnkDK5+dNDXyrWVjj+tGGHawt3PbTYYf+4RU4rppT+Q5yVz01cfMWZveK1F2FphqvHnyZh8vHxu1qZTxh0v7TOYmuD6ru/6aOoLRr669KBxy4K9RvMNbTUbTCi5jqHGw4+CMK2z1gUtA8NQyw1q4qB/JhI0k7bES31qeC9AJUSAaslPxRvN6ydnfPo6noxw5scGd+Tqxzcaty09ZEzW/Ik2HA435g6U+m7M3S5Mru/657O+GzNQLfmpeKN5/eSc18Y8c8F2g43o2S/tMNgsnfHcZoPlnoVeYdGf8eIWg41WzAOrwLQ4x94woSp92pIJaktADmCTvGqjrB9N9KkWq6uHCrUXrWfQ9aODPjlZcyMNfvpEjDBtgU1sxj/eo3XHDDZS7t3wqjHzlRPGtIX7DN2cUdiW4Y9+37vllDF9xWGDTRgmJa+ac33Xz8SN81n/ztVHjC8/vd247vGNRrfGrJu6RLAcDAyjYpv3rJm14Cr5vJbyf/9/vqwj/DmKtQ/+0OA8S0jU61MDEaVf9Y9PX8eTEc5c2eCOXPP0NmPqqqPGZM2faMPhcGPuABVqL1rPoOtHB31ysuZGGvz0iRhh2oIbM7i+60+Wvhtzv+ofn76OJyOcubIxAsbMT6R4zch9i3cbbJPe8fgqg+WeLWviLPdsX8+cv8NIfpNQw8CE6vXV0lBQQ0qyBmrUE7evi/rRRH/az182yE8enMFVDA99bBiIDLp+dNDXfNWhX93uppUSc4I+d4qv+N+14rDxd1tPG7fP3WXc8OhK45YnNxp3zt9jsGnDlGL75Z61rxp8xZ8Jx08FiLCl4/qu7/qqf/Mz24wv/cMi46ofrTFuemKrUfVFMDUSfiYUver9FlgOEc7f/9ePDc7J50UcelXtirZqxmxi6/kL028zyBmfPpAf/2df64cm+jqejLBaMnfhppf2GV9deMDo9v72d/5EGw6HG3MbXHVj7tfC5Pqufz7ruzHH/+nG3GD+RBsOR5sxs6B/9ZElBss6r6eY+vO1BldZ4oHN0odePmiohSh8uYm22E+9PnYFKGBFSTCBWWI8dz+72Sj10UT/qz9ZamBjqlPqo6lU6Q+ifnTKOgFl/unA+JNJKyUVb3C/uP1XPTzPuH3eToOft3/5ifUGf8T72keWGGzLTF9xxHjs1G8NXsvOVx6YTHydAe5YsM9wfR+fev2rf7rZ0MWxil7qv/rRjUYmmDEx+rct3Gdc8YOVxsXfet744kPzjKoNbTUStmf5AhQbs5gNhkQE01KI61XO2fJVS4YH77zE0HOMWe05iSc10IhuKWONg6i/W30dT0ZY7xF34Vu7zhh3rDhqTO78iTYcDjfmDvrJzxJV+oOoH52yTkDZjdn1R1HfjdmNuZf6u9XX8WSE9R6NmDGzQXrv0j0GP8i565lXDBZ3tlunPfmywaJfZTzE1ZhRq9KPvYs+JlTqY2lRLZgZxEjQRw3Qx8Cg3GpO4ol6/cHVjw51aitAE33Gn0xaKarPvePr+2ywzNlxxpi2eL9x29ztBhs1cMszm4ypC2x13v3/b+9dv+6orjPfP7F7nP7Qid2J23ZsY0BYAgkM7SROeyQnPulun5AewTZ23CZgEBeBoLlK6IK4X4wsCUhix45PhiWjVyg4DRgnH3Jmrd/cS89ea69S7Uu92lvvXOP3oZg111OzVtVej95F7dq7Hnw50T3ysPvRHxr+EMR9LxnX3/t8opuyQz/0a/1PfvuIoROQTpctNJ8lxyFor0KwQDMLkR60VyFYoJmFiDHEmHmxBmAzbkhiPFgRBsZDUpPMzq50LzaG0Z78yz81sjcbasZAnPxHnjttHHzujNGvf94Ke+9S2ZlJr2Xrn1dfx5MR1uvCVdDronu1b41mqkI/2qsQNNyGUwtj9jqzeKZff7z60aFO7QVooh/GHPrrrx/GXIgYYcxEVCGM2W04tRnGrNM6P8LPtM5SMGBsgDFgP4oaiWryAwyqf/1fPmbkQ2ewQGxMIb737mMGL6TkK1KqrzpUCPxDQeunzqJ4g3hLn+0x6qdvqyrGk8fN9LzyQTOqr8Z867F3DKbdz995yPjsHU8YLMXAp24/YLDwwmvZd+1/xbi2W9U8Qfymx04avNjdJ/fQD33R14XrYg6aizyXXZai40AKkR6KjgMpRGZSGzOGhMFgPyznEuHrQ/pCSuAxKHKIqL1htGq9mLRadfZmQ40ZHj5+iVq/jlDJquqvI2S29HU8a2Ou0fzhFCI9FB0L3IZTC2MOYw7jCf1R9MOYoRCZSRgzhDHTmsbMVA4YCQ8cYWxqbzfdfdTga1HYSfY8AytC01/Hkb5uxINLvoqb9POhZ/KVAy8afDWL/N3ffdq46a4jxm0PvWCovvbFurRy0DqpvK4fI6z1x6uffK1Ba9Px5Lz0C2k16HMdean6rodeM/h6O0uUTMRf+O4Rg8cWiOy6/yXjxsfeNL728k8MHv1nMZMXr+955HXjqy/+2Aj90EefRcL+yYjpVWEpkom1SF6AQty4mvSxIuyHRWC+aORLvuTQEdPa+tjAzNSeW5BzsFvB9kXsA8dPdRzrwJjdrW3j+GnVx1xz2ZlV1T9cvxjSuSjEDdUvkhegEDfchlMLY3ay8xX1hzFvojGE/pXVD2MukhegEDdUH+MJY1Zq/WJI56IQN1S/SF6AQtxwG05thjG7GSfLwSr23vecUbhaZu/dRw3sQe2En3zQhWW+YoTB1/rktMDGOBavmeSVJuizbKv62rdlzKDV5uJzBCOs9cern3yOC/zjgLO45f7nDHKIoEmkBn2uKV975+vtTKl7nzzZcegt409f+6lx27G3DF4dx0983/TYmwbTNNu8Ro6vzLOwybJn6Ie+WnK9PKuTJpMyUxJxJmiN8MpGVeiHXpurD/PqY1dY2rmtDwy2WShGhxx6oY/1tsB6sWQMGEtWiGPebKv+2PUP1y+Gtwd6XSl9t+HUwpjDmMN4Qn9l+mHMy+jDvPqLGVvhxAVhzNuv7zac2pQxM33vueuwse++54ybfnDM0KXUwtUMXnWJDWBpxMnn5xnYiyHV+uzF2tmu+eLtBwwWgXmtBzaG/i33P2+ovvZVk4NcvIEB8xONWj922NIfr37yVX/39w4Z2DBxtvWI6LOtoM+VvfHxN40bHn7F2Hf4jHHjkyeN6/a/ZOx5/KSx79AZg+mYF6/zqrnf/caDxvX3vGDwtXp+zmzPwTeM2479jRH6O1lfvxCCJbeMmUmWaY7lQR7bYZpjqiIHmMiI82UYJm6mNp8uU86m6zNK9BpDf0j9WOwUxxNp+8DxRDJmLNnNO+Vg5/36Y9e/ufpuw6mFMYcxh/GE/gr0w5iX12eU6DWG/pD6L/lxJpku22HM4+m7Dac2Zcz/9dGXjFv2nzB4HEntKnuzodb1+W/sN7ABIuRggTd88wmDvbU+BlPbTA1fTNp959Md6cUaLCmjz89Nqr725StDWJoelwrZ5kw5L+rnXFr649VPPvq3Pvi8ofWzlyOiQAR9thX0MeZvvPkz49Yj7xhffeHHxh+c+Ftj3zOnO9KU/dUX/s7g0R4e5Pmtr99l8MWY6+460ZFe2ciS5jXfOWzwlZvQ35n6n93/ssEitloyZFc2mLyYnnjY5+zWBx0XPjQmE1bHufO/MYhsXezgkR8mMs08f7EDtdBflf6Bo2cMNWZMF4irPo+GEV+H+jdR3204tTDmMOYwntBfSj+M+erTD2Pefn234dSmjHnvvccNFlRZ4P37Cl34xdiwGWyA148Q56UZN+9/zmCv6rM3u5oxxNjQvz690EP1b77vhKH62ndv+pLSl+8/YXzt0ZeMm/efMHZ/5ymDaqkBS1ZjbumPVz/57L3xr581tH49IpmMP/pEFCz5cGp7nz5l8GgPr4zYffA1gy/JfOXY28btb/7MuOXZt43r7j6e6F6syMTN6yN4ocQND75s3HLkLePLh982Qn+n6X/x/peMax54xRhizExJPjGl5T4mMhb6mM6AKQyIsEioEx+4WprmsngXCf2Eqy2tzyI2xpzTDFeL8V9a3204tTDmMOYwntBfUD+MeefohzFrrzH03YZTmzJmffUji7oYsJr0T4Rr/uQBg+WLwg8M9oJGdne/rOCPMgFHzB1nwmIvjzJl2Zmgr32LhIK99x031J6BSJGc0cx568faseGvPfayceNdRwweCiOfx8T4Uhbbe+89ZnBE/hHA0jf1o58PV4A981DP9fe+2JFeCsGXXtje+/SPjFsOv2XcdvQdg6XLvYdOG/sOd+w5+Lpx4+M/NPY+c9q4/Uc/N3Y/8oYR+jtH//PfO2Z8+s4jHd9+1uDhr8KVDTVmJi8edVGY4Fj646EYhb0sCZLPdKZ7IfTJD32Fveuv7zacWhhzGHMYT+jPrR/GrLA39EOf/MX03YZTaxqzmjHbatKY1jefPW1gVIUTGHceOZ3RSPazDDaTO/bAsf6fgyeNLF5Q10O+9qJyrR9YvubssqCBDttF8cbw+lnK5qEtbBiT9gXttMBOJsvXu7932Lj1gRMGj4BxLLaxeRaxr7/jMSMfKIM+xvzlI28bf/LqT4ybHj9pXHf/y8bvP/eOwSNCTN/8rPeeR98wPnfnM8bvfesJ4xN/do9xzXePGkzTfIXGFzxDf8fof+mR14zP/K/jxp4nThpDlrKZhs5uXYJlvQvv/7pDlv7Y1i+o/PLCRx1pSZAImcCjN6Ef+h7ZQH234dTCmMOYw3hCf279MObQJxNCf3l9t+HUZhgzZoMlY8ZqV2w/dPRMBsMr/MDQHCLZyTIcUXP64VhZtgftVewqQFMpEgx0iuKNeevHknm1CNvAY2j68xt77jpi7P3BceMPH3nJuPneYwYL9bc9+LyBPbPcveuOxw361voY8w0HXjWYpm945HXjpqdOG19//afGLc+cNFio/MMTf2vwk38sh37u24cMpmx9NSNc99fHjdDfOfpffOBl49oDrxu/f/wdY4gxMz2x0MckxRTGF06AKY9lQ7aBXv6faSLzKS/FmRBD3/8z9DdQ3204tTDmMOYwntCfWz+MOfRD39US9PL/XEjfbTi1KWPma0LYjFoyJsRDXsBD82QClqCQQz4RNTMYvggMekTV16/As7fO98yEZrbIBzWofPn6MVG+4AQsaO/7wfEON9rOenff+ZSBxRJhLw958dMUxG954HmDL1P5UUSfCjFmn4jve9G47vvHjWvv6mCyvvnp0x3pVRK3Hn3HIJOfOvjK0bcNJnFeQAEseO578pQR+jtH//fufNb41B3PGJ/+zlGjZcyg9jz1RRGZmJjI8kzXw/SU1zEVCf3Q72VKbW303YZTC2Nukg9qUPny9Ycxh/7VoR/GzHboh37NlNpgfbfh1KaMmcVqJndMWg2JyMPHTxm8xBwwxdqiMD+MkIiaGejeIaBJDaoPWhX5xHnZOtut+slBk7567rB8/Tff95zhLw+5q/uK1I3ff9bYnX4UEtvGjHUhGovd81eHDIzZv0CVfnQSw75lfwdHQZ8KsWR+1I9pd7JQ2b2O0Rcq7z5h7Lr3RYOvzfBT+fww/r6nTxm3PnvauOXQGWPXg68YX3rk9Y70csfQ32n6n/nmIeN3bn/S+M/fOmy0vi4FaszvvmezUp6YOpjOmLCACYu4LhvSl2VAz0wvZyBnMv2Ffuhvnr7bcGphzGHMYTyhP7d+GHPoe2bor0jfbTi1KWPGqJjcsRw1JJjYMx7WmRyZ2AB9VUE1ySHC3pw8EP+JsdQXUKMetoF8cug1qVm5VD/GTCZ99axh+fr1q1lf+u4zhhowlow9Y71s85UnFPbdc6wjLX1j1fRiL1+yok7AmJmgmVKZXvUFFLxkcfcjrxn7nvhRR1q6ZCrn5/+Y3Hm5496nTxvX3vOCgXLo7zR9fcHIF+5/2fjc3c8bwxe0mYyYvJik2Aad+PhSCpPaZGqDboIj570EmUQAtdAP/fXXdxtOLYw5jDmMJ/Tn1g9jBtRCP/SX13cbTm3KmNVssC61JSxZjZl8zBsboC+wV22yBaaIZrGrAE0FfdA4+Rit6itkao72zd6WIV6j+sWuAh4r+/aR0wb2jOnyqpCb7u5gIXrfPUcNFqv3fPcZAwU1csDC2ctCN9eLmjFmXrW457E3DBYqb37ih8ZNT540dv3gBUMXPxWWPflR/ZsPnTZ2P/SqwSInk37o70z96x95zfjMt48Yv/MXTxnzGrMu+hFhymOCYyK75+gZ43/cdeKykIkODNFnmXEymXawl/zJmxcvLVcqoR/6q9J3G04tjDmMOYwn9BfUD2MO/dBflb7bcGpNY2ZbzRh+fu4jg70HT5wxMGZ6KfozYUToRUQV2CY/d+8BBdUHdDSz1tcf9Na9gA59W/q6XevnQ/eAMas9+/J1+ooUrxn58n3PGSxTX/sXDxv05UEw4lgyy9e6lytV2zNfobnhoVeN/3L4jPHF7x83PvXnB4zPffMp4/q/PmGwaMmUzfLmjY/+0OArNEzofBWHCMubob/T9D9757PGf/jje43f/u8HjU/fcdhoPQimxszXSJjICn/NYLQv/XirgHj/3kIqwxGZXi/+6mODberhRRC6lwmUCH1B6+fFEZrDduj7f4a+9IVa3204tTDmMOYwntBfUD+M2f8zjEf6QujPq+82nFrTmPnZR8iubPDKETWnpjGn5WUesCJCvhoeESV374G+qq9q5GBIWTZDpuazjRqgwHatv3z9WPL3j50xMOYvfecZg71f+MZ+A+vl9SPX/eWjBnuvuf1Bg0Vsvmr1tf/9ssFerJorhTEDxsz0+ttfv8v44l3HDF4f8Zk7Hjf4kfz/9I39Bsueux96zbj99M8NfvaAR4qYrHlcCK69+wUj9MfW/8T/fMbY/9RPL8sy9X/iz58yCsEC9K/5wQvGf/yzA8a/+6O/Mv791+4yWgvaasxqloWzFvzdOz8uyK5sFLuMonuBHpdJU2ERUpci2dYlR59YfbuDHCZfJlwiWTZDXPeyHfpAXPeyvRP03YZTC2P2bdQABbZr/TDmzTW2TdcPY4YwZiJZNkNc97Id+kBc97K9Dvpuw6lNGTNmwxRfWzIRXkKCXWFFLWPmxR1ABP2WsfEQVu5+WVQfNWAvxqz2jP4k7VL9oJasypDFjVXVzw9mYMwsZRPHXG++/4TBF6JuuPNJI3ecCY+M6VWrjZmvx7CAecvRt41d971oXPP9IwYLlfC5O582rrvb3OW5XQ++nOge+dn96A8NfwjovpeM6+99PtFZTuiPof/Jbx8x1BTV3lpoPgvLQ9BehWCBZhYiRsuY1RTVLGtb1QjkZEONWeNFF6OO52RD6+EhHaZ4pnsmeqZvbOC8zcjvde+LKJj0ShOuGI8qhH7o9+u7DacWxuyEMbeMYdONbdP1w5ghJxthzERCHya9NlvfbTi1KWNWc8KAgeVrDDj7k0EEskNksCsyiaBPRL+epGh+P5qPfWr9aswK+d5r+tCGKoNnJlZbvxoztqp7seRd33zcIPKF//f+DI+DYeF8RSr/+8nAnoFrp8Z867F3DGzj83ceMj57xxMGS53wqdsPGCxs8rMHu/a/YlzbrcqeIH7TYycNftjAzSn0V6qvC9eFL85FdtDLUnQcSCFSoOZXG6paJtTxOqI6Gh/SF4irjtbJRMmUqtNrHSGT6ZXlViJ8PUZfuAg85kMOkdDPHY2drO82nFoY8xSqDJ6ZWG39Ycyh368fxtyKqI7Gh/QF4qqjdS42sW66MYR+HSFze/TdhlNrLmVjRdgPi7QYsJofEQyPSA12xTb6UOvzRabc8bJkL8xM7V1C3yus9HPx3d6l6//Ws6cNteciIYMB88AXX1cDrPemu48aXIXanvmnFcbMjxbseug1g9dHsMSKkXzhu0cMHgsisuv+l4wbH3vT+NrLPzH4ag2LsfywwZ5HXje++uKPjdBflT5LwRhb4YIZPt4KS2181IvkBSjEjXn1MTlsDyOs7ZCImmX2zkydM4aCxqncT5xJeetjg8mUyTcPS0bHh15M3yxy8kUaX9Ikh46hH/oJt+HUwphn4BVW+rn4bu/S9Ycxh35LP4xZqXPGUNB4GHPoZ9nM2Ppuw6lNGTMGgxlgP0SwJbVkwJgxJ40r9GVb1Wr93MXgWMRb+sTJQU331vpoKsS1F6jpklOr1RFVUH1ew6l74ZvPnjaw59qYeRyMV3Luve8546dnPzTUkmHv3UeN2pjJvOX+EwbGzGsleH0ElrD3yZMdh94y/vS1nxq3HXvL4NWM/IT+TY+9aWAzbPOaRl5JwcIsy7ahv7y+WjIPTKnV1ZMCH2niTBAa4ZWBqtAPvZbXx9jU8LJHZrIvGq2c3N14d0DT/ELKIK7HLRKM3N3gLBgHplTOet7xoS9T9rmtDwy2WQgN/dAn7jacWhjzDOUw5s01tk3XD2NWcnfDvbe3aX4hZRDX4xYJRu5uhDGH/nbquw2n1jRmTMVJRsU2XxbCkjEDz085bCsYGMagNjaF9EUfY8MatSqFOPrkFwmG6rM9RJ/MWp8Ie6dYqH4Mm5eNYMz8oMWeuw4b++57zrjpB8cMLPYfzn1oYM9qzLv+8n8baKolk8/PYzD+Nz7+pnHDw68Y+w6fMW588qRx3f6XjD2PnzT2HTpjYCf8sAGvcvzdbzxoXH/PCwavreDnAvccfMO47djfGKG/jD5fNFJLbhkzH3KmCZbXeCyFaYKPOjnARECcL3swcTA1+HSTcpbXV0tWq8vOlyOgNknEPTa1Ogc4ChS7jCE6RKCuTbc5yqrGZ+zxD/3N1XcbTi2MeYY+mbU+EfZOsVD9Ycyhr/phzETcS1Orc4CjQLHLGKJDBOradJujrGp8xh7/0N9cfbfh1KaMGZthij9w9IyhxoNFAcaM8Xh+49Gnh46dMjAG1Oil+mSqPpbPUYjU+kTQB90L6Nf163EBtTqu+uxdVf0Y851HThsY83999CXjlv0njNseesHAaDFgjBawZ74K9flv7DfQJEIOj33d8M0nDMb/G2/+zLj1yDvGV1/4sfEHJ/7W2PfM6Y5kOV994e8MHk3iQaTf+vpdBl/sue6uEx3plZMsyV7zncMGXxkK/cX0P7v/ZYNFbLVkUGPmw8/Hm4dNzm590HHhQ2Pyge84d/43BpGtix08csJEoJnnL3agtow+BqbGpvZWb4MaJwpqny3InDefo3BErYF4va0RFNZ5/ENfe22ivttwamHMDmp1XPXZu6r6w5hDH/0wZuIoFJ46EzLnzecoHFFrIF5vawSFdR7/0Ndem6jvNpzaDGNWs9EIi7SYDZDTMh5wS07WqGqgmbW+gtVxLNC+UCtrBH3t+/dnP8ygr0dhOZpMUDXQvcvXv/fe4wYL2rxKE2NWsjdn6+WnHlHg9SPEeWnJzfufM7gKe58+ZfBoEq+82H3wNYMv+Xzl2NvG7W/+zLjl2beN6+4+nuheDInx8PoLXohxw4MvG7ccecv48uG3jdCfV/+L979kXPPAK8YQY+Yj7R/stFzGRMBCGdMBMAUAERbZdOIAV0vTRBbvIoP11fZqS6sjWCPbapyQ3bSH5fPrSuo66wgK844PkfHGn0joa69N1HcbTi2MOYw5jDOMeamJCbtqmVkdUTtsGWc/y+fXldR11hEU5h0fIuONP5HQ116bqO82nFrx8BfrtJceVmIbE8JO1GZ0L9ALG9Bt3VvDwiwG+RMB+2EhV80J06qhKrZRrusnPq8+yvStWVX9LbQvaiizAL73vuNGUZLBXuAqfPLLP+hh79M/Mm45/JZx29F3DJZe9x46bew73LHn4OvGjY//0Nj7zGnj9h/93Nj9yBsGDz1df++LHemlGXwpiO3QV/3Pf++Y8ek7j3R8+1mDh78KVzbUmPnw86iIwgTB0hkPlSjsZUmNfKYD3QvFLTGTLGvUVqeosQFGSL6Cjqr1s9p8qipKNYrTMchHJw++wegtP/5jX99l9N0kUvtNav4f0UZoYcxhzM5mGdum64cxK+ioWj+rzaeqolSjOB2DfHTy4BuM3vLjP/b1XUbfTSK1MOax24ylbDUwNbYDxzqwKM1UMACFOPlqNpgZamxjNmxjcmwvZmx1/URWpU/f8epXtC9qLFbzihKsl7NTeKwMuBbHz32UOXS248F//Gfjez983yjmX2PPo28Yn7vzGeP3vvWE8Yk/u8e45rtHDWyGrwD5gu2Rt40/efUnxk2PnzSuu/9l4/efe8fgESrsjZ/l38n6X3rkNeMz/+u4seeJk8aQpWym0bNbl2BZ7ML7v+6QpTO29Qsev7zwUUdaUiNSXG6DO0HvkxrNv/V/PGZkh8uomWFymF+RlsmuaRS7ZjJGPhXWllykGZz18uNPJvDo0GqvL5mwmP6Ff/pXw+1hpe0DaXWk1X71wb/0gA7NO6RWR1qtECxAh+YdUqsjrVYIFqBDC2MOYw5jDmN2wpjDmD2StsOYFXRo3iG1OtJqhWABOrRpYzYHnZgokzvboBarEeDhLzVjHp7y5KSsNoN1sRezwdjU3lg2B3KyPxnZtwrYi352KaPWByKL6Y9RP/lsk8mXoDBjtvmqFfAzGHqmoDlcl7Pnf3NZnj37kYFtM/mynPu5bx8ysBx9tSRc99fHjRsOvGpgYzc88rpx01Onja+//lPjlmdOGizk/uGJvzX4ScSdqf/FB142rj3wuvH7x98xhhgz0ysLlUyyTMF8YQOYUlmWnEyvHfRimyvLVeaKF7fBZcHksC7MrHCvDIZXBAuyaxrFLkP3DqHobvTvVfqrVdtGbbHxxwixQOIY6qqu7/L6WPJqjRl996iqUVV//b/c+j8zwdg2Xd+HKbUwZo8spj9G/eSzTWYY89WnH8asoAbFLkP3DqHobvTvVfqrDWNepqHvPlY1quqvv/CzzPYY59j6PkypTRkzhorZ9EMm8DUhzAADwJLZy2IvxozNYGkYjGqyl216qdXxmknsTU0u+5mBJgYGqgz0VWUYok9kvPoBK2UvR8Gq84EMxjb7rpH9OEMO+VwXbhS/dSqKmddgymYS/8rRtw1MiBdoAAu2+548ZbhR3feicd33jxvX3tWBmd389OmO9KqNW4++Y5DJT0HsNP3fu/NZ41N3PGN8+jtHjZYxg9rz1BctZGLtv77A1WyZsU8ivfpkspyrxqzb2BgmN8QOydkeikMXkEPlROqzY5sRmHf8gUwf7cRUZInrC1NqC+m7JQxo/Q+CuWtJy0X2MFXtgPqxt03X9yFLLYx5Dn0iYcxDjGfTjXNs/TBmhZztoTh0ATlUTqQ+O7bDmGlhzDWL6fuQpTZlzBgqZA8w+BoV2w8fN8e9lNZlJtNl6scMyMGc6MU25sQyL3FAHzvBkLAutTTiWFf2tgwGNlVVUkYTY0MB6DVcH8gcr37+MYEOcSrX+lvjzwjTF2pj5oYAbghuI10We/c9u2M+ZPJ9Y+tjQx8Nu+XQGWPXg68YX3rk9Y70ckp+9BBbmizkdq+r9IXcu08Yu+590eBrRdfd87yx96kfGfuePmXc+uxpY+fof+abh4zfuf1J4z9/67DR+roUqDFzjSYf7A6uXf/15QpyNbmyXOWt9HIDcibTR58+1oU5QW1dGiE/O18Be1tgflDsmsnw/KKMDHtb56LbQL6OD/R/vlhG9sw5x997jazvlrBQYwEcG6PV+ps+PmPo+/ClFsYcxjzjxgpjHls/jBnY22K40cLw/KKMDHtb56LbQL6OD/R/vtbTGLK44ZawUAtjXkzfhy+1gcbcfelIp/sJnUkw6WNOZGISgBrbWBom1NLHfrAljI0IlqZoJpaWizdQRhNjoxdH76fWV0smJxdvrLZ+dFDWyrWXjj+ZjDB9VQHNfmPmSxfcNMCUXcPkDtfe84KBdQGWg/3oCzp4CeXuR14z9j3xo460tIvV8fOImB8vv9z79Gnj6tbXF4x84f6Xjc/d/bwxfEGba8fV5EOeL67B9dXrVVzKDDrvJbgTiABqqo/tYUvZtwq7YikY04La/IaQXdYods1k3nxo1cZZ6HnV58uxWuPPGNafL/KZoMkZPv4wnr6bwRKtNmbVh80dHxhD34cvtTDmGdT6YcygE/2VNbZN1w9jHgLHgmLXTObNh1ZtnIWeV32+HKs1/oxh/fkif92MgW03gyVaGPNi+j58qU0ZM1M5MPVjOZgu0/3EEjrIVGMmgnlgFRgD29gbJoRCrU9fMkFtCcgBbJKjcHRAH030iWB1/VChHkXrGbt+dNAnp+husJd8amaE6QvsRZlrxK3ALcUNxI3CMsvkZupgL/m8lk+n8qPnPjKY7jEtXkW557E3DBZyb37ih8ZNT540dv3gBUMXhxWWhXc98JJx86HTxu6HXjVYBL669a9/5DXjM98+YvzOXzxlzGvMumhGhOvL1eGVIHrtWteXe4CIUutjRbVRKViampzaHgqQE2YyPBOG59eZLWMuTi2jxlyPPyM8/PM1fPzH08cF+h/mGtLcjVPbzvqJbK6+D19qYcwzoEI9itYzdv3ooE9O0d1gL/nUzAjTF9iLchjzeuqHMeeEmQzPhOH5dWYYMy4Qxqxsp74PX2ozjFkn/YMnzhhsM93zIhEiTPdsQ/abjBoGJtSvr5aGghpSljVUTTV1G022+VoX9WcPLshSBvrYMOgR0Ryjfq1Z81WHvRydyumlcL4oc6W4pbh12L74q48Ntnmsny/C615uICJM7hiz2jPLs3zF6IaHXjX+y+Ezxhe/f9z41J8fMD73zaeM6//6hMGiLpbG8u+Nj/7Q4CtGGB5fVSJytep/9s5njf/wx/cav/3fDxqfvuOw0XoQTI2Z6+VzwcUOrpFaMteIqzbk+rpaotbHrjAkpXAsg3h2uILsiEaxq2B4JgzPH5LZf3YK+TqGbDPCbC8//prD9mr13QaWbu7Jqam+1sD2auvXHLY3S9+HL7Uw5imylIF+GLPeWGHMq9UPYy52FQzPhOH5QzL7z04hX8eQbUaY7eXHX3PYXq2+28DSzT05NdXXGthebf2aw/Zm6fvwpTZlzPWEjgEAe5nigTiZaiEKDzfRl/x+fewKUMCKsmAGs+QBKFVTfT0uYGOqU+vTl0Xgfv0sa6yqfnTqOgFlzSeTXorWz/Xi5uCG0MUWhbjuZZslFzVmvnKDDVx79wsG9vPbX7/L+OJdxwxer/GZOx43PvHf7jH+0zf2GywL737oNeP20z83+FkIHrnCzHicCjZF/xP/8xlj/1M/vSzoX/ODF4z/+GcHjH/3R39l/Puv3WW0FrSnjDktf/GACdeI68sV4eqoMQ+5vhPNNHFU+tgYVqQWlR0rR+qFa7Y1UsdrNHNeCqmCVqZGOIvWOeo2vZb/fPWP/9j6bgNLN/fk1Laz/k3X9+FLLYx5hj59w5g1wo0VxtyvH8ZMJIyZEWOEFeK6l+0h4z+2vtvA0s09ObXtrH/T9X34UpvDmJnciTPdE28ZD3E1Zvr2Gxtx9DGhWh9L48UaMOnVgT5qgD4GBvVScxbP9OuznYs3ONYkbfH60aFO7QVoos9xyaSXovpcO78h5MbiVuMG4iEF4twuupfJHZj09cUjWBpfH2KB95ajbxu77nvRuOb7RwwWcuFzdz5tXHe3ueNzux58OdE9ErX70R8a/pDUfS8Z19/7fGJ99T/57SOGmq7aZwvNZ+FaGWLMvLgAJletgytSv0gEWteXaeK83RjvXZLN0Av7wYr6WcyYNd7PZ2/9fqbY1UPrWHWcbTXmfui1zOdryPiPre82sFDjkTGae3Jqqr/p4zO2vg9lamHMXmcWz/Trs52LNzjWJC2MOYy5D80vXNkIY+4njJnIavXdBhZq7smpuSenpvqbPj5j6/tQpjbDmIGvADH1M62zjXlgbIAxYD+KGgmak8XVTkH1IR86QxwbU3IXAzXsR/VVhwqBfyho/dRZFG8Qb+mPVz99W1VNjLnrpeeVD5pRfa4gyyncBDy+ry+EAx5DIIeITusP/uM/G0z6gA24+SVju/XYOwa29/k7DxmfveMJg6Vg+NTtBwwWlvlZiF37XzGu7VaVTxC/6bGTBj/8sJ76unCtljkv2aF7qI2Zq8OV4uPN9VVjBq6aXke9vjp91BHVx36wqyGQnz0vQ7xmuNFmV54rvwhmivIM4sXp9ED+Yp+v4eO/PfpuBnM29+TUiLgzp7ad9RPZRH3GjRbGHMZ8mRtLJ/QwZtUPY+6H/MLzDOI18xrtvPlFMFOUZxAvTqcH8hf7fA0f/+3RdzOYs7knp0bEPTm17ayfyCbqM260pjEzlQOv0eCLRhib2humwteisJPseQZWhCYmAfTC3tDPh57JgWNnjCkzE3uDLG5oX6xLKwetk8rr+jHCWn+8+snXGrQ2HU/OS7+QVoMy15GlGL0VuL1YhOFB/2v/+/MFTOVM7jxMxI8GAlM/ZsCPOux66DWD12uwRIwRfuG7RwwemyKy6/6XjBsfe9P42ss/MfjqEYvJ/PDDnkdeN7764o+N9dFnqRnLVLNU+PgpOv5F8gIU4oZa8tGzH3Wk6wW1PXtHJp2tjw0mCyaXLJvBfli8bT0GBWpXhecZxJXssj32qaw2vyjPIM5Z6Hm1zpr8IZ8vX9Ikh4EdPP7bo88LNd0Slmjuyamp/tj1b66+D1xqYcxOdr6i/jBmJvEwZtUPY25ZFIQxtz5f62wM6IcxXyl9H7jUZhgzkzgmgeUwuReulsGcsAe1E37ygb4oq1qtT04L7aWmqPGWWsuYQavNxecIRljr9x+xRnv1108+xwX+ccBZ6HI3EXSI1KDPNeUG4ibg1uGVctwu2LCaLqg9K4fOfmSQgyXw2g1er4Gl7X3yZMeht4w/fe2nxm3H3jJ4deVtz/2NcdNjbxrYJNu8xpJXdrCwzLLzOuirJdfLy/6BlA+tjnZr/FVhCC19rkK+cEZxyTJMHyzEocM9gE5LH/upbUm3oWXMRGr6jbNmjPy6znmNuf/zxZif2/rAWGz8t1PfLSE1X6FOzUODmztzattZP5HN0vchSy2MOYzZb6ww5iH6Ycy1Lek2hDEzYvr5YszX2RhU3y0hNffk1Dw0uLknp7ad9RPZLH0fstSmjJnpm6lc0aXUwtUMtRMsjTj5WA57ySzEDfZi7WzXYGao0Qs1ItiV6mtfNTnIxRsYMD/RqPVjhy19haOsqn7P10Okvm7MljzZ1iOSw7aCPleW24hbgRsFuFFaxgzs5QbSKZ5lUizhxsffNG54+BVj3+Ezxo1PnjSu2/+Ssefxk8a+Q2cM7JAffuBVl7/7jQeN6+95weC1Hvyc4p6Dbxi3Hfsb48rq80UmteSWMTOqfIxZ/uKxkf7xJ86XMfhg89H16SDlcBR61fpcBf7BpNdI6dfvrx/74acdMCTAotSo1N50u8UQ41TGy68rb50jMBrkL399x75/huu7JaTmnpyahwY39+TUtrP+LG5sir4PWWphzGHMfmOFMffrhzFjP1iRmlNtWrW9sd1iuHHCePl15a1zBEaD/OWv79j3z3B9t4TU3JNT89Dg5p6c2nbWn8WNTdH3IUttypixAZZGDxw9Y6hdZW82auvCBoiQgwU+dOyUwd5aH4OpbaaGR89Q4IhE0AfV176YFr2AI1Ih25wp50X9nEtLf7z6PT/pE9H62csR9UxRY1tBGWOe3BAd587/xiCC6fLQUOHHxun3PzbI4ebj9mKi58cSsIRvvPkz49Yj7xhffeHHxh+c+Ftj3zOnO5JlfvWFvzN4tIoHqX7r63cZfDHpurtOdKRXZrKkfM13Dht85elK6X92/8sGi9hqyZBd2dDx4WGQs1sfdFz40GiN/9bFDh4J4YOqmecvdqDWr89V4KpxdVarj/1gSGpUCnvV3obQb5y6dwhFd6N/b4uWMSvsJV9HdYzrq73G1ndLGND6Dds9OTXV3/TxGUPfhyy1MOYw5jDmMOZB+tjPEKMKYx7j+mqvsfXdEga0MOZV6fuQpTbDmIEF3r+v0IVfjE0Ng23iLM/qXtWH7GrGEGNDDVQf61Jl7UuERWDPl0yqpQYsWY25pQ+5eGNV9ZOfD5HRRWwg09UaxowlH06N2wW4RaA2ZswYiDPpc0tBbcx7nz5l8GgVr+zYffA1gy8pfeXY28btb/7MuOXZt43r7j6e6F5siXHy+g5e6HHDgy8btxx5y/jy4beN7df/4v0vGdc88IoxxJh1fFjO4oPKQlZr/ImwCKYfbHC19DHO4l2k0ucq8D8XuDqr1cd+WLxVu2Jb0Ye/hqDGWfOFL3zdKIIzGZJZHLqH+uEv0LNmNMjXUc0Xd4Xjr73G1ndLWLq5J6em+mPXv4n6PmSphTGHMYcxhzEP0sd+sKLaopQw5nxxVzj+2mtsfbeEpZt7cmqqP3b9m6jvQ5balDHrqx9Z1MWA1aR/IvCwErZR+IGB8QARll7ppQbDEXPHmag5qTKwV/Xrvm5gKZ9tMtmr9gxEWvqaudr6yecowF5q5oj8I0D3An0xY91mL0srPHSgqDH/8aP/NBNymPp5VIGpH9S8r7/3xY70Ug6+dES8xd5Dp419hzv2HHzdKBIKNl2/GHyjSCjQKYAPf5GQ4SrodUGfviypce2YDnQvoE+Owl7sJ/uToRbFtkbI76dwzQKMdojdwvD8ooyZtM5Lt4F8rgKjquQLNJM8+Eb/9e1n+eur84NbQqP1L19rc09OrTX/cPTV1q+w1wtKbXj9V6qFMYcxhzFPMbZ+MfhGkVDAtAJMTEVChqug1wV9+i4/8aldQW1XGiG/n8IvC4YbLQzPL8qYSeu8dBvI5yowqkq+QDPJg2/0X99+VmtsbgmNNtzY3JNTa80/HH219Svs9YJSG17/lWpNY1YzZltNGtPCKgAbUHjsSPdiD9nPMthM7tgDNoay6qMMekQgfuBYIi35aqbC8jVnp/qqUxRvrLZ+MtlW66V+jkWEvgo2rBAnX5dWMFqFab3w4wKmgLNbH15CbECXtRWUgZxDv0ikL/YUyYZm1hTJRhbPvXamvl4LhYnplxc+6khLakTyqprBoytMc3p92Xvh/V8b2A8LvCzhYku1UZED9FIKj+xhuNHCvPlQlGdo/XpeeqaMADn04ioUF8vIFzdftWXuH6Avr1klvxAx8sU1hlxfnR+wLprbw0LNPTk11Wdbv4C0/P1Z66/q9aJ181NKrY602q8++Jce0KGFMU8Rxlw4cQEfeP1gqAEwZeR5IYMy+LSyxMRUJBtZPPfamfp6LZRVTXxqWthSbVdADtBLKXyxh3mNdt58KMoztH49rzDmeZs7Umqqz3YYs4IObYYxYzZYMmasdsV2bQzZezKYEJlEspNlOKLm9KNHVH1/eAoqNSL0YlsjgGFPRa5Q/WSyrO17E/SqI0D9asaqzwP9gA3zkJdSePBM+MCz0MSHhI9Q4QQGkwUUuwo0E4qEmQzP10woEmYyPF8zoUiYyfB8zYQioYApqY5w1fK/wwqYEJn+6uvLnaOmlb0qQ7yGXoARDrfP4ZkwPL/O1DqLU8gUp2wQp5eO+fDrpZlQJMwFn2W1fK7mkOsLeIF7cmpEFmvuSKmhz93IsjPbQFX+n8losVjiw+ufCHaWvFpjRt9PpmpU1V//L7f+z0zCmH2vRiCMufDgmYQx12gmFAkzGZ6vmVAkFDA11BGuWnbigiETn5pW4U8G8Rp6QcsUWwzPhOH5dabWWZxCpjhlgzi9dMyHXy/NhCJhLvgshzFfVcbM14SYytWSMSHikP2gM4BE9p4Me8knomYGwxeBwY+YLEf1sTSNkO97K8gE6p+KJP18UIPKt7P+fsgEHX+MWfX1xuVGYSLOfmzwtahbv/WqUThxAR/1qQf9K/1ipshMPjAd/ZkQ+kVCQUtfdZT6uivsRbN1fdW0ePmGLucqLPnqwi991Q4hO+VMhmfC8HzNBCqkWq2/ODWDs2YEiNC3/6rptejPhHr86aU6StHd4MrymaUvmv2fXzeDwa3fvN21UkO/KHsmZHq1ialIb/0o+OEHtOH103KRPUxVO6B+7NkPmVoYs9c/FQljbhDGvP76qqPU111hL5qt64v9YEVhzGHMtOHGhn5R9kzI9GoHGFs9Pn74AW14/bRcZA9T1Q6o/zLGzGI1UzwmrYZE5OFuvbeb9zOYSm1RGANGQkTNDHTvENCkBtUHrYp84ros3KqfHDTpq+cO21m/xofUjyWr/uTCd3C7cEMwBWPGgOkOMWZy+Ki39IEbjrguW737nt2R3RqU4Znpy/XkTG7fLif0PXNF+lz37MQzIaelj/1gRdgSNkZEzQzU5NhGQe2w8MsCzZyXQqpAM6mqrpZthTNlb23MfB5b4882Yzv2/YMxv7H1scHy+LQ9z9Z3G1i6YXXuY6mhP7z+5cfHS1mosQDupadW649Rvx8+tTDmMOYw5h2hz3UvnLiAnJY+9oMVhTGHMbdaGPNi9fvhU5syZm4sLAQbUEOCiT1fMgAyMarsQFlBNckhwt6cPBD9+hCgRj1sA/nk0GtSs3KpfsyPTPrqWcN21q85WpUU7/VjyVo/lxm4ObgJ2OYjyse18N2BoNDSB71x+VIEN+Xk1oTuBiXnvQSZRAC10F9MH6MFrjj/FFMz1gg55Nf62A9WhC0BS7tqZmxrROPoQMssx0CPpTW06tQ425ypnnttzLA915ecWh9jruGT2/r8ug0s3Wpjnrd+8hcbHy9iiVYbs+rDGPX74VMLYw5jnpvWB5ttGO+DB6EPqLX0sysbXPEwZtAaWnVqnG3OVM89jLluYczkz1u/Hz61KWPGBtQA1JawZDVm8jFvTIu+wF5uU43XYCpoFrsK0FTyJ8HQOPkYleorZGqO9uWMFOI1ql/sKkBfadWPmtaGAnEgU42ZiF54XVQhwseSKbhw3Ax7WzkocKxan1uWG5QbkWWcyc3awV7yJ2/Ou7QcpIT+YvqYa3bfbLqAGQMRvb5qzKqP/agtAeaEaamZKcQVtTQofHTl6LE4elGSUZRtEOfs6FWcvoEmnwjgE7o+94/aMz9zwqdY9XEBbJXtxZq7WWqrqp8cIsrVVz8tjHnK/LRv9uMM8RrVL3YVoK+06kdNa0OBOJAZxhz6tX4Yc40ei6MXJRlF2QZxzo5exekbaPKJAD6h63P/hDEPb156attfP61pzGyrGcPPz31ksPfgiTMGxkwvRb+GRIReRFSBbf3aTz8oqD6go5m1Pi/iIKJ7AR36tvR1u9bPh+4BhXn16av1Y8lsg94cPKbv/3mxg1uKD6ROxEo9TdcPhdWPgKk+EbYv/upjg23q4Yv2upcblIirJVr1E2E79P0/Rb+2ZKW+vjVc2Vof+yk8yVCTw8DYru2tjtAX0K8p/PWyFN0zeqxWPXVEz4i+xekb6PMZ1M/vGNeXCNvz6qsxqz2j7zawdHNPS2219btagnz/z6uu/jDmMOYpwpiJsL2J+mHMRfeMHqtVTx3RM6JvcfoG+nwG9fM7xvUlwva8+mHMQ5qXnprqaw1sj1d/05j52UdQY+aVI3rzNY05Lc/ygBIR8tWQiCi5ew/0VX1V05wsmyGue9lGDVBgu9Yfr372tvTZixmrJZOpSyJ+4X27g6UVbg4+isVc3AMTfRE00KF+1eeGI8JNqRDXvWwPrz/0+/W5XixTF65s1P/MqkGB+1P1sR8sSm0pu53BXjUzNTndrnv1Z3L0foarDcnUs9Beeu7s5eh8HuvPb764+WqCRrbn/lFj5stUfIrJcRtYurmnpbba+vvHxw+/dPPSU7tS9Ycx+zZqgALbtf549bO3pc/eMObQ79fneoUx96sNydSz0F567uzl6Hwe689vvrj5aoJGtuf+CWMe0rz01K5U/VPGzM2EAdSWTISXkDAdc9u1jJkXXwAR9FvGw4NOuftlUX3UgL1s1/qTtEv1A9NQrQyTXh3j1U+8pY8ZE9f6ufxc5vN2x7zXfZ+9gAvPDcG0W8zFPbTy+UhTv+rrjcutTIU8BDHJ7G5H3Tu8/tAvxI1Jrw6uC9cIe4Z84QpY3Aa1bXRUH/vBitSc1LSAHDU2Nbw6EzSH7TrCdq1QZ9YRtqFfQSvXTNBzJ4eR4bNZf35Xe30Xu3+wZMCSueJcZXq5DSzUeOSK5p6W2qrqHzI+XspCzUtPzUtPTfW3s/4wZieMuUUY82bpc124RmHM9V7oV9DKNRP03MkJY3ZPS809LbVV1T9kfLyUhZqXnpqXnprqb2f9U8as5oQBA8vXGDA3HBABeinclGQSQZ+Ifr1H0fx+NB970PqVLJ7zvZfEoZWv+kTGqF/3qj6WrPlcSC65Xv46QiaXn+UUIsPtmUydstnmI009tT5fD9AXzgGPOZBDZLH6Q59tMlWf65IvXw9MzSqVU4kAADlCSURBVBrRu6K+vtgP5oQhYU7ZsWbSMjkitWWCxtlWVKfYZdQKisZVhwjVarxGLZkII9M/P3C9tv/+UUt+8B//2eC6A1dZ9d0M5mzuaakRcWdLbZn65x0fjj5v89JTI+Klp7Y99XNcWhjzFK181ScyRv26V/XDmEOfsQIdMUZSx5/rki9fD0zNGtG7or6+YcwQxlw397TUiLinpbZM/fOOD0eft3npqRHx0lPbnvo5Lq25lI1VcHuxSIsBc/ORQ6T/5RvclGyjD7U+XwQiEytSiCv5js8UCRkU0NcPj3dMlRw4dsYgf2qvQNz3jly/9lV9XxLhcnKNuWm2Pja42NwcvldgKYa+fCDzjGyo9SpM1qCWrJXX+lTF7csiD18kWFX9oZ9lM+jXV3Y4eq31KqOvxgyY0xB7VjPD/NgGzLJG9+q2Ktd7dbuGvaCVzHsWGmdk+ueH7b9/akvmsS99GFDtGX1eSOmWsERzT0ttsfr9xFPm8PHZ3Pr9wKmFMXslYcxhzFeHfn1lh6PXWq8y+mHMehYaD2Oum3taaovV7yeeMoePz1VozNxAGAO3FxE+nGrJgDFz82lcoS/bqqb6OdnAijgWmegT10zi5LC3RZ1T67ONsn6oiNejMUb9xNmuj8glP7f1gcE2CyncHFzy+qbhkhPnBiLCR5EpWCflPEcb2DBxoFc9PrU+EV5ZR22rrZ9I6Nf6XCOunV5NpbVXr3J9fWtjBoyqtRewNCBCL7XGFmqobGdZo97Ldgs9Igp1bTWcnfZS6Kuf1rE/v0SG3D9qz8qhsx8Z2DNXXPXdElLzFd7UPDS4ubOltlj9i42PHz41Lz01Dw1uXnpqY9fvh0wtjNn12UY5jBmYvokDvcKY11mfa9SyXmjt1atcX9+W9WJXrb2Qnc8gQi+1yRa19WZZo97Ldgs9Igp1bTWcnfZS6Kuf1rE/v0SG3D+FH2fCmIc0Lz21sev3Q6bWNGZuJidNxGzzZQAsWRexyWFb4QbFbPQ2ZS9xBX2MjamBXkXaTFR/iqr+ouNlmdQzbv2AvsKF5BLysD4Xnkvrt0vK4QJzExBn+YXHFriN0CGHD+RwuJpUxXn168N49UPo1/p61dSG2dYIaL5eX644+kRaBoxptfZm5zOKXQZ9sUxtxGvqvjUuIY249oX+2jijVl/21vPDFGn+We31JQfoO1xf7ZnFba676rslpOaelpqHBjf3tNRWVT+9iLfGxw+fmpeemocGNy89tbHr90OmFsY8iPqDN0b9gL6yqgtf31h5Lh4IV5OqOK9+fRivfgj9Wl+vmtpwduUcAc3X68sVR58IVlT4k4F1tfb2mx993T+lEa+p+9a4hDTi2hf6a+OMWn3ZW88PU6T5Z7XXlxyg73D9MObhzUtPbez6/ZCpTRkztxGWc+DoGUNvLD6igDFjPJ4vjz4pDx07ZRTek2npE0efCPrENYI+aK/++jWTSL9+UXaG/PHqn1z4Dh4Z4EJOLm3H+YsdPHrAzcHlJ3J264OOCx8a2uvc+d8YRBarf7j+2PWHfkuf65Udt4f6+hKp9bGiwp8y2Fudk53P0PgQMEV319SItOJF98vSqo2zqOMKOa3PLxH9fK3P/YMxHz/3kcE9oL3cEga0fsNzT0tN9Zevn0hrfPzwA9r61O+HTC2M2SP9+kXZGfLHq3+1F1576Y21WP3D9ceuP/Rb+lyv7L491NeXSK2PFRX+lMHG6hzioPEhtAy4FS+6X5ZWbZxFHVfIaX1+iejna33unzBm2vrU74dMbYYxA7aqERZpsWQgRz/GRBQ3sHRrqloN+qhpXPXZ9khaPmK71mcIgGFikUEHDnSY2B6iX7M+9XskLaeQz0KK9mrpez1SCRHqX16f/JxmuNqK6g99qPXnvT9b+vTCkAqXMrAx9moOccjJCzO2mtavcYW9jNXw+YHxZCTBr+a23z8tYwa3hKWbe1pqqr98/f3j44dfunnpqan+GPX7IVMLY54xcEP0a9anfo8s9MH2eqQSItS/vD75Oc1wtRXVH/pQ6897f7b06YUtFV5lYGPs1RzikJMXZmw1rV/jCnsZq+HzA+PJSIJfzW2/f8KYhzQvPTXVH6N+P2RqxcNfrMN0jzBgq/o4A7cglsxjX7oX1Ix1m738ac//9FY4Pf7k53+DU67uBU6eHIW9oR/65Ie+wt5V6fOpx5YKrzKwMd1LRMnJCzOeGhDnLDSisJd/XjO/6fypsJf5k/Fch+tbGzNk2Yzuran1i4SBrOr+pJdbWqP1L19rc09ObbXjr7DXD5laGHPoh37oz6HPpx5bKrzKwMZ0LxElJy/MeGpAnLPQiMLeMOZav0gYyKruT3q5pTXahhmz3kDYqt5YB451YMmaqWDDCnHy9U97tvUB9F9esL/ure7uT34i+a9+g/+1zmmc3boEey+8/+uO0A/90N8WfT7RmJPaFTbWioPGF2N71DiLVpwHvnR+A43U8+caXd/KmGuTBl7bCeQc+kUivaKkSDY0swV9eVEo+YWIcZn6e8cH66W5vS3U3JNTU322V/v58kOmFsYc+qEf+nPr84nGotS0sLFWHDS+GNujxlm04mHMYcyr/Xz5IVObNma7nya3FMbMNrRuQeDhETVjXeThgXLglFgWYBv48z+//bGAE+b0yOQkGYLh+v6faSB8yFI89Onl/xn6oT9An083RoVpZYcrzEwZktPP9ijUOZxpPb/5zCnzJ8vavjdBr9WOv6sl6OX/WeljwzVvbH1sYIQaxyxB48W0nGnlzwuvCFXLp/7h44OXuSenRmSx5p6cGvqM8LzjP6R+P2RqYcyuFvr08v8M/dAfoM+nO4z5kitPZsgw5sUIY6ZNGTO3jt5MLcgEvgaAkWPM3LLs1QNTaD6TAi4wF6aGvX6S+qD5YH2FTFdLTEVCP2UywjE+NVNqO1hf5wRMqzazfubNB44Fxa4e5j2W5nMsn/FkfvPTT5Y8FWnAuE2N9hLj30LV1PaOnv0ogyVjpVggvTRfGTI/a/689WtfQFlrQ7N/fNzMBrd+83ZPTg39ouyZkOnVDr6+fsjUwphH/2CEfs2UWuhXTKmtsb7OCViXmlnhczOZNx84FhS7epj3WJrPsXzGC2OuYK/mz1u/9gWUw5j/jRsO9GbSZZmHu7cQXErrMtNNiSVza5IzOXAH5VIQUBBxlgX6LzyQ8+57dlb5xIbqs01flhE8M325m5zJ8IV+6If+UH2dHzAwzKzwuR6y/82kSDY4ChS7jKJ7QZHcA/kchXPU+Y1tzhqmZkWJ6/iMMf70ZbvWx+T4sQp92Eotmb5Z3Kj1t3N+pubWPx1a+m5jSzes2t04NfSH17/Y9fXDpxbGHBNr6If+Uvo6P2Bji1lgiyLZ4ChQ7DKK7gVFcg/kcxTOUec3tjlrmJoVJa7jM8b405ftWj+Med62QcbcPfTPYvXk1rx0g2LJ3HxkchigOIpgGzgxLiRwAU6//7GhF1sj5JA/RJ8cHmpnUCZDA90AkfNegkwigFroh37oZ3Gj1teZoWWZLbJrGsUuQ/eiXKM5RXejf28LlCdz4KX5LU+MBrMlZ50nT0Nz6DX2+Lf0MTngq0rMooDhtfTz5GyQvz3zs9asUC3U+m5jS7famOetn/x5r68fPrUw5phYQz/0V6CvMwOWVvhcD/3GqXtRrtGcorvRv7cFypM58NL8lidGg9mSs86Tp6E59Bp7/Fv6amxhzEPa2hmz3kzcatxS3JS1MZOpxkxED6x/1BPhlLh4+ermiwpcbCCiP+quF76lzwAxECwjTAarg73kT96sdmk5Qgn90A/94fo6P2BshdvNZDHjHM68+tOWfGkOJKK0zJgR0L558I3xxr+lr/bGsjbzKiZX66/b/FzXT+Wqj4thq2wv1tyNU1tV/eQQUer6aWHMcwwckdBXQj/0VV/nhzBm7ZsH3xhv/Fv6tbExr4Yx1809ObVV1U8OEaWunzbDmLml2D544ozBNsbMi0SIYMlsgxbHY+L+n/bX/cWPOKX6kiv1Za7xm6mhT4Tti7/62GCbfL7orXsZICKulgj90A99/8859ZkNmD0wOSj8LzOvcc7LEH2tU+tnG5gbga+JakRz2FYFHR8dve28vmpswHzLjErOOs/Pdf0cC323saWbe3Jqq63f1RLk+39W9Ycxb+sHw9USoR/6V6s+swGzhxpe4YWZIca5DEP0tU6tn21gboQw5hbjzc871Jgn1nvphuOWAvZixmrJZOqf5H5g3+7gT3uK48KzDFJcdePWb71qFFe6AAWWj2p9TpgIg6IQ171sD68/9ENf97Id+kAcdH7g06rmp6Y4xDiXoaWv9Wi1UNcPGuEBWCLk1/Nna3w0sj3XtzY2XjaCvaG/zvOz1s+XqaicHLexpZt7cmqrrb//+vrhUwtjnmPgQj/0ietetkMfiIPOD3xa1QjVIFvGuSpa+lqPVgt1/aCRMOaa8ebnMOapGwswY+LcjsQ5PIc5bxXbn/l2DtNwYApiKLmEXH7I17WAxRPQ2wKdWl8HjqGkQv4n/CSzGw7dO7z+0C/EjUmv0A/9Up9ZYmJjaVZJqCm2jHNVqL4el9qAB7Xq+Q3q+pVJrw6dP4eMD3vHGH9srAZj46tTaszos80cuz7zs9aPJXNEjkIvt7GFGo+M0dyTU1tV/UOur5eSWhjzHAMX+qE/yQz9ofrMEmHM2z/+amZKGHPd3JNTc09ObVX1D7m+XkpqM4wZ9OsBWDLb3HAIcUg9fB0hk8Pz5zxDma9rDwy9RlgkYRsd/wCIPkfk8XR94Rnwv9nJITJv/URCn20yQz8nFBEyQ59t5hCFz6+aJWCihb/ORW3DwBF1flPYC8WumXhmQs0b/Ss1/mpjvIYTG1awZ0yOuRR9tvOU28P2zM/1uXBc4Ciq72Y2Z3NPTo2IO3Nqy9Q//PpyXFoY89z1Ewl9tskM/ZxQRMgMfbaZQxQ+v4V3GmHMbJM57/jXZla4shHGrM09OTUi7smpLVP/8OvLcWlNY8aMgUUevijlf5IjxzEoeutjg4NRnO8VWApgKPO1nAsuPKDDx0P19VQZPhYZeJB9+fpDP/RDfxl9JuvsbRnivjfRMtd+6FWIG7U+9qnzm84wQOaBY2cM1cmymSxuLDM+y48/NsbjWsyc2BhmnJ/kMlimZi5Fn+085c6Fjhs6jMy89ZOT/djAkuv61Z7Rv/BP/2q4pS3R3JNTW6x+epE55Pr6gVMLY74CE1Poh/5O1se6+OQq2dW6vYkwZmX4+GNmWBczZxjzvM09ObXF6qcXmUOurx84tRnGjBlze3HLMrgc8tzWBwbb/CFPcRyyLppDEucEGER9TKCmtVcvOR8qalN9PSKvTKO2VdUf+qEf+kSW1+fzW882dYSFYoW4zgP0UtPVeL8+c4tO+kBce/Xrr3Z8VG34+GNmPNjFzImB6XkdSrCXGRV9ttdnfs7eXED9nAtHVH23tNR8hTo1Dw1u7sypLVb/8Ovrh0wtjHnu+kM/9EOfyPL6fH7r2aaOFK5sENd5gF5hzFhXGDPNPTk1Dw1u7smpLVb/8Ovrh0xtypixZIZSQQgJHhbnwEh7uSmHA1AEcf7853+bcxroMJSgl5ltjYDmUxUfAz4StT41wBj1Z3Ej9EM/9JfX5xOdp51L4IVpmy8jYcxM/d4r5TAbkEmcyCS/Tx9Tyb5VwN5+/XUYf7UuNWZmVM6FOMvCOruqfp5sDZ2N2dYIaH49PsPrHzI+U+eYzoLjqr5bWmruyal5aHBzT05tVfXTi7heXz9kamHMC9afxY3QD/3QX16fT3Sedi6RjJPtMOZ+/SnTCmNOzT05NQ8Nbu7Jqa2qfnoR1+vrh0xtypgnA9px4OgZY3LgDv6XNUIT6Y7zFzv4X98Ux+GJnN36oOPCh4b2Onf+NwZHzFe0Bx7NIN8/DCnSr09kvPqJhH7oh/4Y+nze1XSBODMVkdb88NCxS2gv5jcimG692As8HkUO+egPqZ/Ido6/21WyXr4KhXFipUQwM85LbbXW53zzJNxDa/zHGx/OlK9+UYP2cksb0PoN2z05NdVfvn4iOj5+yNTCmJeqn0joh37oj6HP5z2Mebh+GDO93NIGtI0xZkACOAx/pOuBQQ/DtkfSn/Pk84e89qr1WaTiomolepnZhnn1x64/9LVX6Ic+uNoI+v3zA8vLbGPteUopqI0Z0wLiTP2rrR9cbcD4YEVQ6+tePQusl3NkW+Ogxga1/rrNz5xpbczglrZ0c09OTfWXr78eHz9kamHMI04c4GqhH/rSK/SX1++fH8KYqR/rDWNerLknp6b6y9dfj48fMrUpY+ZPb/6ntMLh+ZOc/02NnO4FiiNHYW/oj63P43v9ZNlMkVCg+tRfJBQU4kaRUDCvfot1GP/QJ3+z9NWY1a4UcjCAQtzo12fvvPWr8VAb28RbPP2LDzN1/cCytu7lvFZbv8LeMcYHGB/OooWbXGr9y9fa3JNTG3t8/JCphTFfVfqFV80ky2aKhALVp/4ioaAQN4qEgnn1W6zD+Ic++Zulj10xuatdKeQwxRfiRr8+e+etH8sJY2Yv1OMDjA9n0cJNLrUNM2b905ttfUD8lxfsr2/T7f4kJ5L/Kjf4X98c5uzWJdh74f1fd4T+SvULZzKOn3rX+MW7v+6h6GLQS/v+/dkPjZ8mimRDM2uKZCOL517L6AN9z/zDRYP8QsRgJGETry+ZEPqr1VejAiZ3tasapvgh+mwvWL9YTm3MwOs1Dv0iIa/aYLterNYzbRnzyuofe3xEvx4rHR9e5MnocY6K215vc09ObYz62cv4+CFTC2PeYP3Ch4whllZ0MeilfcOYh4w/mRD6m6WvRgVM32pXNUzoQ/TZXrD+ymyoLbuOgfGEMddjpeNzlRgzj31zSP5sZxv489z/Mwn5IVOcgjg8EYqgRJRDf1X6GA/m9A/nOv6/d39tYFH/+O6vjcLJMuwlE4ijAyiDZkKWmsn26GPtqNErixsoM0qM22Zd39AfTx9zwsYUNaoWTOj9+lQ4b/1qMIDB6FeeiGA2WDKVk4MZa76CGWdvNnQv57VM/Vf2+hZD1wMjhm1z1m5+jeaenNp49aPsh0wtjHkj9cOYw5hDfzF9bIkJWlGjasFU3q9PhfPWX/iHEcY8XL8Yuh4YsQ0zZoTykXqYPmTHVEQfBJcDk1NIzWRKLfQFzEZNCH5+7iODpV1MGgNrWRqZRBT6FuIG5sdeIP9K6dOLiB6LvlnWYMRWNf4wpbbS6wtTaqFfMaU2pz62xAQNWBrWpXZVw1S+2vrVNngxiL4ehGVYjs6LQdimcnKwauIthhjzYvWv2/UtpDI6zsAYcu5ugVVzT06tX18h06sdXL8fMrUw5g3TD2NGn15E9Fj0zbJGGHPNlNoO08eWmJQhjJnzWqz+dbu+hVRGxxkYQ87dLbBq7smp9esrZHq1g+v3Q6Y2Zcx0ADpwGP2z/V37e/y97m9wwzPTl6PJmRy+y5kcuIO+WbzrFfpz6mMwGNiF9//VwHiwZGwJA8veVkAmy7yaD0SAfNXH/MjMggXrps8oMWLT9ryO15ft0Pdeo+ljS5gxYE5DjJkcpvJV1a9WgcVixmrJbFMtNWDS5IPadg0K2ZUN3csZ5eKN8cbfe11RfUZb/+nDCOCDfJnK3Tg1+g7XX6x+jk4LY94Y/TDmefXDmImHPn3Jx5ayKxuYE4aXvWom5DCJr6r+7MoGFotVAMdlm2qpIYx5GX1Ge+ONmYfCEZ1IQ3cAct5LkEkEUCM/ixuhD6i19LETUPvBbDA2ItmfMsRrS2O7SM5or03XZ5SIsFfHc8j4kzPe9SUn9LdTnymY6VjNaTgotPRh3vqxCh7vojatULcxZraxZHpBy55RWMyYh9S/PtcX+vUZ7RrGAdyTU5tXn/x563cbTi2Mea311UjUeMKYi+SM9gpjJif0VZ9pV61uXlBo6cO89WMMmCu1aYW6HcZMBFCbVz87cQHjAO7Jqc2rT/689bsNpzZlzKRySA6AEH+GTw7WwV7yJ28mu/TnvKJ/1BMJfaWlj3lkvzEwGMCcWhalmdCfDzsnnxxG+Epd39CH7ddn2lWrq2FvKwcFfsJhVfVjDGquenTdVlvNfpx7AXsB80Yhu3JWAM5omfrJIaKsanzG1s/ebDCGjMl21u82nFoY85rqhzGPl09OGDP5O02fCVetroa9rRwUwpi1fnKIKKsan7H1sysbjCFjsp31uw2nNmXMHBJpti/+6mODbR775ovSupcDEMmVGeT7f9pf9xddkwjboe//KfpqydlpMmo5RLLfzMwH8jUTijQjixtE+vOBfM2EIs3I4gaR/nwgXzOhSDOyuEGkP5/R3s7rS4Tt0Pf/3EZ9Jly1JUUtEHTpWCPo1PpE2B5ev1qCQj1ag9pqkWzwFSD2Asac/TijOZwLVS1WPxH6Avn+nxty/9RXwa/yttTvNpxaGPPa6Ycx15CvmVCkGVncINKfH8a80/SZatWWlDDmxeonQl8g3/9zQ+6ftTZmOugf4wpx3cu2/knuB/btDnJCf4g+VsFXfdRCMBt9YApalgP68FT2p4xm7jR9RpjR1vHf9Psn9Pv1mWrVlvqpbQzQefj4KUP1h9ePDShqCU562UhtzNitZmLJfAUoF2nMa8xjj/866+tVYCQZGXLGrt9tOLUw5rXTD2NWxtMPY9bIztFnqlVb6qe2MUAnjJnt9bm+y+jrVVgjY/YOcmBK4QD8T2ziyOleDnPeOtqf+dZxmkmv0L+8PlbBV30wD1CLAgymZTzE6YVd0Ys4kEkOZHFDddhWiNNrU/R1PBlhNebtub6hX4gbk17boV/bUj+tfKbsR46fNlR/SP3ZiY360S3w+BBjnrzF01jGmIfXv87XdzF9vSKMIf8TgZGZ9Fpcf0j9bsOphTGvnX4YMxCn16r0dTzDmHemfm1L/bTymbLDmNm7Ptd3MX29ImtnzPy5TRKPd+sLw4D/TU0OET18HSGTw4d+HSFT9dWYgddVYif99qMQ56Uc9Q8/ZCcziGj86tNn9BhJHVtGezuvL5HQZ5vM7devzakFmWqNbDNlP3z8tDFv/RgAi88YJzasYLqYhFbLtpqx27Pkk4ky0EshBziX4fWTQ2Sx8V8f/ezHBmOFJasxb0/9bsOphTGvnX4YMxBflX4YM4Q+kdqcWpAZxqz1k0NksfFfH/3sygZjtXbGzJ/qmsrh+SOdB8H9T3JyOEbKPLf1scHBKM73CqHfr6+WXFsOpkIcavsBjWNsgLERR0F7ZdlMFjE0U+Obos/okalxtedNv39Cf7g+E66ak1qvomamlswLRqDW768fG8CYOQo2gLkSB364gqNrPbUlE9EfulCbIUJfIIImZzS8fs9hYFPmul3fIfrZjw3GipHU8Wf0YOz63YZTC2NeI/0wZtD4qvTDmENf9bEibAnUqJTazOgbxuwDmzLX7foO0c+ubKy1MXMAkpDmlWPIcchzWx8YbPOHPMWR4wVJ0aoW+vRq6WMPaj/ZdYzCdTJkYl1styIoh34dYeQ3/f4JfXoN0ceKsCg1PLahNjN68cDXwec6MOZan0irfswAK+VYTP1qCYcS7OXouo0BA8vXWAs5VF5H6AtE2Mt5Da+f7XW+vkSG6GdvLmD8uRZcnbHrdxtOLYx5jfTDmNluRcbTD2PeafpYERaFOek21GZGrzBmttf5+hIZop+duGCNjJnDkIoQIESch8U5MNJebsrhAPQizp///G/z0O/Xxx4wjOH2U+cT117EIfSJay9GftPvn9CfVx9DGg6PemHGB587YyxWP1O/GjM2iQ0QZ1mVvVhpva2oDbONnagB01chztkNr39Tri/Mq5+9ubtG6SowkmPX7zacWhjzGumHMZNPXHsRhzH0w5h3pn523IGEMa92/GHd9LMrd9doHYx50qHj3PnfGES2Lnbwv6wR0szzFzv4X98Ux+GJnN36oOPCh4b2Cv1aH3vAQvQLQi37UcuB2nLqLyCRGfqAMiOvV20T7x/tFfrD9VmaxnSnrbeDyIHjpwziRIbr1/Uz6bMEjTVin0QwA5ap2asmqts16KhJE2GbvgpxjHl4/Zq5/td3MX2uEV9dw5i11xj1uw2nFsa8RvphzFdKP4x5J+uHMYcx1/prZ8yABBDhj3Q9MOhh2PZI+nOefP6Q116hX+tjDxgGpoL9KLXZQHaaTPazAvaGvmqqMcMY11d7hf566mO6GLDaMMa8vD7TPbSsV+Oge3W7BksGtWSgr4Il80+TXLzRqp/zzWmGj8ZVd/9wjWpjhuX16/rdhlMLY14j/TBmpZDNsHe1+mHMoY9+GDO06ud8c5rho3HV3T9co7UwZv705n9KKxyeP8n539TI6V6gOHIU9oZ+vz72gFWw6IqpqAn9RGBva3m2n9BXGPnNun/qiYNIls3Qd7X1cyxlGX0U9CxAFVZbv8LeefWpUMe/Xz+flPH0Lz40WpbZMtR6uwZLpp5il0FfzFi3+SfIasdHYe9m6ev1GnJ9l6/fbTi1MOY10g9jvlL6YcwwvH6OpSyjj4KeBajCautX2DuvPhWGMbMXtnP8FfauVl+v15Dru3z9bsOpzVjK5g9ttvUB8V9esL++Tbf7k5xI/qvc4H99c5izW5dg74X3f92x4fpHPvl/XRaWvPr1Hzp2KqN91ZjVbNiuTYjtIcZTU+vsZH1Gfuz7Z2X6MmXUxlwzt/6A+lGuj7uYPn1R44yyoIHaautne7Xjr/qao/DaitZiNfQbc71XoZIimMGGFV261/rZXnB8xh7/bdTXazeGPnup3204tTDmOfTVRFuEMUOts876Yczz1o9yfdzF9OmLGmeUBQ3UVls/26sdf9XXHCWM2SMboq/Xbgx99lK/23BqU8bMY98ckj/b2Qb+PPf/TEJ+yBSnIA5PhCIoEeVN0edmPXDslKHG+epnP3FZyFT93L0H+ro9pB8oxFowG6yFbcBygMgQ+wH2hj5qjDYjv6r7h8hq70+dIABL0K/cEOHLNod+0VF0MVr6Q+ovpAyOywsxil3GEH3NR40z0riyTP2AwhjjXyRkyMGMNV/BbrM3ZxsGjfQbcz9qxsxvWPLy4zP2+F9Zfa7jePoouw2nFsY8Qz+MeefohzGjP6T+QsrguGHMVF4kZMgJY95cfa7jePoouw2nNmXMCOUj9TB9yI6piD4ILgcmp5CayZTayPqFR84E4/y7L/xuhggUyYbqa6aiaoA98EOEGIYaCdQmBLxkg71AfvYzg4haGhGFvlk2c/XpM8L6s49cteJWmYle37Hvzzy/G1ggMMXr0iURDACIY9Wqo/rD61fL51jo61HY5iiu1qtPJiZHX84IfTSBTJhS69XfzvGnTrZ5uSY5PJBFvMVwY14MFDBmLBl7Xn58xh7/naPvNpxaGHMY8xT0zbKZq08/jBn94fWjE8bcGn/qZDuMme3QH67vNpzalDHTAejAYfTP9nft7/H3ur/BDc9MX44mZ3L4Lmdy4A76ZvGu19rot2xSyW5aUPhxZhl9tWfQH/mv7QfLIY6BZe8pIJMFXs0HIkD+1afPSOrYMtrcG1wvWJ/7U42BKR4zUEvQbYXpnl61vQ1B68dseHypOJDBsfQofqbV+GTxDAam/5jIJ2jU9a/n+FM/Fki15AMR8mtQoC/o3joyL1gyZvzwcXPlU6san7HHf+fouw2nFsYcxuwQAfKvPv0wZlUbgtYfxkwlWptWG8Y8xvjvHH234dQGGTMPhSM6kYbuAOS8lyCTCKBGfhY31kefxx94Yb0aZOGdBZpZo/rFrkwhmKmNubYfNR4imgOaqZbGdpGc0V5Xq76OLaPN9Vrs/iFn7PsfY2DJl0kcmHZ1W1Fjpi8W2E/2oQIsmZziQEZtzK3xyYIGy8JYGqCWT9Cgcu1Vj8/6jL+aqI48tOwZBfqqAtSRGsa/CBpYMvMbP1XJGQGjsfz4jD3+O0HfbTi1MOYw5im019Wqr2MbxlzDsWrCmKlEa9Nq2VYTDWNGLfSH6LsNpzZlzKRySA6AEH+GTw7WwV7yJ28mu/TnvKJ/1BPZTn1uRG7KyTJOh+qz+Fy45sKgtoy+GrPaCQYDmFPLojQT+vNheL5mQn8+DM/XTOjPh+H55KgxX6n7c7i+GgOTu5qBbiv1hI5V9INBchRgERvUPhWORT7VQj0+uldtXpU5o+xnBvmt8VF9ZfvHX8c8F597AXuBMUeBvqoAdaRmiDHzRwjnBasaH3KIKKE/XN9tOLUw5jBmZ3i+ZkJ/PgzP10zoz4fh+eSEMbfAILOLGGHMHJ1KOEcdc93WMc/F517AXmDMUaCvKkAdqQljJrK5+m7DqU0ZM4dEmu2Lv/rYYJvHvvmitO7lAERyZQb5/p/21/1F1yTC9tj6B0+cMbgdDxyHS6/MRJ+9gG1jpf2Qjz5qrfqzuNGvX1tydpqMWg6R7Dcz84F8zYQizcjiBpH+fCBfM6FIM7K4QaQ/H8jXTCjSjCxuEOnPV3vmqun9wxVku3V9t+f+xxh0cgcm9Nak3JrQswcXaA6WiVmCmmgNx1ILp2bgjDRSq3EWnFFtZvRa//HXMS+SDUaGvcDI00vRnDpSU+dgyTr/+GgkVjs+RFwtEfrz6rsNpxbGHMY8RRY3iPTnA/maCUWakcUNIv35QL5mQpFmZHGDSH9+GLOiORhnGPO8469jXiQbjAx7gZGnl6I5daSmzglj3ix9t+HUZhgzHfSPcYW47mVb/yT3A/t2Bzmh36+PPbSMBLPRB5qgzlT04aksm9HMnayvxrw+9w9moBSzfEd6eEqNQakna2xAFWoL1PzhcCzsFlArTsEgjtmrAmdBPXVVhYihI7ad4+/TZbRoo7Uw5jXSD2Ou2R79MGaNaP5wwpijRVtVmzJmv6HlxuVW5pblf2IT53bXvXwMzltH+zPfOk4z6XVl9FnG4UGwYvV4Jo8cP21sv37LmDEPwH6AvZqpEKcXdkUv4kBmFjeyuKE6bCvE6bXp+ox86/qOfX/W+moGtUWBxxvGTESNGUsGFlSndCqy1ED0WIA91/q1JQM1kz/VK50jUDkjc6XG36fLaNFGa2HMMwhjBtVhWyFOr03XD2POspksNZAw5mjRVtWmjJnlIG5NHu/WF4YB/5uaHCJ6c9cRMvl4bKc+Xw8oHNEovps0EzL79bNgQSE1EzJrfeyBH1fITmOonfBSyZb9KMR5KUf9ww8tfSJXkz4jVogb5DPajLxe3yt7/2MJmBBWmr0qg0lgfrUpqjFnPzbU3gCdQtwgrpr9cCyFODas5C4F9OKMshN3TIoxOIvsmsb2j79Pl6nlkw2CJfFbKrUw5hmQ2a+fBQsKqZmQWeuHMSvEl9cPY0YBsDqUAZ1C3CCumv1wLIV44cpG7lJArzDmYGfit1RqM5ay9Vbm9mWRhwfBfcmIHD4D3PRbHxt6c/teYTv1Cy/sQV+HqfFC3BhbH3v46ON/MWrL4Ys93/vKHxu1/WimxjE2wNiI1/pElCxiaKbG11+f/3HA6JFJHBhtRl6v79j3Z7++GgOmxddyMCfigNXxwc4OZ+RPu4G1TFldQnWy8xX62KQqt9B/CijEi+SZkM8ZeZFSFSNAJnsZpe0ff58uU8unGQRL4rdUamHMYcwOESWLGJqp8fXXD2MOY4ZVjb9Pl6nl0wyCJfFbKrUpY+YG5Sbm9uWVY9zu3LLntj4w2GYhiJubnPqmV7Xt1FcLhLzaPBNyeAEIU/n262MPPEqGbWTXMbCWb335j4zafrAutlsRjE3tTfVVUyFzc/X5nxqMXpYy0Ge0GXm9vlyRK3X/YwzYjxpD9kuDn5RgLx9stjUCLWMGVcviOYJNqnKLVRkz29SQXdlgBNhL5YzS9o+/T5ep5dMMgiXxWyq1MGaHnDDmGjI3Vz+MOYyZ+KrG36fL1PJpBsGS+C2V2pQxc5ty43KzAjc6cb5swE3Mre+3e8rhdqcXcZaPeOxiO/XVDoeTfdQYog/0bS1Za6ZS66sx1/bz3x54ybj3D/5vQ40Hg9F84tmxDOJQ52tmls1suj5fY2P0yCdOPv9UYuT1+uab0xjj/sziRq1fGwP25nYFya7YywebbY0A5qq4QqK2ZOLzLmJjXXpcpegyE82cqiedKUdhLxUySrCd4+/TZWr5BINgSfyWSi2MeYrsmsYQfaBvGDOsm34Yc+HKhiskwpjnHX+fLlPLJxgES+K3VGpTxsxtynRz7vxvjMmN28EjFdzomnn+YgePTnBz8/Egcnbrg44LHxraa2z9A0fPGIUXFrDIydQ8rz4KasBDyIc2an3sgap4KAn74Ss9WAsPfxFRiwK1HKi/IESmfgGpZW+brs8ocX0ZPSLkMMIPHTtlMPJ6fa/s/Y8xqDViDEQwKiyWvXyw2dZIHQcWt1Fg2y0Qkr4evQV9YbXGTG1URSWMAHuJ8E8Kxmo7x9+ny9TyCQbBkvgtlVoYcxhzGHMYcxhzGHNwhfFbKrUZxuw3q0CERR5u3Jxm6MeAbY+k5T7yWSzSXpuuz4KzGm0Nma42QB97QPn2B44bmAcPfGEtbBPHliB7UkYtTWEvpoi9KbVZQpbNFLIZ9q6DPqOkxsw28QPHThlE1Jhh7PunpY8lAOaEMfDRZVvjoHs1UsdrUMNcseR1MGbQM9W9xLFtHbHtGX+fLlMjHgTL47dUamHMYcxTqLEpWTZTyGbYuw76jBLWG8bcAjXMNYxZ1VpH9+kyNeJBsDx+S6U2Zcws8vDQhMLty5Idj1Fwu+te4OYmR2Fv6PfrYw88rKSPLClqJ9hP//JvC3qhoCb3E2HT9RlD/qFTDKPBSAIjv9rry+TOSxwxrX797AfG07/40MAGQD/Auqire+tIHW+BCanRqi3VaCbnqEesKbrPpM7kTLNIsRdjZvldRw+4CsAIr2r8fbpMTeNBsAx+S6UWxrxG+mHMq9VnDMOYNd4ijFn7hjEH24/fUqnNWMpmIYht/YLBLy981JGW7IjkVSODRyf4GJzdugR7L7z/a6NY6Z3JgeOnjH59HtiBovtlWWd97IHFaii8xPjzB44bmA1LsosZG2bGDzywXZsc28vo81oPtsfQVx3VZ2T45wsUw2gw/uxl5Fd2/8sUr8as+pqj8EBTbYr6AR5uzHVmPyxf10dXHbVk4Ow4YoshlZCpEXplkWIvdWLMugiv48loM/+savx9ukxN40GwDH5LpRbGvEb6Yczz6quO6ocxtzL7CWMOYw6uFH5LpTZlzHxtgNuXZR+2geU7/890o3OLE2fCYnpismORUI2n+O7QTMhU/dy9h0KkB/LXUx97+F76QhQUXmJg2Bgz48xXgLAi/ToQBob1Zj8z2IulsRdrxNjU3oDIcPtkL/rU2dLn6FpDFjcK2Qz56KNWj4CODxTDaHB/ksnIL3P/F/O7gSVjdUzuRUJG7VDzlX6LakXopfHFQKfwY4NzJIcjthhSCZl1BFoK9ejV9txPrVAcwuDoVOLTZWq5vCBYEr+lUgtjDmMOYw5jvgzoFK5shDHn8oJgSfyWSm3KmJlo8kzUg05JhcfMBOMZ/tJK1ddMRdVqNLMQN9ZTH3vgpZv9xqyWk13cwLQwJ+wNNSyNOAYG9MpeaNQmCrzEg71AfvZLgwiWybGwPWAv2yxxL6aPAr04CmdNHHR8DiSKYTTYSz4jz1UrbvWZ6PXVKd6XVRNM8SzzMrljGGzz4BI5mBzxFmoMoHuHROaFI0J2YgMzhiGL2EpxiII6J3c0qET31lAho6qjTbWrGn+fLlPL5QXBkvgtlVoYcxhzGHMY8ww4IlAhZFc2wphzeUGwJH5LpTZlzHwlH3i8hWlIl/Xefe9Dg4dcyGzZjJLdqKDws8zO1McesssaaiSYGcbMMiyQiWlhUYC90VdtWGEv+SgAfdUyiWOQ7K0hk2Xq7JEGLxnlWIvpY8Ccherkk831P3z8lKHjw49sMnr0hdqYuV4w/P5XY2aKx66AaZ1tFkv5EGIS5IPaRg0K+TNs6N4hkeFgQlobqBkD+RxrCPkQM6lzckdDj1gzYzzTP4/oy8ivavx9ukyNSBAsj99SqYUxhzGHMYcxTxHGXMPR6evTZWpEgmB5/JZKbZAx86URlu90EY9JSidfDAYK7ynQzBrVL3ZlCsGCIrlgPfWxh9ZSNtZCHFPBhDAkLA0wKnToy7ai+uTTFwvsh0yOi3GqJZPDXTG5Ny69LEV7YcxE0FQ0E0vGaNFBWSvXXjo+ZNbGTBzNfmPuv//JwZhb1qXbfAjZxhLoBS17QCF/hrMCDIkMB2PWqkDPAjgK0EsjNdq3ps7JHY366MCIaZ2MKnvpm5OLyGLj79NlakSCYHn8lkotjDmMOYw5jHmKMOacnOHo9PXpMjUiQbA8fkulNmXMTDFMSUxATKmY7mSy62Av+SzeFq6zMKjtTH3sActU4wSsBSviKmAtakuAOalCFiyo96LfDzbJUQBjBvZSod4/HKvOL4o3sqyBzWOfnC866Ld6sZd8ah5izFwvvf+xZJayJ2bcodeX1zqqMTO5q5HoNh9CtrMf5F7AXsA8UMif4awAdQSb1Mhw6MsRFeKQyyiOq/Eazaypc3JHgxoYDc3RMQQdQ/rm5CJS99K+UI+/T5epEQmC5fFbKrUw5jDmMOYw5inoyxEV4pDLKI6r8RrNrKlzckeDGhgNzdExBB1D+ubkIlL30r5Qj79Pl6kRCYLl8VsqtSljZkpi6mH74Ikzhk9h/s2TS6+cvPirjw32AhMiVtQP+eijxg8A8KKSnamPPfB4Fz/7qEYC2AxqHL1lTujQi21F9VHT68tRauiFApaJDQMRzlErZJtjqSVTZ6t+VVNNrVnzAWX2cnQqp5fC+aLMyHPV9P7nCrLdur7YM8askzswoWNmTPR8CNkukg2+xsNewBjypzejORrJ3pmPOC/L9M3lzaRfmZw6ojAamtNvrvTKyUVE82HI+Pt0mZrGg2AZ/JZKLYw5jDmMOYx5imX65vJm0q9MTh1RGA3NCWMOrg78lkpthjEzAelinUJc97KtXyBhaptsd5AT+v362IMaRuElBjbDXuwHAyv8yVBD0vxanzjQS3Vqy6Qvi8A8YEUEBdXPsgbHolqtudYHzL7WR6euE0tGWfPJpJei9asxD7++mLFSzPId6Us7akh8CIk7ks8rL7IrGLUxgOZopN/8hrCMAn1zkTMpumTqvblLhtHQHEZMxxB03DSfyDLj79NlahoPgmXwWyq1MOY10g9jVsKYoTYG0ByN6LEWYxkF+uYiZ1J0ydR7c5cMo6E5jJiOIei4aT6RZcbfp8vUNB4Ey+C3VGpTxuyGIRMTUxUTHA/yFKuvM+GVDlvWfQJqoQ8t/eHGnFek85KyWhSoIaEG6GdBgwVq8gGTQ6dlnJwF1PpsMzLAsSZpnR1Sea2PJbf00aFO8vlKFaCJPsclk16K6jPyreuLJfOQF3E143oRFTyepn61Oj6EtSUQ4SUY2RWM2hhAc2r9vGsuVGcxUMhFzqR1FPbWEYXR0JyljFm7DB5/ny5T03gQLIPfUqmFMc/gSumHMUMYc3YFozYG0JxaP++aC9VZDBRykTNpHYW9dURhNDQnjDm4OvBbKrUpY2a5lamHr7gUjmIU3/CZCZlMZ6hhP6qfBQsKqZmQefXpYw/YD6ZbeImBzQBfcFJ7UzAtemE/k8XbS/YGqom9Ycy1PSvEUav1uX+yKxt6RCCODSu5i1Hr0zc7sUElMDHmrpeeVz5oRvUZeb2+fEVq65/Mm6cWtPlhUyyZB4WYuLFhheke2+CDx0TPNgYA5KCT/cAgAvRSNFOtTnNaFthi3vwWWkNN6yh1vOho6JiQw+gVg28w/vTKggaRZcbfp8vUNB4Ey+C3VGphzDMgc/v1w5ghdzFqffpmVzaoBMKYNae2un7mzW+hNdS0jlLHi46Gjgk5jF4x+EYYc7BZ+C2V2oylbCamwkt60JdKapxlQCX0NV6IG2rMhYtk9DUjRDAzNSe1VXLUhGp91NTqQHVa+hhhrY+VYs8s8usRaw4cO2OoDtsKcfKpUKsiwmiQw3nVrxZRUGbk9fryTyXsmUVsvijFI3tqzEzifC0KMyAOTP188MjUbQUDYJscIvqFK+KgNlbvVT755R8YZPZDfhGcCz2iQlwpOhr9Z0SE0WBkiDPCjHw9/uTkQxh1BNBkmxwi9fj7dJkakSBYHr+lUgtjDmMOYw5jdsgvgnOhR1SIK0VHo/+MiDAajAzxMObg6sBvqdSmjJkJCJNQC4G8WjsTcnxKTTCpocZkF/r9+tgDVlH4R4YlbiynjmCTmJNaFMfFIGt9+mJsNRgwP1CR/ThHOEqt33/EGu3F+GDqGkeN/HyCBmfNWehyNxF0iNSgz8jr9eWK8EpOFrGx5HNbHxgYM48LMZUzfaslHEroRF9v17AX1CrUGICI7i28MMM5aoReNSgXwcuSSzLQ5ypwXMafuGaqAvWDRjRf9zIyxDXCojRWDZoDdURhL6BJXOvx6TK1nBwES+K3VGphzA45V1Y/jJlejA8TusZRIz+foBHGzDbmV8M5aoReNSgXwcuSSzLQD2MOgnnxWyq1KWNmGmJiUjsZTvYhg2mO5UEeq6n1gb6tJV/NVK4+/X5j5uca2dYFbTVmtkFtjImSSK2vJgdqzBgwP9GIJRPHDrHMWl/hKJdZUk5mjBq9UKv1PV8PkfoyAnxZi209IjlsK+gz8np9MWNgWZs4X6aqjZmJG0smzrIqe/ng1dstsATMvu6rEMf2GJ+pkYF07mwzPuQPh6MoHL1IM9CfXC9cuauqSJsJY6j6isYZGTVO3Va0bytSg1pr/H26TI1IECyP31KphTGHMYcxhzFfBo6icPQizUB/cr3CmINgKH5LpTZlzExDLLEeOHrGKLykgA8eUxuPxjB5sQxI5OzWBx0XPjRUHwU1sCHkQxtXnz72wKgW/mHw5Sjdxn40osbMz1Gw96Fjpwym5lqfvgrKmDTbGDOWzMNWGDPKtT73D32h35ipFgXuKCIufvSMwV7PT/pEMB56sZcj6pmixraCPiOv9+e5878xiGxd7OCLUvxDCmNm4ZQpG1MhgiWzlKoTer3dQm2m7qsQx9gYDR3/enxAM4kwPsQ1wvhk7ywgf3l9PUr/meo2o6SRmnpvfz70j79Pl6kRCYLl8VsqtTDmKbK4sf36YcwozJi4w5hlWyGuNqnjX48PaCYRxoe4Rhgf9GvIX15fj9J/prrNKGmkpt7bnw/94+/TZWpEgmB5/JZKbYYx+2QkEGERj4kppxlqw2x7xH+koctnMVB78RFVo6oh09V2gD6amEThH4aaLpHseQbTHFOeT3xpOZFMpk70gTioskKm2jOWrMbMsWp9yOUZQ4w5F29QP9u1MedDZFhE1SOS6WpJn4jCaFN/vrhG6/7HkqFlvRoH3duKAJYArV6KG2Q1/q36ud+IgN+Ncn/6iMn41/o1jL/nS5xI//VVfc6oOE2jHgcdK90LdS+ltVc16xwiPl2mRiQIlsdvqdTCmMOYw5jDmKfuTx+xMObGcX26TI1IECyP31KpTRlztGjRokWLFu3KtjDmaNGiRYsWbY1aGHO0aNGiRYu2Ri2MOVq0aNGiRVub9m//9v8DuLNpsz5n4o0AAAAASUVORK5CYII=";
+const imgGrass = new Image();  let imgGrassReady=false;  imgGrass.onload=()=>{imgGrassReady=true;};  imgGrass.src=ASSET_GRASS;
+const imgSnow  = new Image();  let imgSnowReady=false;   imgSnow.onload =()=>{imgSnowReady=true;};   imgSnow.src =ASSET_SNOW;
+// Grassland tileset (transparent) — discrete decor sprites placed on the board.
+const ASSET_TILES = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAANACAYAAADEtbMjAAAACXBIWXMAAA7DAAAOwwHHb6hkAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1MAAA6mAAADqYAAAXb5JfxUYAAGlRSURBVHja7L1rjKRXee/L/nq0tZUPkSIBmyjZkmP2ZLfxANKUZ9w9Uz3TU9W36q5L16WrbzPTPePB0zYeG9y2Z3oM5pLMBPYGkxAuSUxgAxFxEgXtKFI0MgYGMDYBfCGQnQ9EiTAbBCc6h8PR0Zae8+F9n9Xup+bxWuu91FtV7//D/0NVV72r1uX/63V/XvOGNx94TZba/vYObX97h7a/Hup6qK+Fui70TCjxuYs/fj9d/PH7yTzvHwK986VA298I9eVQ3w2Udf4HVb879lp6pVAm/dVvX/46vVJppfMaAACNDQAAALIDwI0d2r6xQ9vfCvVsKDasBAG//1Sor4bi7/PnGCjfDLTxowf3afvvd2j77wEAzfi/bE3uU/31v0L11/8KyqtPxr/lBdqn13beS6/tvJcAAAAAAAAARggAbPCwS24MzV39F0Kxwb8TSg4F+O9fCcXPfS5QDwDC72m/68gnXkdHPvG6HiPw+7bPa58b1K65fO6zk7fsE7/vCoK4v5PLTxrBVv62zw1q11w+9zWfeHmf+H1XELj+TgAAAAAAAIAMAcCGZUMzCMIuunn/a/vVM+nHAAgNb16z+Lv8vJcCaQ3JBoCJq8f2if/+i5++m37x03eb12l3zeOCQD6XDc/5YPH7tiFB3CGELH8NALL8+e8/+7eX6Gf/9pJ5nXbXPC4I5HPZ8JwPFr9vGxL4DiEAAAAAAAAAMgQAd/nZ+M8H6umy86SfNPTTofh9uZzIz2Xj83MUAMiGK40g/66BgF+n3TVnY0WdpJOG5dec3xdfeJpefOFpkp+T6SX1O2XDlUaQf9dAkFT527rmbKyok3TSsPya88vlLz8n04v6OwEAAAAAAAAyBABP8n0pVGjcHgCIv/csD/LkYLiMePEHgcyQgMHAy47ha1cAcEXIv99x8Xa64+LtPQ1RNkDfSamku+Y28fdkevL50uhJ/04NAFz+8u9plX/SXXOb+HsyPfl8afS4vxMAAAAAAAAgQwBwlzzsyr/jh4F4KGC69nLLMH9PdvnDycN7nw/Us0EoBABPIsrfo3XpWWPtW/aJG6CtIfouDybVNfcFgDSqTN/2ftzfqXXpWVHL33d5MKmuuS8ApFFl+rb3fX8nAAAAAAAAwABsBBIGNgbnSbzvhQon88wyIAOAlxN5KzEDg4cAAgC2jUA2AMiGpzXEqF1Q3655Ult15WSd7+ReUr/TBgDX8n/qqafoqaeeirwxyLVrntRWXTlZ5zu55/s7AQAAAAAAADIEQGhEY2jusvOhn/AwjxkSKMeBzffERp/7/zGQ+bsFANpGE1uD44apLRPGNaTWNZdGjJoO//7pG79B0zd+I/bkXtTfGbf8tWXCuIbUuubSiEmVf9zJPdffCQAAAAAAAJA9AHoMzdKO83KXPzS6GTrwcuE3hfh5N/ZLO8yjTSbJBiknpWwbhXwbBEt2taX4c3EbHpdD3Mk97fdp5SC3/kYtf9tGoajlL7vaUkmXf9zJPe33yXIAAAAAAAAAyBAAvJWXJ+/kpGA4maduDeYrvniIwIYPtxg/9E+B7nk+ED/v4vcDaQ1RW5aSDdB367Bvw5CHY7T35d+jpiMbou/knvYcfm37fb7l77t1eNjK33dyz7f8AQAAAAAAALIfAtzz/UAGAHxISG704eVAOXRg48uNP/w8HiKEn9M2Atku+rBtFLJtHY7aRdQU1Wiuz/edhJS/I+7vsw0NfLcOD1v5+05C+pY/AAAAAAAAQIYAYMOyQcPrvM0yIG/o4Um/F0Px3+V14aHh1UlDsRxo+33aRR9yucp2gYjvRpRKpXLlZkq6IdrSkUMB2ySflNYldTWIdtGHVv7aBSLDXv6uk5C+5Q8AAAAAAACQPQAuvhDo8ouB7vt2oJ6uPm/t5ck/2eXXlg352LG4Rtx3COB6KWjcy0G1hiEbiK1hRm2Ars+Vcv2+67Kc62WfvpeIovyD8gcAAAAAAADIEADh8t993w3Ey3tmazB33dm44Wvzd7Gxx4BBbhmWAUPC5yWdn6hdzqhdRO3vSTd41q0Lh+jWhUM9XUnX70f9fSj/dMofAEADBAAAgAEIDvqsEG/skV19GTCE/65sIDKGl58LQTMsIaP6bSzfLnBWhkf5x/tdAAAaIACQZwD4dh2S1rA1hK3Kf6FXEwJcjpbeNFmmm+nf/8fX3lTDlj8AAACAAIDBB4C8AKLfhn/vuSP03nNH6PnnHqPnn3uMfv7yF/eJ3+fP+QJBguQjOyegBOULajb6pU88eVN99C+v79PixUu0ePHS0AEBAAAAAAAAIHsAaAbn176HLJIy/le+eJW+8sWrxuj8mrX9mcV9eupfrtNT/3Ld/P3Nt/4avfnWXyNbOhIof/Z4m/7s8bYBi0wXevV6YHE5yvLVQGAzviYGgHw/KgjkkGNs/E37BAAAABAAMHoAuPPz/47u/Py/I2n8qBcuxAUANxhuULIhseFZEgSuAJANWQMB9OqSxmfx+1zOEgBstKe+/gw99fVnvAFgkysIXAGUFAgAAAAAAAAAAABpSJ48ksa2AYAbGL/m52gg0IYAGghYcbvGmlGipqOlp33Olq7NwLbn2sDN5c6Gm1w9S5OrZxM3visI+Hf84J//lX7wz/9qJhfTBgEAAAAAAADA4CwDytBPbHx5DXRaxucGxMblrqUEgdYA5bKgXI6SINAmG9MaCsjfOyhdd1fA2L4vAaBN4koAsKF4CMCSy31pA4BBxOkzEOTv48/ZNigBAAAAAAAADA8A+KKCuBdJxN3iq3WFbRuBZEOUG1EYAJx/23JjXADENdaggED7vDZk0MqRwSoBwMt4sgtuk83w0rCuAJDi38fpuk4W2kAAAAAAAAAAMHhbgbWAEP1a/pMGZrlOQsnvS+NHBUDcSTpf+U7WRf1dST0/LgDYOK4gYIPz92XXXTO0NCa/liDQXvtOFmogAAAAAAAAAMBxYK3rLwEQ9e/rvzNP678zrw4BXI2f1BZZ12U1X8OmtbWXy8/2PVkP2qQqlzsbQy4DSkNrAGAj8uflc6Tx5WSdvABEgkCTnCyUIHAdegAAAAAAAACMPgBsx4ltXX8+5qtN8snPaX/3BYANMDaDs3E0uW4Q8j1+67vBx/X3atJ+h1auGgC0yTe5PGjr4ksAaMt12mSgBI00sutkIQAAAAAAAMDoAyDqcWLbBRzygg9bF19eICKfw2IQ2A4d2a4gk7/X1zC25/umb1PU3yG/p70v/+4LANnFll17V8nv+QJA25BkmxyU6dvSAwAAAAAAABgdAEQ9TMSG1KQBQGt4tufJIYBmfFeDuxpp2K7y8u3ya1eBaVuBtck3GwC0STnNgK4A0CYBtUlEV2l+AwAAAAAAAAAAbAEZJAi0rr+24UeTthHI17D96sIndSmn9juiGl57nisAJAjkMptmfBsINONr7V/+DpuhERgEAAAAAAAAIK3jxBoIbBt8XPMrwSInt+JO0tmMkTcxCOSxbA0EWhfcFQQ248YNRRbXTwAAAAAAAACjA4C0jxNLENiMb3ueBIBtWQtKRtoVbRoIomrQt8IDAAAAAAAAjN5W4LSPEyeVLw0oULpyradRPwQHAAAAAECeATDowQsrh/4z3UzFAwduKoS0RvlDAACE8oeGGQDc0D7z0Lmb6q/e8859enTlOD26chwNMuHydz1GfLT7FjrafQvKHwAAAAAAlD8AkJLxNTEA5PtRG6Ls8qYVnnlYyt92vJgBkFT5D9rQZ1TrHwAAAAAAAGBwCvzv/vAa/d0fXvMGgE2uDdEVQKPWEKKWvwRB3PIftKHPqNc/AAAAAAAAgLvkoYe4kz5c4FoXvl8gkAbgycVBA4FtOS5u+bteKRYVEHFBkHT+5XNdLycdFRAAAAAAAAAAuBvfFoLItyJkl5sNKI3oasi4ANiuFGi7UqDv/fUn6Xt//cmeLjG/z5/r12SR69Ak6fJP6truuABwnZyM+3yuVy3fWdU/AAAAAAAAQP8BIK8pdg1G6Dvpxl1QLmBpfE02Q5iGHFaYKwCk5BClX5OFUYcmccvfFnDEN/CI3CgUNf9pgSbp+uffMeggAAAAAAAAALADgK844pBIDAQZTpk/F7UByq62DQDcMPj7/Fp21aTk7+PXsiFor9MyZFJDk6TK3wYA/h1s8J7PhL+H/+4LAi3/EkAyPd/yttU//+5+AQkAAAAAAABg8ADgGozQNcP8OS5wubVXmwxkcYPgz8vnSOPL5SN58YNsCHKZKW1Dxu2a+qbnWv4aADif0uDSkLbyzyr/SdV/0kACAAAAAAAAyB4A/MN9gxFGbYBaBcvlKVsXXzYIbQOJ1uBk114eN067QfoOTThdX4MlXf7yUJBv+dvyL7vi/Dpq/l2PQcv6N6BLuf4BAAAAAAAAsgOA7Bq5yvXyQ9kAtYatNVBbw40KAG7gLK1BJ23IvJd/v/Nv2xJsq38JpKTrHwAAAAAAACD7rcBpXXusTb7YGqBsUFoDtF1q6dol1io07QaZVfnLrrXs8qZV/v3O/7DUPwAAAAAAAMDoXQgiK05bltIanq0hag3PFp7ZtUKHLRCEa/nLyTzZ1dUklwN9y39QyiMv9Q8AAAAAAAAwuA1Rm2xzBYGt4rIOzzws5e8KAPn5qOU/aOUxqvUPAAAAAAAAMPgNMapG1bAofwgAQANE+UMjHhx0xMMzo/whAAANEOUPAQAQBAEAEAQBABAEAQAQBAEA0HDpjou3082E/AMAEAyA/A87AA48MEEukt87/KFFeqVsn4+aTtrKe/5dDfDSL6v7lBcQDEv+YQDkHwAAAKIbgBvyGx+e3CetgfP7p/72fftk+7z2/De1fpve1PrtzACQ1/xrXVwpbviP/7y4T9IItucMSxd/2PIPAyD/AAAAEN8Ir1+/nV6/fju95fHqPnGD5b9zg3/sxh/TYzf+2Lzmz/Pn+Hvyefz3Qen65jX/3DCnb/zGTXXkE6+jI594XU/DZ/HnzHNe+o2bauLqMZq4emxgATDs+YcBkH8AAADwV+OTHWp8smMaouyiygYrDaBJfl4aicXp8u/odwOImn9+f9jzLw3ADV6TZpQeY3DjF3937XIj/wAAAAADIP9pAUAuY2kGlw1WGsNmAPk9zSDy96Rd8b75v3qjSldvVOk7/+8H9kkrh0HNv2xoPQ1c6cK6GsFmDBZ3iflzxz73Bjr2uTekDoDfvvx1eqVGJf8AAAAAAAAA7g2+9Pk1Kn1+rWfySmugskFrxtcmzWzP4e9tXn+MNq8/lrgh4uafDS8BKEEwqPm3TXa5dmF5OUwzAr8vG7jWxZafS2uyjPN/ywu0TwyCYc8/AAAAAAAAgN7wuWFpxtWWs2RX2NaAtS6v9nmZrpQ0RFTjR82/NDoPBTg/EgByqCDLpd/554bPDcu1Kyv/LrfCSiPI921dYJY22ZbUpCB/n43+mk+8vE/8ftb5l0MS3/wDAAAAAAAA6Abg5SbN4DZpQJBdYg0AUdO7tfSbdGvpNyMvk8XNv2ZsDQASFBIk/c4/NyBX47F4Ukpr4JpBtI0y8rU0GqcnNda+hcbat1DcST/u8v/s316in/3bSwYAcijQ7/zL38evffMPAAAAAAAAYN/woi13RW2gti6uK1Dkhhtu+IXTb6LC6TfF3igTN/8yvxIMEggSAFnlXwOArQvruiHGtlW2ZzJMWWYbFACknX+5DCmHJvL3AAAAAAAAAMQHAHeBuWGx4gJBA4BNtmUyaYS4AEg6/xoAbMbvd/61Cy3kpKDWhdUafFJbZTUDxTW+7yRgv/IvgcS/Q4LptZ330ms776XE9gEAAAAAAJAjAGhXTsmGJyebbMt8tg0/2qSXbaONtswoj826XpzRr/yz4fl7GgD6nX+5/Cfl2oX13Spr2xrrahj+nVFBIPMvjWfbCJRW/rVJPwZAVBAAAAAAAAAA9DZ87UIKaWA2gHb81bbxRzv8YvucBg7td9qM0O/8awDIKv9yyy9PpmkA0Da+xO3C2wyvXrAhjOULAFv+rYeBUs6/BiQ2/IsvPE0vvvB0z99tIAAAAAAAIM8AkIdHtGO8UlqDlJNibBDt+5phbMdgXX+ndpmmpn7nX4Kg3/mXBtCW1VwPqbhuFdYMILfEaltlbV1q36HAoOdfDnHk8p98DQAAAAAAAOAOANkFdp1k0i6x9D32a/u+qwG1z7ERuQtsC9CRl/xrk1+aAVyHBJrkJFncrbKa8aMCYNDzr20MkiBw3RAEAAAAAECeAWC77FI2IO2aa+2YrHZc1nZVmPZ92yWacnJOboixbYzJa/5dl/9sXWJpBNtGoqhbZV2X2aICIKn8S6PGzb9Mh38Pd/WlAAAAAAAAAMh7K7BsMNqGl6gN2Nbl9TWQNII8DOO7JTZv+bcZwHVSLKmtwvI5vhuF5O+3XZCRdP5tG4ji5l/7nZq0/MMAyD8AAAC4H4d1PbTjeqgnqefJLvHM++Zo5n1ziR8HHtX8RzWA9jl+HbcLL59vm2TzNUDS+deO68rJuR4QZJR/GAD5BwAAAHcDuC532S6y0AwV9bmyK5wWAEY9/65dSm1SzLWrrEo0/LhdX1cAxM2/7biu7UKRrPIPAyD/AAAAYD8eG7VLql38YQslllRXOKkLQfKSf9+usNYl9t1AozVw366u1vBdARA1/7bjutphHQmAfucfBkD+AQAAwG4A19BergFCfENf+V65lVT47LzmP+pymOsymeskouvkW1IAiJt/bSigdf2zzj8MgPwDAACAfUus77KW66EZ7SINzRCuXWT+3XEn//Kaf1tXWBpFa6i2LqztApKok1xxQ4RFzb92Xbd2WCfr/MMAyD8AAADoobG0LqlrOGvtQgztOdphFinbchyH8Y4bHDSv+ZcGkA3eddnMNnkVt4vru8zXr/xrh3NYg5J/GAD5BwAAAN0A2iSTbOi88USKD6Voh2m0Szb5e5o0Q8jfGxcAec2/1uC1v9u6zElJM2bSAMhL/mEA5B8AAADcu8Byg4mruOHarv+WBtCMJcXfk0ZNegiQl/z7dpVdDRDVKDKdtAyft/zDAMg/AAAA2LvAcmOJ6wYT7WIN7dJKeYjFV9IISQ0B8pb/tIxgmzzTnjcohh+1/MMAyD8AAADoBmAldaxWu5ab30/qCi8tAIYvAPKa/6SMoDXcYTP4qOYfBkD+AQAAoP/KqoEOivKef2gwBAMg/xAAAEEQAABBEAAAQRAAAEEQAADF0Vblv5CPUGYQAAAAQBAAMApGf/65x+j55x6jp/7l+j79/OUv7hN/DmCAAAAAAACAhhsAo7rVUzO8q9F9pYEBjbc/etNkmZJQVr8DAAAAIAAgOwC89MvqPg07CGyG14z/lS9efVVFBQJM2h8AfPQvr7+qLn3iyZtqcvUsTa6ejQ0Qfo58vvZ7AAAAAAIA0gOA1sWXYuM//vPiPtkCGQza0IENpxmetf2ZRdr+zKLV4PJ78vP8HA0E/L1hB8G7zhQpS0UFgGZ4DQCu31+8eIkWL15Sn6N9DwAAAAAAAKD/ANDCPHMgCGl8Fn/OPOel37ipbNcyZ93lZ6Oykp4ElM+XABj2IQEb8Ydf/iD98MsfpP/75adfVfw5Ta7fjwoAV+NHNa4EAL/vChIAAAAAAACA/gNACwLJ0kDRAwY2v/i765CjX11/NqTr8l/cSUBOhz8v0xt2ANiMmxQAWL4AsBn9qa8/c1OxcbW/SzEAbM+xgQAAAAAAAAAgOQD87thr6ZXqMbjShXcFgQ0MLC2sdNIAcO36a5OBvgZ3/bwGAP6db7711+jNt/4aAQD9AQAb8N//x9f2RQwImwAAAAAAAADiA4CN9cvW5D4xCFy78LwcqIFAho/W/q59LunJQlvX32Z8NqSv0WVX3zY5KNMHAPoDANkFZ4MmtXVYE6fTtyEAAAAAAAA5BAAbn43+7OQt+8Tva0bl13IrsASBfN82BGDx9+WQJKlJQQ0A0phy0k9ODmoGt/1d6+rbQAQApAMAnoTT1G8A2IYkAAAAAAAAANEBwMbiLv8vfvpu+sVP320AIIcCbECelNMMrgFC2ygkX7Pk7+PXnP5Y+xYaa99CSU0Cal153w08rpOAvsbHJGC6ALB1uTUAxJ30055nAxIAAAAAAABA/wAgDW7bEGTbKiwn+eQypByayN8TFQDy4g3N6LbJPhsQfA8LcToaAPg5DIBhAcGwASDrZcC+TQICAAAAAJBjALhOAmpdeM3wUbcKSyDx75Bgqr/+V6j++l+JbPw/e7xNf/Z4m9577gi999yR2Mt6tuO82tZhaWxb158/x/ng328DQdbHcbERKJpSPw4MAAAAAEAOAcDG5y64NJ5tI5AEgOtWYdvWYG3SjwEQFwQaAGSXXW4Ndj3043shiG0yUH7vIzsn6CM7J1QAVCqVK5VK5cqgHccdtWXAfim1SUAAAAAAAHIIAHm8l5fTJAjUw0Cex321SUDb1l9tKPDiC0/Tiy883fN3VxDYAKCBwLXL73scWDO81uWPC4CsDDgsF4K4XughLwCRF33ENbzr1WIAAAAAAAAA/gBg40u5HtKxAUF+TgJAbgmWr/l3yOU/+doXABIEbCg2PoOBJQ3sCwTXSUJpeK3LL19L4w86AH7x8+edZHuu63OSvhJMA4B22afvNd+pXwoKAAAAAAAAYAymAUDKFQjS8FG3CmsbgyQIom4IkoaSxmfx31la194VDJrRWVr63NUfVgDM/tav0uxv/So98UiVnnikSp9//+arij+nyfX7nG7S14LLrroEgO8ln1GBwb9bq3cAAAAAAAAAHQCa0W1DAgkCaVT+XtStwjId/j3c1ZeKCgDNeBoApLQtv5o43fXfmb+pNCBJEPDnNQDIBjEoALAZNykAsHwB4Hqpp3ZJqLzs0/cyUdvnpSQANBAAAAAAAAAA2AHgOinouoHItlVYgkJLx1W2C0Jk118CgA3tanzbEEIaWAKA3+fX2iQkv9YAYhsKAACvDgDXjTdyA05Sn4v6ef7dAAAAAAAAAOkBQEo7risn53pAYAkNZhs6SHBEBYBmVA0AchLONnnnOpknAcB/BwAAAAAAAAAAAIBkAcBy7VLLSTjbcV3bhSKmey+MH7frHxUA0nBal187NOQ7iagBQP7d9Xmuk4EAAAAAAAAAAAAAEG0ooAFAHtfVDutIALh2+X2NrwFA2/hjM6ScvJMAcO36a8t4Wjq25UAJAH6tgQAAAAAAAAAAAAAA3IYCtuVAbSigdf215/tOPsYFgOuknPy7/L5t665tSKFtBJKXlfpuTLIBIKvjuIO+FTgqAJK+AAQAAAAAAACgfwCwDQUkKORQQDueq4UWi2pwbZLPNUSYNvnn2vW3LR+6PlczvgYAV6BoF4NIAGR1HJeNmJVcARA3oEdSIcF8BQAAAAAAABAfANLwtqGCFshDdv3jdvFdl/k0ccGwQaTBbF3/uACwGV9Lz/V32pYBs+6CD/oQIOqQQHbZtS686+eidvkBAAAAAAAA/AGgGV77u23IkJQ0MMUFgASBr9IGQNTfZWsQWS/DDfoyYFIAcJ3cswFA+z4AAAAAAABA8gCwSU62+Ro46nJeVMO7gsBXGgi0jTw2ALh24aOK8w0ARAOAbXJOM7INIK4A6NsQAAAAAAAAACAxENgmD7XnJW34tEGgLRcOivEBgGSHAFGHBtrfbQIAAAAAAAAYHAD4Gjcrg/cLHHIyThsCaJN8SRncJgAg3hDA1aCun/NV5pOAAAAAAAAAAJBlCBF3uS6qwQGAdAAwqAIAAAAAAAAAAAYVBGl36aMCAFuB+1uvWQkAAAAAAAAAABg0IGT1u7I+jjvox4FHDQQAAAAAAAAA6QMg7oUHQ2/4Q/+ZfFQ8cGCfkH/80+iHAAAYAPkHAJI3uhY2Weqjf3mdPvqX13veHxYgaA367/7w2j595qFzN9Vfveed9FfveWfP+8NiiLznHwAAAAAAACA/AJBG14wtxSCQhtcAMKhAkA1da9hSbATZ4DUDDKohZP5tF5qwRiX/AAAAAAAAAPkDgOzauxrf1vV3BUDWQJBdW1fj27q+rgbI2hAy/67G1zRs+QcAAAAAAADIHwDkscWkAKCBQEpOJmqTi2kBgRvYdqVA25VCYgDQQCAlJ9O0ybW0DKHln4Ohagbnv9s06PkHAAAAAAAAyB8A0jZ+2orbENI2ftpKK/+uxpZASDu/Mh2AAAAAAAAAAMAXANpVRcMGADk0iNrwhxUAUY1gy/+gGF4zvvwdAAEAAAAAAACADQDS+IsXL+3TsALAFQSy4T+6cnyfhhUAriBwzb9m/KzzZ1t2BAgAAAAAAAAAbACQxs8bAGTDzxsAbPkfFOP7bjwCAAAAAAAAAAB8ATCshk8KAMNq+KQAIJ/DABiUST4AAAAAAAAAACBpAIyK8XnoIoMo2gwwKsaXQ5ex8TfR2PibIue/XwBIyvjy92r5BwAAAAAAAAAANCP94J//9aayHeYZNgBoDfJ7f/3Jm8p2mGVQAMDLezYA2AzZ7/xHNXzPoSRL/gEAAAAAAADyBwDN+HIy0NXwWQFBO0YstzRLAGgNX06GuTb4rICgHaOVW3qlAbT8H+2+ZZ+0izzSyn9U47Nk/jkfAAAAAAAAAACABgBtI1BSIPC9DDTqhSJRAaBthEkKBL6XYUa9UCQqAKTxpfqdf1/jSwDI3w8AAAAAAAAAAEQFwKCBwNX4Ggh8ATBoIHA1vpS8QsuW/6xAENX4susvhY1BAAAAAAAAALZDQP0CQdYAcDV+WiDIGgCDlv+kJv+kAAAAAAAAAAAABgAbQRrEdXkwLRC4AsLV+Fo4cu0KLC30V7+M4AoIV+PbwnEPav6TMr6WfwAAAAAAAAAAwBUAaYEg7hBAA4AWvjwqANIyQtwhgGYALXx3VAD0O/+uQ4Co+QcAAAAAAAAAAGyTZpo0AKR9WEiGCHPt+rsCwFWaAdI+LCNDZLl2fV0BEDX/bMi4+Y9rfAAAAAAAAAAAIO4QwBcAbEjt+LAmX8Pz93yN7zsE8DWA7fiwJl/D8/d8G77vEMA3/77BQWX+XSf9kso/AAAAAAAAAACQ1BBAC+Nte44tDLgERtSuf9pDAPUqLctzbGGwNWCkBQDf/Mtjwz0G9sy/ZniW7bkAAAAAAAAAAIANAJVK5UqlUrkSFQQaAKICxVW+y34aADj/UY2gASCqoVylpWNr+NIAcfOvXRwSNV+248i2dHzzDwAAAAAAAAAA5AUA0vh5A4A0vm/+oxozaSBEBYDMPwAAAAAAAAAAEBUEvgBw7aL7AiBq1z8uCHwB4NpF9QVA1K6/a/7jds3j5l+mk1T+AQAAAAAAABAYJCoItENBUY0fFQhRja/l3xUE2qGYqA0/KhCiGt+Wf1fjJzU5Z8s/p5N0/gEAAAAAAAAAANZY+xYaa99CNhAk3fUfFABw/m0gSLrrPygAkPl3NX5Ug2adfwAAAAAAAAAAwHcoYANAXOPHBYFt0s+W/7gAiNvw4xrBNunnmv+oABiW/AMAAAAAAADkFwC+INCO/w4rAHxBoB3/HVYARAWBDBsOAAAAAAAAAAAMKwBcQcBio/UbAAwe+XuktHzYGoDNCBII/QYAg0f+Hql+518CYljzDwAAAAAAAJBfANgaggYEOVRwXZ6LKtvvi9sAbN/XGl7Uizl8Naj5dwXAoOcfAAAAAAAAIL8A8G0QNjAkbeB+V7zr8/vVgJF/GB8AgAGQfwCgPwCI2zBGtcKR/3znHwCAAZB/AGD4ALD9nR3a/s4ObX8j1PVQXw11XUj53MUfv58u/vj9ZJ73D4EeeDGQ+d6XQn1HKKfp/+jZP9innz8fSL6vfU77/L9+bb9cv5e39AfFiHefv0J3n79Cv/vBj9DvfvAjxK8BAAAAAAAAUgQAN/TnhLjBSiPIhiy/Lz8XauNHD+6T+XzO09casmzA2ufk+64GshkpL+kPCgBOHK/RieM1Y3x+DQAAAAAAANAHAHDXlV9z430xFDdwrcssDSWM0WMA2dXOafquXddf/s/98jWYfL72eZn+Vz91L331U/eadPk1f973tW/6aecfAAAAAAAAAAAwDZobuNYV1ia9nrNIM1bO0/dtwL6TYTaj2YzLz43696gg6Ff+AQAAAAAAAAAA2cXt6bLypJds0OH77/r0OXrXp8/1dI173pefTyj9HsNy11x22S3p8/tpp88A4IbLXVvXZS2tq2wzjmZMWxc/rrT0JUDSzv+gTgIOzjIgAAAAAAA5AgB3hblhhg1XNYCyUcYYKjTCxe8H6gFA+D1+3/w9ZvqyK+6avsy/BgDzec/01aFE+Nq3i+u6DMaGkpN5ti68Js6/fO36flxARF0G1ADBwMMQAAAAAACAHAPgS68w/5d26B0/DNQzuaV1ZcPXsuLf/p0devt3bmJ0CwA4fQkUW/pyOS5q+uZ1mJ58LfNrS79ng5CYRLQtf9nA8PIPv7JPrsaPanStvDT5gsH2u2355/dt5ThoW4EBAAAAAAAAMlwFkBta5KEZ7iqHDd4sg1m69r6Sk3EyfX5fpq8BI+7v6RkqaABQJjM1AGgbgXwV1+g2o2rlaCt/XzC4DglclxPlkEADLAAAAAAAAECOARA2RFOhctJKbJBxNa5vhVsNKLvkwlCaYX27pK7pq8uYYqNPz2SgAgBtMlB2beXnXI0fGXxK/WvlL/PvCwbbEEHbeCTL0basimVAAAAAAAAAgJ4LL+RhFu04q6XLbzN81C6pq9Gj/g5X45jysaSvbSVm2Za1tIZrM7630cVyrvz9Wv33HJZSJodlvl3Tdx0iuC4HyuPFGAIAAAAAAIBlQK2LKrt+PRtzlOUg1y5cUmDwNbrv1lfvLnNYjg/9UyB5BRkPDVy3rLpO9vkOpXomT2WX3rY1W04WO+a/ZwOY5+ShbXLQtvyHjUAAAAAAAAAAxujhJZbaEMDWRYs6eSMbti8gfI1u2yrruzW2x/jasp+YJORJV9uVV1rDtf4eyyQdp2/ed6x/0+XXLkv1zL9sfz1DBmWjmQ0E8gIRrXwBAAAAAAAAcgwAeXEFNwR5QYZl0itqV9u1i+t7JZXvRRVJdbGleibNRFfbdUOLLf9aurb0o9Z/DxhE1z/p9F3bm1ZuWAYEAAAAAAAA0ADAASwuh9IO06Q1ORP1Mkqb0V0P17im7zoU6DGAvIIsLHfbMpWv8VUAKenb6r+nqy+X+5Tr0F3zH7f9xb16DEMAAAAAAAAAAFPhYcWaSRplA4uv8V03aEgDaNdC+waEiJq+BgJ1Y5B2TFnpKkdNX/6OqOlHrX/17ymnH/UfDyYBAQAAAAAAANTgoHIyht933KgR9dBGWtc+x32u67Kg88YgGUosfO36O523KNsuI5VG9az/nmvV5XNTSt93COpargAAAAAAAAAAgBb22ncS0DYJN6zhqb0PC8UMDx53i/KohGdPu/35Gub+pXl6pUp33L5PUY34F3/++3QzAQAAAAAAAAxeeHDXDRm2ZcBBD0/tbLiUwoOnnf6whmdPqv35Gv9ju/e/qnxBwEb/f+j/26f/TR+n/00fTx0EAAAAAAAAAO7hseNOxgxaeGjfY7fqpFvC4cH7lf6whWdPuv1FNb4cCviCgI3NRtcAkDYIAAAAAAAAAOzhsZPeCjwo4aF9r9py7opHDA/e7/SHJTx7Wu0vrvGjgkACQNPPf/Eg/fwXDwIAAAAAAACkCYCEwoP7VkS/w2O7pu9suJTCg/cr/azCsyedftT2N6gAYOMDAAAAAAAApAiAmOHBfbtkclIvrfDYruGhXQNtqId/Eg4P3u/0kwoPn1X6cdufZgw27rP/43P07P/4nPckIH/PdTJQGj5t4wMAAAAAAABEDw8edzLGtvEnanhs3/DQtgtBvA/hJBQevF/pJxUevt/pJ9X+bABgg2sg0IwvtwprV4Bdf/qrdP3pr5K2FZj/ntbhIAAAAAAAcg2AlMKDy4rwNXjc5TzX8NCuy3C28NhJhQfvd/pJ13/W6fu2P1cASBBo0g4L2S4BZaNL8d8BAAAAAAAAUgCAZ3hw12ObrheDxA2PHTc8tJa+evWWdmw24fDg/Uo/qfrPOv2o7c8XAK7SjglL40v95Cc/oZ/85CfmYhCppEEAAAAAAAAA4B8e3Dc0WNTjvVGP9UY9Xmy7Csy6BVdOjnmGB+93+nHDw9vCg6eVflLtzwYANqav8dmwGgBsINCMDwAAAAAAAEDJLwNawoPbwkO7XtEUtYue1CSia/reW3E9w2PbwoP3K/2k6j/r9KO2PxsAbBuAZFdf+zu/1kKAaQDQLguNewUZAAAAAAAAgH94cBke2vdiBq1r7hse2/VztvDQWiAO62RcQuGxs04/bv1nnX7c9ucLAE3S+GxYuUGIpYFAMz7LdYsxAAAAAAAAQPLhwX0nX7Tglr4benyvBHMND62lH3Uyzjc8d9bpD0t48LTaX9TDQDYASKPLz7sOAbS/AwAAAAAAACQHgKjhoX3DNbtO8tkM7LpcGDU8eFTjJR0ePO30Bz08eNrtz3UZ0AYCaXxpZGl8m+E140e9fhwAAAAAAAAg+fDgrscxhy08uO/lnEmHB+9X+sMWHjzp9ucKAAkCTZqxNeO7Km4AEgAAAAAAAIDo4cF9J1+Sus47q/Dgtsk416CVccODp53+sIcHj9v+fAHgK7lRKGkBAAAAAAAAZBce3Hb4wrUrNmjhwV035PQYzjM8dtTw5Fbjj0h4cJm+azt0rX8bAKJ24ZPespvepaAAAAAAAOQYADHDM0e9AGTYwoPbluXSDg/uuiyY9/Dgvu3PFQCuIJBbeAEAAAAAAACGAAARwzNrQwBtI4ZveHDblk7f13HDg3tPwkUMD65tDZblEDf9QQ8P7joE9b1+3vcwkLZRx3Z4BwAAAAAAAGAIAKCEZ3Zt6L6BGVxf2yblbH+3gcD1e9aud8Tw2HEvK3X+PSMWHjxql981PLh2HNgGAgAAAAAAAIAhngR0DM/sOhRwNZitix9Xti6ibbLN9zBO3PDg2jKgFjpMnQwM0++5Qizj8OA9W5hFu7JdAmoL/uk6GRz1QhDXwzwAAAAAAAAAAwwAz/DMUYcCrl14m/G0Bm973xcQVoMpW19N6K6I4cFty5RxJye1Sba0woP3gFHZYObavmzLfr7h4QEAAAAAAAByDABLeGbrddSe4ZrjGj1qg/H9Xc6/I2Z47KjXnvPv4tBpzluVLQbk+u+ZTIwYHtw1/bjGjxoePu6loAAAAAAAAAAjMAkYMTyztvwU1ZDa4RpbeGzX9LUG5Wt4a4iuiOHBfRV1CGP7/T2Hm8L6dy1/2z+QpIaQccPDAwAAAAAAAOQYADHDM/dUvOMWTu8LLeRylnJsWW408QWD9zJfSuHBfcOj2ybFogJPA7Ht2Lgs/7hDMt8w866h5wAAAAAAAAAAgKjhobXw1FqXWW0wyoUPccNT9yx/RUxfXU6LGR476fDommG0DUS+QzJXo2vPiWp0V+P7Hi8HAAAAAAAAwDJgUuGhpUE4PLTsSvZsFBHpy88nHZ5anbyzpN+zDJpSePCkw6P7bryKuuHK1ei+x7vTCg+PjUAAAAAAAOQYAH0KDy271HIZMavw1Fr62qRf2uHB0w6PbjsW7QsIX6Pbhib9Dg8PAAAAAAAAkGMADFl46FFLf9DCo0c9rh31opas8+8LAN/gngAAAAAAAACDD4BhDQ897OkPanh0V+PbjB43PHva+QcAAAAAAAAAAIYtPPSopD+o4dHzkj4AAAAAAABAjgEwJOGhRzX9QQ+PPurpuwLAFhJMGv/+pXm6f2keAAAAAAAAYIABMKg/LC/qvPXX6ZX6cPt2Lz3zoUv0zIcu0eXZN95U/Lm/ua9Bf3Nfw7yW6dqkPd/1+69fv/1VlVX+bQBwDQcujQ8AQAAAAAAAQG4A8G343KBdG75NSYFAM/gbH56kNz48Saf+9n106m/fR295vEpvebxKm9cfo83rj/V8vl/5BwBgQgAAAAAAoOEAgK3hs1yN7wsCLT1pcM3wj934Y3rsxh+b96UkENLOf1QAaBeCAAAQAAAAAABQOgCwNXyeFHv5yav08pNXzWubEfhzvkMBNrpmeM3oUvz5W0u/SbeWfrNv+QcAYEIAAAAAAKDRAICcBJPLZdIY8rn8e9iYbEg2OP/d1/Dy7/yau/o246eV/6QnAbERCAIAAAAAABosAMi/a8t0NiNrALCJPx93A1BS+WcBADAhAAAAAADQcGwFThoAmmF5uU4u28muO7/Wuvj8Whpe06ADwPVSUAAAAgAAAAAAenVph2qiGkH7vjS+XL6ThtUAIA2tPUd2+W2G7Vf+owJgZK8FhwkBAAAAAIAyBoCrEXyP5fL3bF1+X2mTiLycx3Ltsqed/6gAGPnAIDAhAAAAAACZ6R0X/w/KUlnnXzvc4nthh+uFHK7LfbaNPNoQQIpB8IWzBfrC2YK6JTft/EcFABvZFwAnjtfoxPEaAAAAAAAAAACgGp/op5kqaxBohmDDxDXEgQcm6MADE5G7+nJSTwJAbhXWXrNcj+kmlX/bkMN1ElCCQAMAGx9DAAAAAAAAAAAbAJ67sUjP3Vik/+tnd/dVnO6gAeDpRzZvKt8uMn+OAWDbumvbyCOX9aSxpbShAOdHGxIknX/teZy+6xDANtknjY8hAAAAAAAAAIANAGzIj//Jp/sqTjdrANgaqOwSS2nHedmorkMA7UovudwnDan9fm0ooH0+6fzz+9rzXY8Dc5dfgsA2BMBWYAAAAAAAAABfAFy5comuXLlE/+fP/1ei4ucOCwA0Q2iyLfvJrr22ZVczPF+k4QoACQJfAMTNvzS6Jt+NQK5DAEwCAgAAAAAAAPgCQDOwBITs0sv3bc8ZFgDYGrB2mae29Vce52XJ58nfIa/S4nS032Ob1HNV1Py7fi/34cEBAAAAAAAABh4ASWnQAMDGsskWEMN1CMDvu6arpW/baOP7/KTz7/o70goPDgAAAAAAAAAARAWA7NrLyUH5vvy+9v6gAUBuhNFCYbmGxNKu/OLlQNetuHHTt+XDlm6/0gcAAAAAAAAAADAEyBYAUYOC2o7/uobb9k1f63K7Psdm/Lj5d/09aV0LDgAAAAAAAAAAxAWAbZnPdzlw0AAQNyx4XAMkDYCk0wUAAAAAAAAAALAVeDS3AidlwLQB4Gu8fgMIAAAAAAAAAADAceDhOg4c1Yj9BoCrAdMeCgwqAPj4LwAAAAAAAAAAgCvBBgMASRkx6pVcWQPA9jsAAAAAAAAAAICsVF2boyyVdf7TMkBSIPANxZX2UCDp/GMSEAAAAAAAAGBYxMaVy4aDYui0AJCUEV2NGTW9tIYCaeU/LQDgUlAAAAAAAAAAACAeALSG63uYxjdMd1LBOtMagiSVfwAAAAAAAAAAAADIRr5G9L1QIy4IfLvUvgDIOv8AAAAAAAAAAMCwiDfuSABkvaFnUACQFAiiduV9r+7KOv9JA4CNDwAAAAAAAAAA9Ov48KAc7vGV7/KVqwHigiDqJJ7v9d1Z5x8AAAAAAAAAABgWAGiHhwblcE9aAHC9XFMGvuAQWNr7tqu2+r2FuN/5T/owEAAAAAAAAAAAkPYyIBuexe9XKpUrlUrlyqgAIOo120lt/HH9HTJIZ1IASDv/vgDQgoUCAAAAAAAAAABZHSNm40sNKwB8r+piAya95ddmRC08twYCVwD0K/9xAcACAAAAAAAAAACy1rADIKmAGUkd6tG62DbjRwVB2vkHAAAAAAAAAAAYAHErwNb1khXFr+MeK417QUVSDTBu/rMOj511ePBBNQYAAAAAAABAfgCQdNfLt+H1GwRpdz198z8qwUF9l+2GBQCa8QEAAAAAAADyAwDXrqBvl9MVBGldXZVV/vMeHhwAAAAAAAAAABgWANgavjx8IQ+dpLWs5AqA4oEDVDxwIDIAks5/3sODAwAAAAAAAAAAowIAreI1YyQV8slmeKm0ABA1/3kNDz7oALAZHwAAAAAAAAAASOr6534BQIIgq/znPTw4AAAAAAAAAAAwLFuB+w0AW9fd1/BxhwLDAoBhCQ8OAAAAAAAAAABkBQCtQuM2jKjG8TWwTb/6H/7DPsm/Z53/vIcHBwAAAAAAAAAAsgaAqxF8G0ZUAEjjJiUNAFnlP+/hwQcdAGxkXwDw9wEAAAAAAAAGFwC+h0ySagj9Nr4EQNRDNmnlP6/hwYdlCGADgTT+0AwBAAAAAAAAAHr0hbMF+sLZQuJdQNukX9oAYNku7OhX/vMeHnzYJgFtXf2hmwQEAAAAAAAAMHr6kc2bKuryk/Y8Nhg3nH4Z3waAfuc/7+HBB/16edflQM34g35NPQAAAAAAeQaArYHKLrGUtkWV39eeL4/DZgWArPOf9/DgwxJoxgYCm/EBAAAAAAAAhgcAmiE0yYqVDV3ToAKgX/nPe3jwYQs5Jyf9pDTjAwAAAAAAAAwfAGwNWGvIrt8bdACknf+8hwcf9uCzvgIAAAAAAAAYHADIySFNvss7/L7tuVkDIOv85z08+KiFox8W4wMAAAAAAAD0bgTyDU/t2oW1hQLrNwCSCs+dVP7zGp592AEw7AIAAAAAAADILjz1oAAg6/znNTw7TAgAAAAAAJQVALIOT501AAYl/3kNzw4TAgAAAAAADRsAkgoNNawASDr/eQ3PDhMCAAAAAAANOgCSDk/Nf++38SUAogboGFQADFt4dpgQAAAAAABoVAGgNcisuv5xhwJJB8fMW3h2TAICAAAAAAAAjDoAbA0la+PbhgRpGUUDwKCGZ09bMCEAAAAAANCgAyCtBjMoxk9r40tU42UVnr3fodBgQgAAAAAAoEEFQFrhqbMGgLZc5xogI62gnFmHZ08bdAAAAAAAAAAAwKAAIOvw1IO2FVhuqZUNPOn8D2p4ctcgqdr3tcAqsrxgQgAAAAAAoFEBgK8RsgaANLx2KCat/A9KeHItfSltaGT7npZPmBAAAAAAACgrAGQdnjorAGhbU23lkXT+sw5P7po+S9vCrBnflj5MCAAAAAAANOgASCs8ddYAsB1W8b3m2zf/WYcnt/0O+XkJJNvvtz0XJgQAAAAAABpUAKQdnloCQDNmVMUFQNr5zzo8uSaZPoPLFQCuggkBAAAAAIAGDQD9Ck9tuzoqbWmXVfYr/1mHJ/cFgExP+77rpCJMCAAAAAAANCgASCs8tet10VkBIKv8Zx2ePGr6tuVi1+fChAAAAAAAQMM6BLB1fV032khjViqVK0kq7rJfWvlHI8y3ivPzVJyfp9LUeKDaPJVq81SsLgaamqLi1BSVShNUKk1QdXYyUK0SqNukardJ9bvXqH73GhVbTSq2mlQ4OUuFk7NUqlaoVK1QcXaOirNzVKpVAtUXqFRfIAAAAIAAgF/3NoJvl9Rm/KQN7wqErPMPE+RbpcYilRqLxpDFbjvQQoWKCxUqVWepVJ2lamORqo1FY+hSZZpKlWlj7Opyg6rLDSq1a1Rq16i4VA/UqFGxUaNCeY4K5Tli4BTnK1ScrwAAAAAEADgo6YYfFQBRC1p7Xtb5hwlyPgSoVKhYqdDkyjJNrixTsbJAxcoCleZnqDQ/Q9VKqJlj+1SaPk6l6eNUri8E2uhQeaNDpaUalZZqVJybCxQavlCpBaotUaG2ZIYYAAAAAAEAyV0wkfSkX9IFHhUAaeUfJsg5AHjSbm6BCnMLdPDkPB08OU+1VpVqrere0KA8E2g6EBu/tFSl0lKViksNKi41aGpjlaY2VqmwWA8UTgYWTs4Eml+kwvwiHel06EinAwAAAFCuAeC6LJaUsjK+BoKs8w8T5HwScHGeSovzVFqYC8SGby4FWm5TcblNC3et0cJda3R8pUXHV1pU7AQqn1mh8pkVKlSqVKhUTdefXx+cWaCDMwvmNQ81yt0mlbtNAAAAgHINANtGmbSU1mRf1KFAVluRYYJ8q7beptp6e2/5LjR8sbUUaGEhULMRqNOmYqdNk90OTXY7VFxcCDR1kopTJ+nQkQk6dGSCCqU5KpTmzGQfg6a22qTaapPqZ9eofnYNAAAAIABggNSvgs9bfqHBVPX8GlXPr1H51AqVT63Q7OYqzW6u0onVDp1Y7ZiufqHepEK9SVOryzS1umwmDQ9NlunQZJmKxw4HKpcDzcxRcWaOytUKlasVqtVY84HOdKl2pgsAAAAQAJBjIwAAUKaTgGttKq21qbTSpNJKc29LbygeChzvtkN16Hi3Q4VGiwqN1t7hnlDFUpmKpfLe4aHKNFUr01TrNKjWaVD51HKgjUAAAAAA5RkAqAQIynAjUDhJV23XqNqu7S0DmkM7odpLVGwv0cFKgw5WGjRzukszp7vUvbBB3QsbpktvtgSHAKmtt6i23qLSeodK6x2qn1+j+vk1Ki0vUWl5CQCAIAAAgqBMxMt58+dWaf7cKk2vNGl6pWmW7w43m3S42dw7xBMOCWqnu1Q73aXqWpuqa20qVWaoVJmh4skpKp6cokOHD9Ohw4fN1uFSqxYoHGrwUACVAEEAAARBmQwBalUq1qp0YqVDJ1Y6r5j8Cw4JTXSXaaK7TMc7DTreaRAfH+blwPJ6h8rrHeKLRXgSkI1fOF6mwvGy2WrM7xdnZ6k4OwsAQBAAAEFQJuKu/aHpOTo0PUfFmVkqzsxSqTpPpeq8mRysnVqm2qllM8lntgKHV4fNbHYDnVqmmVPL5gqwg0fLdPBomQpTM1SYmjFDi8lmkyabTQAAggAACIKyAQAf2pmepeL0rOmq89Zds8lnaZFKS4tUXG4F4uVBPjQUDhlOLAcq1JeoUF+igyfnApUrgcILR/iCEFQCBAEAEARlMgkYGt9c3hle4WUMHh4DLnUCTTaXQgVdeJ4U5KEDd/ULCzUqLNRostOiyU7LTBKai0dCoRIgCACAICiTC0HWmlRba5qNOsebgYqtBhVbjT0gTM/cVIXJcqDwcwdPBGLjl1t1KrfqVOsuBQovIOGLQVAJEAQAQBCUyYUgHPKrVadSq24m8bhLX5w8RsXJY3T74Um6/fDkXhc/3OBjjD9TDVReoIPlBRNCjC8AMZeP8vutGtVaNQAAggAAKL+TUBmHp0b6GYcHhwkAABgQAIDyeiVVxuGpkX7G4cFhAgAABgQAoLwOATIOT430Mw4PDhMAADAgAADlFQAZh6dG+hmHB4cJAAAYEACA8joJmHF4aqSfcXhwmAAAgAEBACivh1EyDk+N9DMODw4TAAAwIAAA5fUwSsbhqZF+xuHBYQIAAAYEAKC8TgJmHJ4a6SM8OAQAIP1hBUDxwAEqHjhAnbf+eiqK+/uGPX1NXO6x6y9meOq06z9ueOxhT99W/5mHBwcAAAAAIEcA4IRZH27fTh9u307PfOgSPfOhS/T0I5v09COb9OdXW17avr5D29d3et6PW1D8nMqTi1R5cpG2b+zQ9o2doUmfxeXK5czlLuvDtz69w1Oj/ge6/lMPD44GAACg/nMIAE5A/hDfit/+9g5tf/smBfDsTqCvBTIF9s0d2v7mTT7/lR3a/spN3v/SDm1/aaen4O95fofueX7HpM/vZ53+9tM7gcL0beVnK39fELiGp0b9D1f9Jx4eHA0AAED95xAAsuI1aV0arUAv/vj9dPHH798roO/v0D3f3/v89ldDhQW28aMHaeNHD+4956mdQF8OJJ9vvs/P+/tQA5Y+lxOnb57D3/96IK0haHIFgS08Nep/uOs/dnhwNAAAAPWfQwDISR5+8N/c16C/ua9hbQBcYCzuMm1/K1Q4GWJecwH9Q6hvhAorwHz/xVD8d25oz4QKC3zU0rc1AFkvcpLINzw16n+06t87PDgaAACA+s8hAPgL2iQD6wtnC/SFswV1soK7MqYAXtgJxF2bb+3XxRcCXX4x0H3fDmQKmPVcqLDrZZ7Bfw+7WD0VMKTpy8kqKa4HWT+y/jQQyPDUqP/Rrn9reHA0AAAA9Z9DALhWvNYATJeGC4a7RLIAw0kNUxDh8sd93w3EkytmkoS7Tvz58LX5+42d/Rrx9F0bgCsIODw16j9f9d8THhwNAABA/QMA1oq3bfgwGeXJE84wFwwvi/AyCn/uWaHnQ8muFhcsd6nkc0c0fdcNIraGIAHAIadQ//mq/57w4GgAAADqP4cA0Lp+3LXg5QUp2+QPL2e886VAZlmDC+K7oWRBiQ0kPV0o2bUKP2e6TPy8EUnfNgnE0uqJ61HrCqL+813/AAAAgPoHAOxbPW3LPj3LIZwhbVmENz7IDRHcBeICkxXB73MXSi6r5CR9reJtk0I9h0ZQ/7mufwAAAED9AwAH6OUnr+6TnAzSGoD5YZwBXrbgHx5unOgpANnV4i4RF6icbOHnfyeU7IrlJH1bV1A2AK5HWb8SAKj/fNY/AAAAoP4BAPvyj20SyEz+8FZJsdXRZJQz9lIoLjB+nwuCu0jikIU66cLpjGj6tskgWT+uy0Go/3zXPwAAAKD+AYADkQ99mCuNOKNyOYMzxBnkyRMuADmJEm6A6Oky8fdkgSJ92n66d1LIdkjEFQCo/9GufwAAAED9AwAHeroOciNIT8XL5QmeHAmXMS7+IJDpEnHB8LIHv+ZJjvAyRX5eTwGIvyP9QLYuoWwI/L4EAOo/n/UPAAAAqH8AoPfqJ20SSJ384R8WTl7c+3ygng0SYQGYSRTu2oRdmXf8MJA5DMHfl1sm+Xuyy5WT9LVJIdskkBZQAvWfz/oHAAAA1D8AsBfc0fX4p8kAFwAvZ/BWRv7B3AUSBaB2pXj5gwuGJ1G+FyqcTEH6N0/fdjxUBpdE/ee7/gEAAAD1DwDoDUB2/bTjkD0XJoTLHPf/Y6Ce65DFMUuTIf4cH4bgQAvcJUL6N03ftSvoCwDU/2jXPwAAAKD+AYDeBuB6EYSZBOKuCy9XfFOIC0peoigvXBBbLtXjlNzl4g0VOUvfNgmkbQ11BQDqPx/1DwAAAKh/AGBvGcj3CihzxRF3UURwxIf+KZAMj3zx+4FkeGTtckV1ayTSv+mlkVo92pYBUf/5qn8AAABA/QMAB7y7fj1dF8643PjgGR65Jzyz3GjByyFIn7av73hfEmm7Egz1n6/6BwAAANQ/ANB7LbT2ANdroREeOp30fSd/WL7XgqP+81H/AAAAgPoHANwbgO1SwlELzzzo6bs2hKQAgPofrfoHAAAA1D8AcMB6CaR1OQjhofuaftTJH9fAIKj/fNQ/AAAAoP4BAPsykG9X0GwRRXjoRNKPOvmT1DIg6n806x8AAABQ/wDAgZ7LIKOGhzZdQoSHTiX9qOGh5eWQGgBQ//mqfwAAAED9AwDu4aGdt4giPPRIhgdH/e+MZnhwNAAAAPWfYwBw2GDbtcK2gBFasEiEh46WvmtQSFvF8+ds4cFR//mqfwAAAED9AwAHej4gg0XK19auIMJDJ5q+azhord6kwbXQYKj/fNU/AAAAoP4BgL0roViXZ99Il2ff2PMA5wYgwiObLuGghGfmyZcBS187TuvaAKSBuR5l/WpXgqH+81X/AAAAgPoHAPQGwJINQNswYt0gIsMj8+u0wjMr6ZkGmXH6plzC59vKz7bBg+tJ1l9UAKD+R7v+AQAAAPUPANgbgDbZICcd+AfZGkDPcpEIj2zejxmeuaeiByx9V8mK1sqf6ylpAKD+R7P+AQAAAPUPABxQK55DCcmuoK0BeB8e4cIJC9C8L8Ijc4HK8MimoEV4ZlsDHJT0bZM8tgYgu36y3mRD0ACA+s9X/QMAAADqHwDobQD8APkg/lzUhiAbRE/4aa2CwuWZnmUmJTwyLzNpBTso6bse57RVvG/9cb0/8cQf0RNP/BHqP2f1z/UOAAAAAAAA4A8A29ZR14slbAVi7ToqBW2r8EFL3/UiB21rZ1wAfOsbN+hb37iB+h/x+ud6BgAAAAAAAIgOAFtD8G0AWgFoyyG2gh6V9Fm2io8KgLETyzR2YrkHBCzU/3DXv6xPruex8QaNjTcAAAAAAAAADhxQG46tAciGIA+RaAWhHSqxXWWkXVChyfeKq36nL8tBq3i5IUerB9d65Hq/bXaDbpvdoGa7Sc120zQQbWiA+h+O+peGZ7WWW9RabtFt0+t02/Q6AAAAAAAAQIIA0I6Tul5WqFWQraBdC15bTrF9T05yuf7+qA1KO86ZNADGjrVo7FiLWrUatWo1mpicpYnJ2cgAQP0PRv1LAEzM1Wlirk6tboda3Q6NTSzR2MQSAAAAAAAAQApDACnfAvTtatmWTXwl05fHYdOSrHjtUE5iALizQWN3NqjVXKJWc4kmpiqBTgaSIED9D3b99xi/1g5UWqCJ0gK1alVq1ao0dqROY0fqAAAAAAAAAK8AgO0wiJaw1gC146S+BdJvaQ3A9ftR8yuNlFT5SxkAnOzS2MkutZbb1FpuU2d9mTrry9TaWKHWxoo3CFD/2dS/ZvzWcidQ2PVvrXeptd419Q4AAAAAAABwwLtCbV1ArQHIrhS/tsnWxdTk+vyk03d9riwH13KMWk89G4HCDSFbZ9Zo68wa3XXhDN114QxtrnRoc6VDzdkyNWfLNH60RONHSyoIUP/Z1H+P8ecbNDHfoJX6PK3U52lruRlopR1otUNbqx0z+QsAAAAAAABwwNq1dG1Yrj9cZlhr2PLvrhVge45N/UpfHueM2gWUn7fVpwHA0SaNHW3SZrVMm9Uyba22A4VA2GzVaLNVo/HD4zR+eJyaMyepOXNSBQHqvz/1L41/+p5NOn3PJk0stmhisUVb68uBQsNLcb0DAAAAAAAAHLBWhG/XSy4/2QrW1mC1Coi6bOkrrWJ803NtcNrzk2qAciPQ7tvvD3Rll3av7NLWqW6glSZtrTSpWa/vV7VCzWrF+Tgx6j+Z+pfGbzbqgTotanZa1Oq2qdVt09a5jUBn12nr7DrtXnxHoLCee4YAAAAAAADkGAC2CnNdXtIqxLWih70BxE1XawCu5a5tHZXPMQAotmis2KKjS8t0dGmZJsoLNFFeoN233UO7b7uHNlt12mzVqTl9nJrTx/eGAuHk4FpjjtYac9bjxKj/aPWvHefl8jcbuOptmqi3qdVuUavdoq21Dm2tdYzhJ+aXAoXLg2PHOzR2vAMAAAAAAABwEwBoFRcVAGlXQNoNwLfhxU0/KgBcQWIAMLNOYzPrNDFb269ShSZKFdOANpdbtLncovHJWRqfnDUNr9VuBlrrUmutqx4nRv37STvO26zVqFmr9ZT/RGWJJipLdP7i2+j8xbfR7sOP0O7Dj9DE1Px+hYeCDlY36WB1EwAAAAAAACABANgacNIV0e8G4NoA0wKAa4P0BkB4GGhiciZQuPV3YnGJJhaXaPfyLu1e3qULD5ynCw+cp2NLbTq21KbW6XVqnV6n9tZpam+dpq2zpwKFXc+kAZC3+pcA4PI/d88mnbtns6f8eQOQ6frvPES7Ow/RxEIjUPh3HuqNlVZprLQKAAAAAAAA4ACAuIdTsmoASaXv2gVMqgEmdfjKCoDyKo2VV2lithoonEyaqDZpoto0y0et9RVqra/QRK1DE7UOtTdPUXvzFG2dXqGt0ytmsnCzPk+b9XnaWu/S1no3cRCMev1L42+dWgl01+lAd2/R1t1bdHb7HJ3dPketTotanRaNT5RofKJEzZlAu29/gHbf/gBNzFQDHZ8NFA4BbqucodsqZwAAAAAAAABeIVtBSjDw8UeZEXksMumKsFVAUg3Bd7IzbrrSwK7la6svaXzWoaUtOrS0RbfNn6Hb5s9QsbUSqLlMxeay6Wqyis0uFZtd2n3Hg7T7jgfp2rt/j669+/dos1amzVqZtpaXaGt5ia6954N07T0fpA/c+zb6wL1vSwwEo1r/0vjvevQKvevRK3Ttwx+jax/+mDH+Xfeeo7vuPUfXrj1O1649TrsX3k67F95O43ccofE7jlCzukjN6iK16g1q1Rs0cWIuUDjEGztcCzS3QWNzGwAAAAAA5BoAlUrlSqVSueILAO34o3YxQlJd4rgV4VoxUdOL2xXUAKCFgbbViwYArvdCtUGFaoPGyis0Vl6h8enFQHM1Gp+rUWtjlVobq9TZ3KDO5gZNd1dourtCrTOnqHXmFDWX6tRcqtOffOyj9Ccf+yhde/QqXXv0Kl19eJeuPrxLl++6my7fdbfpqkYFgcyX3CCjKen6d03X9TLVng0+4Zbe3Qd3aPfBHbr23z5K1/7bR+kDv/9x+sDvf5y+8Befoy/8xed6yn98ap7Gp+apubgYaPoENadP0PjESRqfOEkT04s0Mb1It82fotvmT1Gh3qRCvQkAAAAAAADgAABXg0kQxAWA7XJE1y2mvodp4ho/aldQA4DN+K711gOA2QoVZivmcIhZBgxltpqGk4IT9Q5N1Dt0bCnQxoUztHHhjBkiPPHZP6UnPvundO0DH6FrH/gI7T70EO0+9JD5+9vfcZ7e/o7ztLW1QVtbG96G0jbIaIr6/LjpuqbPx663Nrq0tdE15c0bsK6977/Stff9V3riv3+Knvjvn6LWmQ1qndkwQC6trFJpZXXv8k/eEryyTK2V5b1lwPDvhaUtKixt0aH5Kh2arwIAAAAAAADEAIDW0DUASCP4GtH1IoekQOA7pIgKAC2f2jXRrvVhBUCjRYVGi95S36S31Dfp2EKDji00aHxmkcZnFqmztUGdrY29BsYgqLZootqi8fkGjc83qFldCLQwT82Febr60C5dfWjXTFLxpaPN9RVqrq/Q2QtbdPbClunKrpw/Qyvnz6hGYoDsPvJIqMuBwg0vu3dv0+7d27TVrtFWu0abtWnarE3T1nIrUGg0XwMz6Mwlm+GQqHVqjVqn1qi52g0U5n/86MlAd4zT+B3jJuCKfC7n/+yFs3T2wlmT//Z6l9rrXdp94J20+8A76YN/8HH64B98fG8iNkxflv94sRwoTJ+HABzohZcDedm30GhSodEEAAAAAAAAeBUARO3y2gAQVb5XOkUFQVQjJ5VfDQBx60cC4NDcAh2aW6DbF07T7QunaXy+TuPzddPAprorNNVdoWO1JTpWW6Lx8gKNlxfMMqEMPMGTULw8uLt9H+1u32cCUhg16tRq1KnZ7VCz2zGgaa4uU3N1mVoba9TaWKPVu8/Q6t1nqH16hdqnV2j34gO0e/EBetejj9K7Hn2Udi9dDnTfA7R73wN0+W330OW33bNn/G47kHkdyJa+zD+n32w1qdlqmuW4rbs3A4Ubnzh9Nv6e/PK/+8gl2n3kEn34E39EH/7EH5n0beU/fmyaxo9N7xmfNwDxMmAYEKQwNU2FqWkAAAAAAACAV8i2McgVAK5Xi/ku30W93DHqcp/vJJ4NAL5g8T0Ga9v4I+u7UFuiQm2JDk3P0aHpOXNNOGu8tEDjpQVjCJ5kOtpYpqONZdMgjzWX6VhzmTqb69TZXDeGlJdRcnjq1voatdbXTAPm50wcn6OJ43PUqteoVa8ZwzEQrly+HGj3Cl3ZvWKA8OijVwLt7tKju7tq+ltnVmnrzCqdvesMnb1rb/KSw6O36nVq1evmd8j0z17YDBRuxeWr0+669yzdde9Zk36r1QwUGp01MbMYKLy8U6a/tdIJFVzjzfng9G3lf6zRoWONjgHC2PjSPhVmKoEWG1RYbAAAAAAAkGsAvOHNB17zhjcf6AGBBgQbGLTJwKQPc9iuWZbLkdr7tqum+rWFVKbjO/mn1ZNWr1zvhdIcFUpzVDhe3q/JQBxGmq8O4y2kEyfnAy02QwUNunNmjTpn1kzDvnbtw3Tt2odpa2udtrbWTYgqc0FF2FD3uqqB9rrKDWo1GmaZbOvCJm1d2Ny7xDS8+GL34Uu0+/Al+tPPfor+9LOfoic++2l64rOfNumbCbg/CXTtvR+ka+/94J7BRJedu8xa+uba7fOnQ52hrfNnTGAVM2kXXtJpluX4whWRf06XhyjX3n2Nrr37mkmfgTJRbwUS5T82vU5j0+t0+1yg22ZP0W2zp6gwVwk0vxhobiHQyRkqnJwBAAAAAAAAeIVcQRB1KJD0cUoNBElt/HH9HWzYqFemaZd5upaXr/FZxelZKk7PUnF+norz81Q4ORuoFGqhSoWFKo1NdWlsqku3ldfotvKaMTxfImoMfGKeJk7Mm+PDVy5dpiuXLu9tdAmNbS4g4e/x5qMwPDlviNk6dypQCJCz504HCrvwPATgycbdey/S7r0XTfrGiNwll5NxbHq+YmspkNkIFQbT1NLnfF177Pfo2mO/15N/mb7Jt8i/ye/aMm2tLRvAcfoTc7VAC81Aovz5YhcGdmGhFigc4hXKc1Qoz1FpYb8AAAAAAAAADniDIO5koO37vlc1aV3mpDb+uBrf9TCVLb9RAeBqfFZtrUm1tSaVWjUqtWp0vBmoUA3FQAiHBryM1NOQuUsbHjoxG3ceeJB2H3iQtjbXAoWG5ospJuZDhRtVji3U6dhCfa9rzV3tsGtslvNC8UYj7tLzoSNjPCU8NnfJW6uhwo1KnD5fiWaMqaTPXXWZfy08t9maK/LPG5XOnVunc+fWaffhh2n34Yf3tmLzsp4sd17em2jS2ESTCtPzgepLgWYWqDCzQLXuUqD1dqDVJtVWmwAAAAAAAACvon4DIKmAEUkd5tGGGDbj+26pTgsAtvqtNhap2likUqtOpVadTiw36cRyk4ozs1ScmaVDd04EOnaCDh07YZaTTNedG/7CUqDw8kle9tq9+17avfvenvDUZuPK8blAMzUan6n1hCffbMwHajdos93YW84LN/js3ns/7d57/16Xe7UbiJfeqlVqVatmWc9ckKGkX6y3qFhvmfcvb50NdP4CXT5/gXbvuUi791zc6/Ir+TfpFGdoojhjljW19GV49svb99Hl7ft6wrPzEEOW/1h5jcbKa1SoVANNzVBhaoZqtXmq1eaptBiqWqFStUK1Vo1qrRoAAAAAAACAg6ICwPXa8KggsHX9426djTqp56u4l1BKALjWK0/+labGA9XmqVSbp2J1MdDUFBWnpujQkcN06MhhGntricbeWjIBQtg4M2urNLO2urfBhSfVQiPKDTny2PF44UigE3M0fmKuJzz5Zn061Cxt1mf3uuBXH6drVx834bF5w4zpOrPh2DgsS/o8JBmfmKLxiSlqzpwIFYRH5wAdWv7Nsx3Tl+HZzeGpyhw1K3MmJNv4kaOBRPnf0dqiO1pbxBe88NCNDV+cnaPi7ByVapVA9QUq1RcAAAAAAAAAPADguywoARDXGFG33A4bCHw3/vh2/VmlxiKVGoumQRS77UALFSouVKhUnaVSdZYOnZjep7HDC4HCIQFfJWauF680aKLSMJNsWxsrtLWxstfoeQMQd4VPVmj8ZIUmljqBwuUtDk++t0U20O7dF2j37gtqeGxO30wy8nKlZ/rjx2dCBV11GR6d09fy75v+1vZZ2to+a0J+yfRZsvwPzVTo0EzFbPwpLtUDNWpUbNTMMiADvzhfoeJ8BQAAAAAAAMBDSW0ZjmqMrIzfbxDE3eLrPASoVKhYqdDkyjJNrixTsbJAxcoCleZnqDQ/Q9VKqJljVJ05RocOHw5051E6dOdR09XkLcJjxU6gcEOKafAiPDVfOMLGkOHJ+VgrX2rJ145f3jxNlzdP94THbp1Zp9aZdZooLwbiybmE0h8/fGeo/eHR005/7NBCoLecCDVFY2+Z6in/QmOJCo0lKi3VqLRUo+LcXCDe4FWpBQo3BvEQDwAAAAAAAOBAYiCIumwY13i+BtSMFXWS0zeduBt74hrfAKDVpGKraQ6JHDw5TwdPzlOtVaVaq7o3NCjPBJoOZBre9FygcOvpncvLdOfyMhUW61RYrJsNKjI8dbG9QsX2yt4VY0p4cjNJV5yh8eKMGh6bw5NPdlZpsrNqNvLYwmNzePSxE8v7pKWvhUfn8Nwyfc6/OVQVbqm25X/sWJPGjjVNOR+aLO+TLP/iUoOKSw2a2lilqY1VU/7mc+HhHz4UdKTToSOdDgAAAAAAAEACigqCtIYMUY2f9FDG97muxk+q3swGET4gwoZvLgVablNxuU0Ld63Rwl1rdHylRcdXWlTsBCqfWaHymZW9DSjc0Pj1YqCxkys0dnJlr6sbdonNIRbeYizCk/M15FPdVZrqrprw5NyVPrrUpaNL3b0NOGx0fi3CY3NQTA6PLdMfO9oMNL0WaO4Ujc2dipw+B1zh/Mv0e67sCtM3Bg4v7zy6skxHV5bpcHOJDjeX1PLnrj+/PjizQAdnFsxrHuqVu00qd5sAAAAAAAAAKco2WWibRBw0JXUVl608kja6ehgoPBxSateo1K4ZwxdbS4EWFgI1G4E6bSp22jTZ7dBkt0PFxYVAUyepOHWSDh2ZoENHJshcNBIGHimcKFPhRJnGTnZp7GTXGIGHDmMnOoFCw43NrAUqtgNNrwaaPUVjs6fotsppuq1ymsYm24F4suyt04GOtgId7wRio4v0+Zps1/Q5PLoBWXj4h8Nzjx85RuNHjvWkz/nnLvgdzTbd0Wz3pG8O8VTrVKjWY5c/T/Yx6PkQUP3sGtXPrgEAAAAAAAD0Qa6TWf1WWqCI+7v6VS/V82tUPb9G5VMrVD61QrObqzS7uUonVjt0YrVjupocTHJqdZmmVpfNpCFPShWPHQ5ULgeamaPizByVqxUqVyvmirHCZClQ2NCLK8tUXFmmQqNNhUabjrQ7gVotOtJq7V1oEaZ/pNWmI612T/qHDhcCFU/SoeJJKpyYCRQeitHSl+HRDy5u0sHFTXNN+tjsRqgAPAcXztDBhTN7E4Y8dHjz8UCHqzR2uOqcvpb/pMu/VmMFh4NqZ7pUO9MFAAAAAAAA6KMGFQSDon7XR2mtTaW1NpVWmlRaaVJ1uUHV5QaVQvFQ4Hi3HapDx7sd4pBi5nBJqGKpTMVSmUqlCSqVJqhamaZqZZpqnQbVOg0qLDUDhQ3aHF4JJwsPzcwHml+kQ/OLpit8eKlJh5eaPekfOjkdaiZQCACzYenocTp09PjeRRkDnn7a5V8+tRxoIxAAAAAAAAAAlFfxJFG1XaNqu7a3DGgOjYRqL1GxvUQHKw06WGnQzOkuzZzuUvfCBnUvbJguZXmjQ+WNjmnAtfUW1dZbVFrvUGm9Q/Xza1Q/v0al5SUqLe9tSUX62aQPEwAAMCAAAOVVvJw0f26V5s+t0vRKk6ZXmqZhHm426XCzuXeIJOyS1k53qXa6S9W1NlXX2lSqzFCpMkPFk1NUPDllusC8dZgvHeWhBndFkX626cMEAAAMCABAuR0C1KpUrFXpxEqHTqx0XjH5FBwSmugu00R3mY53GnS80yA+PszLUeX1DpXXO8QXi/AklDk0FF4nzluN+f3i7GwgpJ9p+jABAAADAgBQXiXDg/N14KXqPJWq82ZyqnZqmWqnls0kk9mKGl4dNrPZDXRqmWZOLZsrqA4eLdPBo2WzIYa7tpPNJk2+omuL9LNJHyYAAGBAAADKLQD40EgYJJS7irx11GwyWVqk0tIiFZdbgXh5ig8NhV1WDizCW10PnpwLVK4ECi8cMceGkX6m6cMEAAAMCABAuZ0EVMKDmwYWHkMtdQJNNpdCBV1InpTirqs5/BIe853stGiy0zKTVDI8NdLPNn2YAACAAQEAKK/SwoMXWw0qtvZCTJnlIyFzzDX83METgbjhlVt1KrfqanhqpJ9t+jABAAADAgBQXmULD16cPEbFyWN0++FJuv3w5F4XM9xgYhreTDVQeYEOlhf2wlBbwlMj/WzThwkAABgwzwDY/vYObX97h7a/Hup6qK+Fui70TCjxuYs/fj9d/PH7yTzvHwK986VA298I9eVQ3w2F9DNNn68ws4Vh14K9amHN5ec5pBt/7uUnr9LLT14178u/y1BwtpBwtnD08jk29St9Lgct9F3UcrfVJ9c7AAAAAAC5BsCNHdq+sUPb3wr1bChuMLIh8vtPhfpqKP4+f44b9DcDbfzowX3a/vudQEg/0/S5IdiM6NrwtVBpNmPZGqxmQNew9HGlGdM3PVfg+IbE8wUQAID0AQAAgF5jGhh3SblBcVfzhVDcwL4TSnZF+e9fCcXPfS5QTwOUXV2kn0n6WsAT2TC1LqmrIV2NPuwAiJuuBgDXcpfpa88DAJA+AAAA0GtMg+EGxQ2Ru6j8/tf2q2fSiRtg2ODMaxZ/l5/3Uiikn2n6tpBn0rhRAZC2AdMGgC944qYfFQCuIAEAkD4AAADQa3omkZ4P1NNl5Ekn2aCeDlR5cpEqTy72LGeZ97nhhc8x7yeUvnlfLqexoUT6ZvJtwNLnckk9/YQBYGvASRux3wBwBVBaAHAFEgAAAAAAAIAHAHiS6UuhwobT0wDF3+Xy1J9fbdGfX22ZZayLPwhk3ueGGTZ88z4bIWb6ZnJMpG+eL9I3AMo6fVH+XC4yffN53/R5SCDS59euAPDdmCIbalYASCp91yFAUgDyLV9t4xUAAAAAAADAqwCAu4RhV/IdPwzEXWHTtZRbVvl74WtuoNyA731+h+59fq9BS8Pza9OwRfrmfcf0jRHCyTNOv8foA5a+KZcwffM6LH/zWqSvDblk+j0bhML0eRJRhjW3GUmC4ZkPXaJnPnSpp2Hy+xIg/QJAUiDwneyMm640sGv52upLGh8AAAAAAADgFRuBRAMyDZwnkb4XKpxMMstQ3ADD5SzZsF1lzBGmb94X6XPDl+kbQ/BW2tAwNgANSvrW8hHl3zO04uVEkb4ZAggA8OuFt76OFt76Om8AyPf5UAs3zKQBkJQRXY0ZNb24QwENACwuZ9d60QDA9Q4AAAAAQK4BEDYE06C5y8iHTsLDJNwllV192VX2bdicUatBZZdYTIb1fD5c5rKll3X6zgAQ6ZtyZ4BzvYmNPvf/YyDz94gAcDWYBEFcAGhG9D1M5HuYJq7xow4FNADYjO9abwAAAAAAAAC9AOhZXmJpx0kjdvm145BRjaIZzWb4YU/fdPnD9CWYVVCIyci4ANAaugYAaQRfI7pe5JEUCHyHFFEBoOWTyzHq0AcAAAAAAADgVQDAW0l58khOCoaTSXKLqpkkDK+Ykg3vC2cL++R7JRN/T3uuzTDDnn7koQIP2cItxg/9U6B7ng/E9Xnx+4FsAIja5bUBIKp8r/SKCoKoRk4qvxoA4tYPAAAAAAAAQO8Q4J7vBzIA4EMqYqOJrQHKhv/0I5s3lWYM7fO252galvR9QaEaX2784frk5d3wczzpyw1BgiAqELRLQOMeq/UFQFwQRJ3EswHAFyy+x6BtG39kfQMAAAAAkGsAcIPhBhJeJ22WAXlDCU86vRgoqvFZ3LXxNYirXNNn2b5n+73a7/cFii3/rkOBniEb159YDpQNwgYEGxi0ycCkD/PYrtmWy5Ha+7arxvq1hVim4zv5p9WTrX4BAAAAAAAAdujiC4Euvxjovm8H0paXXAEgjSaVVFc7avquv4sbTlRDx5WWT20o0LNsy8eOxQUkrTv/0z65giDqUCDp47QaCJLa+OP6O7jdRL0yTbvM07W8XI1fL/z6PgEAAAAAkGsAhMt/9303EC/vma3B3HXkhhO+thkwqtFsXfV+SQOA6/ejTiq65l89zMShv+S14TJgSFifEgCuIIg7GWj7vu9VXVqXOamNP67Gdz1MZctvVADYjC/rGQAAAACAXAOAJ/meFeILQbhBWQ77RAWBnJzRFLVr5/r8pNN3fa4vUGxDgJ4twGx4rkdeFgxB3z32W9Q99lvOIEgbAEkFDEnqMI82xLAZ33dLdVoA4HqUAOB6BwAAAAAAANDDU7tOAtq21MoG7RqUctTDQ3M5aMuSvluEjfEdw4NzQ3AFgS8AXK8NjwoCW9c/7tbZqJN6vop7CakNAFIAAAAAAAAA0cODa8Z33QAjAZDX8NBcDq7LgOohoIjhwX0B4LssKMslrjGibrkdNhD4bvxxNX7vJCAAAAAAADkGgGd4atcNQXIZS05+8Q/Pe3hoLgdtctAGgLjhwWWX0BcEUbcMRzVGVsbvNwiibvF1NT4AAAAAAACAe3hw22Sg67FaOQmY9/DQchJQKzfbJKCZ/PMMD64tE9lkO2SS9EUjUa/k8jVW1ElO33Tibuxx3egDAAAAAAAA8CoASCg8tgSBNhkYFQCjGh7aBgDr5F/M8OCyQfg2JP58VBCkNWSIavykhzK+z3U1vlb+AAAAAAAAAB4AiBke3DYkkCCQy195Dw8tl0O1C0F6jJ9QeHCbsV0B4AsC2dCjGrPfSuoqLlt5uBpaK3/X+gMAAAAAINcAiBgeXJsUtE0Cyoaf9/DQshxsk4Dq5F/E8OC+BtYulog6NMhaaYEi7d/tW/7y83sXggAAAAAAkGMApBQeXGvIsouU9/DQsmuplZs0vlb+vuHBtYbhO5mU1GRh3pV2+QMAAAAAAAC8AgCe4cF7rppSJgO1oYAvAEY9PLQNAD3hy5XyjxoeXDYI21bgpEGA9LNNHwAAAGBAAMA/PLhtElDbGiwBkPfw0BoAXC8CMZOAPHTj5dpvClnCg8sGmJURkH5/0wcAAAAYMNcAcAwPrm4NVsKD2wyaFgCGLTy0HAr5XgFmrvjiIZpneHDfhpj0JBXSzzZ9AAAAgAFzDQDP8OBmOdASLtw2FPANMjmq4aHllWDO4cDl0C1ieHCtIcoG2G8jIP3+pA8AAAAwYK4B4Bke3HfyTwZSkMeB8x4eWrsW3FaermHBXcODaxtFbJNSvoeGXLe2Iv3+pA8AAAAwIACghwfv6Wry1lLPyb+oABj18NC+ALBdyho3PHjcLqZvQ0f62aYPAAAAMGCuARAxPHjUyT/XScC8hIfWAoN4LwcmHB48qcmmuIeMkH666QMAAAAMmGsAOIYHjzr557sMmLfw0K7LgL5DgaTCgye9zOUbiATpp5s+AAAAwIAAQHbhwfMeHjrp8OCmPhMOD560bBtdkH5/0gcAAAAYMNcAiBke3DUgiO8kYF7CQw9LePB+GQHp9zd9AAAAgAFzDYCMw4PnPTx03PDg1knAhMODJ71MhfSzTR8AAABgwFwDwBIe3HUS0DUwiOskYF7CQycVHtwMAfoUHjypjS5IP9v0AQAAAAbMNQAihgf3DQqqASDv4aHjhgfvAUHG4cGT3rCC9NNNHwAAAGDAXAPAMzy471DAFh582JQWaJIKD85DtqzDg/erS4z044YHBwAAABgwxwCwhAfXJgHN98KGpIHAFh4cunl4cFl+zl3+AQ0Prl15hfSzTR8AAABgwFwDIGZ48J4GGW4l1hps3Mm4UZWz4cPyl2A2G38GPDy4q5B+v8KDAwAAAAyYYwDEDA/esxEl/LvrZGFay3ZJLSumnb5rOSE8ONJPNTw4AAAAwIA5BoBveHAZKESGp5bXVMvLK7VQV76AcDWY+Z1Dlr4sP/Mc3sIdGh3hwZF+tPDgAAAAAAPmGAAJhQeXy4YyPLW8sorDU8vJQ3kVmTSA+bxyPbkEED9HhseWk2iDlr4sLy73nmVYhAdH+rEuBAEAAAAYMMcAiBke3DU8tTQUTzoag2jpCwOY5wgDyOeb71vCYw9q+j3Xeoflad5HeHCkn0h4cAAAAIABcwwAz/Dg2y+G4r9zQ+Plp7DBuYanRvrZpo/w3AgPDgMCADBg3gEQNTx4T5fTMzw10s82fYTnznt4cBgQAIABcwyAiOHBzd/FxhLf8NRIP9v0EZ477+HBYUAAAAbMMQAcw4P3HDbhLqUMOy02ENnCUyP9bNNHeG6EB4cBAQAYMK8AqFQqV+LoDW8+8Jo4Gvb0R0VxyxHlP5zlDwCg8QEAAAAAkHXF57UhovyzLX8AAA0QAAAAAIBBqfC8NUSUf7blDwCgAQIAAAAAMGgVnZeGiPLPtvwBADRAAAAAAAAGtYJHvSGi/LMtfwAADRAAAAAAgEGv2FFtiCj/bMsfAEADBAAAAABgWCp01Boiyj/b8gcA0AABAAAAABi2ihyVhojyz7b8AQA0QJQ/ADB8xxih4TbQoPwDGJX6AwAAAAAAAAAAAAIAIM/1BgAAAAAAAAAAAAQAQJ7rCwAAAAAAAAAAAAgAgDzXEwAAAAAAAAAAABAAAAA1AAAAAAAAAAAAEAAAmLQFAAAAAAAAAAAAAgAgrxu4AAAAAAAAAAAAgAAAyONhLgAAAAAAcgyA/38ApOFn50XpmE4AAAAASUVORK5CYII=";
+const imgTiles = new Image(); let imgTilesReady=false; imgTiles.onload=()=>{imgTilesReady=true;}; imgTiles.src=ASSET_TILES;
+// Decor sprite source rects within the 32px-grid tileset.
+const DECOR_SRC = {
+  tree:   {sx:0,  sy:96, sw:64, sh:64},
+  rock:   {sx:0,  sy:64, sw:32, sh:32},
+  flowers:{sx:64, sy:0,  sw:32, sh:32},
+};
+// Terrain cells: row*GRID+col → 'tree' (blocking) | 'well' (bonus charge)
+const TERRAIN = {}; // populated by initTerrain() on reset
+// Fixed scenery layout (fractions of the board, adapts to GRID).
+const DECOR = [
+  {k:'tree',   cf:0.02, rf:0.16}, {k:'tree',   cf:0.98, rf:0.84},
+  {k:'rock',   cf:0.04, rf:0.66}, {k:'rock',   cf:0.96, rf:0.34},
+  {k:'flowers',cf:0.06, rf:0.40}, {k:'flowers',cf:0.94, rf:0.60},
+];
+
+// Use the grassland scene as the boot-screen backdrop (pixelated, dark scrim).
+(function(){
+  const b=document.getElementById('boot');
+  if (b) {
+    b.style.backgroundImage =
+      `linear-gradient(rgba(7,10,22,0.72),rgba(7,10,22,0.84)), url(${ASSET_GRASS})`;
+    b.style.backgroundSize='cover';
+    b.style.backgroundPosition='center';
+    b.style.imageRendering='pixelated';
+  }
+})();
+
+// ═══════════════════════════════════════════════════════
+// COMPLEX NUMBER HELPERS
+// ═══════════════════════════════════════════════════════
+const C = {
+  add:      (a,b) => ({ r:a.r+b.r, i:a.i+b.i }),
+  sub:      (a,b) => ({ r:a.r-b.r, i:a.i-b.i }),
+  mul:      (a,b) => ({ r:a.r*b.r-a.i*b.i, i:a.r*b.i+a.i*b.r }),
+  scale:    (a,s) => ({ r:a.r*s, i:a.i*s }),
+  norm2:    (a)   => a.r*a.r+a.i*a.i,
+  norm:     (a)   => Math.sqrt(a.r*a.r+a.i*a.i),
+  fromPolar:(r,φ) => ({ r:r*Math.cos(φ), i:r*Math.sin(φ) }),
+};
+
+function blochToState(theta, phi) {
+  return { alpha:{r:Math.cos(theta/2),i:0}, beta:C.fromPolar(Math.sin(theta/2),phi) };
+}
+function stateToBloch(s) {
+  const nA = C.norm(s.alpha);
+  const theta = 2*Math.acos(Math.min(1,nA));
+  let phi = 0;
+  if (C.norm(s.beta)>1e-6) phi = Math.atan2(s.beta.i,s.beta.r)-Math.atan2(s.alpha.i,s.alpha.r);
+  return {theta,phi};
+}
+function normalizeState(s) {
+  const n = Math.sqrt(C.norm2(s.alpha)+C.norm2(s.beta));
+  if (n<1e-9) return {alpha:{r:1,i:0},beta:{r:0,i:0}};
+  return {alpha:C.scale(s.alpha,1/n), beta:C.scale(s.beta,1/n)};
+}
+function measureState(s) {
+  if (Math.random()<C.norm2(s.beta))
+    return {collapsed:1, state:{alpha:{r:0,i:0},beta:{r:1,i:0}}};
+  return {collapsed:0, state:{alpha:{r:1,i:0},beta:{r:0,i:0}}};
+}
+function fmtState(s) {
+  const p0=C.norm2(s.alpha), p1=C.norm2(s.beta);
+  if (p1<0.02) return '|ψ⟩ = |0⟩  [ground]';
+  if (p0<0.02) return '|ψ⟩ = |1⟩  [excited]';
+  return `|ψ⟩ = ${Math.sqrt(p0).toFixed(2)}|0⟩ + ${Math.sqrt(p1).toFixed(2)}|1⟩`;
+}
+
+// ═══════════════════════════════════════════════════════
+// QUBIT BATTLE — Bloch vector + "charge" (excited-state amplitude)
+// ═══════════════════════════════════════════════════════
+// "Charge" = P(|1⟩) = how likely/strong a unit's strike is (Born rule).
+function charge(unit) { return C.norm2(unit.state.beta); }
+// Faction palette (used everywhere a unit's side needs a color).
+const FACTION = {
+  white: { col:'#2fe0d0', rgb:'47,224,208', name:'KNIGHTS' },
+  black: { col:'#ff4d9d', rgb:'255,77,157', name:'MAGES' },
+};
+
+// ═══════════════════════════════════════════════════════
+// QUANTUM GATES
+// ═══════════════════════════════════════════════════════
+const GATES = {
+  X: s => ({alpha:s.beta, beta:s.alpha}),
+  H: s => ({
+    alpha:C.scale(C.add(s.alpha,s.beta),1/Math.SQRT2),
+    beta: C.scale(C.sub(s.alpha,s.beta),1/Math.SQRT2),
+  }),
+  Y: s => ({alpha:C.mul({r:0,i:-1},s.beta), beta:C.mul({r:0,i:1},s.alpha)}),
+  Z: s => ({alpha:s.alpha, beta:C.scale(s.beta,-1)}),
+  S: s => ({alpha:s.alpha, beta:C.mul(s.beta,{r:0,i:1})}),
+  T: s => ({alpha:s.alpha, beta:C.mul(s.beta,C.fromPolar(1,π/4))}),
+  Rx: s => {
+    const [c,si]=[Math.cos(π/8),Math.sin(π/8)];
+    return {
+      alpha:C.add(C.scale(s.alpha,c),C.mul({r:0,i:-si},s.beta)),
+      beta: C.add(C.mul({r:0,i:-si},s.alpha),C.scale(s.beta,c)),
+    };
+  },
+  Ry: s => {
+    const [c,si]=[Math.cos(π/8),Math.sin(π/8)];
+    return {
+      alpha:C.add(C.scale(s.alpha,c),C.scale(s.beta,-si)),
+      beta: C.add(C.scale(s.alpha,si),C.scale(s.beta,c)),
+    };
+  },
+};
+
+const GATE_INFO = {
+  H: {label:'Hadamard',short:'|0⟩↔|+⟩ superposition',ctrl:'π rotation around (X+Z)/√2. Creates maximum superposition — equal |0⟩/|1⟩ amplitude. Drives qubit to Bloch equator.'},
+  X: {label:'Pauli-X',short:'|0⟩↔|1⟩ bit-flip NOT',ctrl:'π rotation around X-axis. Full population inversion. The quantum NOT gate — foundational to error correction.'},
+  Y: {label:'Pauli-Y',short:'bit-flip + phase flip',ctrl:'π rotation around Y-axis. Applies both bit-flip and phase-flip: α↦−iβ, β↦iα.'},
+  Z: {label:'Pauli-Z',short:'phase flip |+⟩↔|−⟩',ctrl:'π rotation around Z-axis. Flips the sign of the |1⟩ amplitude (φ→φ+π), which swaps |+⟩↔|−⟩. Phase is invisible to charge and a Z-basis strike, but flips a safe X-basis GUARD into an exposed one.'},
+  S: {label:'S Phase',short:'+π/2 relative phase',ctrl:'90° Z-axis rotation. Multiplies |1⟩ by i (φ→φ+π/2). Chain two S gates to get Z. Sets up the relative phase that decides a GUARD\'s X-basis crit odds.'},
+  T: {label:'T Gate',short:'+π/4 relative phase',ctrl:'45° Z-axis rotation (φ→φ+π/4). Non-Clifford — essential for universal computation. Like S/Z, it only changes outcomes through X-basis interference (GUARD).'},
+  Rx:{label:'Rx(π/4)',short:'π/4 X-axis tilt',ctrl:'π/4 X-axis rotation, modelling Larmor spin precession. Tilts the qubit toward the equator, adjusting both charge and the X-basis phase.'},
+  Ry:{label:'Ry(π/4)',short:'π/4 Y-axis tilt',ctrl:'π/4 Y-axis rotation, modelling Rabi oscillation — the cleanest coherent qubit drive. Nudges charge without adding a complex phase.'},
+  CNOT:   {label:'CNOT',short:'entangle two qubits',ctrl:'Conditional X: flips target if control |1⟩. Forms a correlated Bell pair — a strike on one bleeds onto the other (no faster-than-light control; only the correlation is shared).'},
+  MEASURE:{label:'Measure',short:'collapse to eigenstate',ctrl:'Projective Z-basis measurement. Collapses |ψ⟩ to |0⟩ or |1⟩ and stabilizes the unit (coherence +12).'},
+};
+
+// ═══════════════════════════════════════════════════════
+// QPhysics — open-quantum-system engine (Lindblad T1 / T2)
+// ═══════════════════════════════════════════════════════
+// A standalone, unit-tested physics core, separable from the game UI (per the
+// QuBlitz critique: replace the ad-hoc decoherence with a physically-motivated,
+// verifiable model — recs #1, #2, #6). It models a single qubit as a 2×2 density
+// matrix ρ and evolves it under the EXACT analytical solution of the Lindblad
+// master equation for amplitude damping (T1 relaxation toward the ground state
+// |0⟩) plus pure dephasing (T2). No HTML dependencies — callable + testable on
+// its own (window.QPhysics / runDecoherenceDiagnostic()).
+//
+// Bloch convention (matches blochToState/stateToBloch and the Bloch renderer):
+//   r=(x,y,z), z=+1 ↔ |0⟩ (north), z=−1 ↔ |1⟩ (south).
+//   ρ = ½[[1+z, x−iy],[x+iy, 1−z]]  ⇒  ρ00=(1+z)/2, ρ11=(1−z)/2.
+//   x = 2·Re(ρ01),  y = −2·Im(ρ01),  z = ρ00−ρ11,  with ρ01 = α·conj(β).
+//   charge ≡ P(|1⟩) = ρ11 = (1−z)/2.
+//
+// Exact Lindblad solution over one step dt (relaxation toward |0⟩):
+//   x(t)=x₀·e^(−dt/T2),  y(t)=y₀·e^(−dt/T2),  z(t)=1+(z₀−1)·e^(−dt/T1).
+// The physical constraint T2 ≤ 2·T1 is enforced.
+const QPhysics = (() => {
+  const cConj = a => ({ r:a.r, i:-a.i });
+
+  // pure spinor {alpha,beta} → Bloch vector {x,y,z}
+  function blochFromPure(s) {
+    const r01 = C.mul(s.alpha, cConj(s.beta));     // ρ01 = α·β*
+    return { x: 2*r01.r, y: -2*r01.i, z: C.norm2(s.alpha) - C.norm2(s.beta) };
+  }
+
+  // Bloch vector → a pure spinor on the same z & azimuth. Charge (=(1−z)/2) and
+  // direction are preserved exactly; this feeds the game's pure-state code paths.
+  function pureFromBloch(r) {
+    const theta = Math.acos(Math.max(-1, Math.min(1, r.z)));   // cosθ = z
+    const phi = Math.atan2(r.y, r.x);
+    return { alpha:{r:Math.cos(theta/2), i:0}, beta:C.fromPolar(Math.sin(theta/2), phi) };
+  }
+
+  const charge      = r => Math.max(0, Math.min(1, (1 - r.z) / 2));   // P(|1⟩)=ρ11
+  // QB-5 — defensive interference. A GUARDing unit is measured in the X-basis,
+  // so its chance of being caught excited (a CRITICAL) is P(|−⟩) = (1 − x)/2,
+  // where x is the Bloch x-component set by the relative phase φ (Z/S/T) and θ.
+  // This makes phase mechanically real: |+⟩ (x=+1) is crit-immune, |−⟩ (x=−1)
+  // is fully exposed, |0⟩/|1⟩ (x=0) are a coin flip.
+  const guardCritProb = pureOrBloch => {
+    const r = ('z' in pureOrBloch) ? pureOrBloch : blochFromPure(pureOrBloch);
+    return Math.max(0, Math.min(1, (1 - r.x) / 2));
+  };
+  const radius      = r => Math.sqrt(r.x*r.x + r.y*r.y + r.z*r.z);    // |r|: 1 pure, 0 mixed
+  const purity      = r => (1 + Math.min(1, radius(r)**2)) / 2;       // Tr(ρ²) ∈ [½,1]
+  const coherenceL1 = r => Math.sqrt(r.x*r.x + r.y*r.y);              // 2|ρ01| transverse coherence
+
+  // One exact Lindblad step toward the ground state |0⟩.
+  function lindbladStep(r, { T1, T2, dt = 1 }) {
+    T1 = Math.max(1e-6, T1);
+    T2 = Math.max(1e-6, Math.min(T2, 2 * T1));     // enforce T2 ≤ 2·T1
+    const eT2 = Math.exp(-dt / T2), eT1 = Math.exp(-dt / T1);
+    return { x: r.x * eT2, y: r.y * eT2, z: 1 + (r.z - 1) * eT1 };
+  }
+
+  // ── density-matrix layer (unitary gates + self-tests) ──
+  const rhoFromBloch = r =>
+    [[{r:(1+r.z)/2,i:0}, {r:r.x/2,i:-r.y/2}],
+     [{r:r.x/2,i:r.y/2}, {r:(1-r.z)/2,i:0}]];
+  const blochFromRho = rho =>
+    ({ x: 2*rho[0][1].r, y: -2*rho[0][1].i, z: rho[0][0].r - rho[1][1].r });
+  // ── 2-qubit Bell pair (QB-6) ──────────────────────────────────────────────
+  // A shared 4-amplitude state [c00,c01,c10,c11] for an entangled pair. This is
+  // the physically-correct model: measuring one half collapses both with
+  // correlated outcomes, and a LOCAL single-qubit gate on one half leaves the
+  // partner's marginal statistics unchanged (no-communication theorem). The old
+  // game code applied a gate to the partner directly — the #1 entanglement
+  // misconception — which this replaces.
+  const Bell = (() => {
+    const inv2 = 1 / Math.SQRT2;
+    // |Φ+⟩ = (|00⟩ + |11⟩)/√2 — the pair CNOT produces from |+⟩⊗|0⟩.
+    const phiPlus = () => [ {r:inv2,i:0}, {r:0,i:0}, {r:0,i:0}, {r:inv2,i:0} ];
+
+    // P(qubit `which` = |1⟩), marginalising over the partner.
+    const marginalP1 = (a, which) =>
+      which === 0 ? C.norm2(a[2]) + C.norm2(a[3])   // |10⟩,|11⟩
+                  : C.norm2(a[1]) + C.norm2(a[3]);   // |01⟩,|11⟩
+
+    // Apply a 2×2 unitary to one qubit (tensor with identity on the other).
+    function applyLocal(a, which, U) {
+      const [[u00,u01],[u10,u11]] = U;
+      const out = a.slice();
+      if (which === 0) {
+        out[0] = C.add(C.mul(u00,a[0]), C.mul(u01,a[2]));
+        out[2] = C.add(C.mul(u10,a[0]), C.mul(u11,a[2]));
+        out[1] = C.add(C.mul(u00,a[1]), C.mul(u01,a[3]));
+        out[3] = C.add(C.mul(u10,a[1]), C.mul(u11,a[3]));
+      } else {
+        out[0] = C.add(C.mul(u00,a[0]), C.mul(u01,a[1]));
+        out[1] = C.add(C.mul(u10,a[0]), C.mul(u11,a[1]));
+        out[2] = C.add(C.mul(u00,a[2]), C.mul(u01,a[3]));
+        out[3] = C.add(C.mul(u10,a[2]), C.mul(u11,a[3]));
+      }
+      return out;
+    }
+
+    // Measure qubit `which`; return {outcome, partnerOutcome, amps} where amps is
+    // the renormalised post-measurement state. `rand` is injectable for tests.
+    function measure(a, which, rand = Math.random) {
+      const p1 = marginalP1(a, which);
+      const outcome = rand() < p1 ? 1 : 0;
+      const keep = i => {
+        const bit = which === 0 ? (i >> 1) & 1 : i & 1;   // i: 0..3 → bits b0 b1
+        return bit === outcome;
+      };
+      let norm = 0;
+      const out = a.map((amp, i) => keep(i) ? amp : {r:0,i:0});
+      out.forEach(amp => { norm += C.norm2(amp); });
+      const s = norm > 1e-12 ? 1/Math.sqrt(norm) : 0;
+      const amps = out.map(amp => C.scale(amp, s));
+      // Partner outcome is whatever the collapsed state now assigns it.
+      const partnerOutcome = marginalP1(amps, which === 0 ? 1 : 0) > 0.5 ? 1 : 0;
+      return { outcome, partnerOutcome, amps };
+    }
+
+    return { phiPlus, marginalP1, applyLocal, measure };
+  })();
+
+  // 2×2 unitary of a named game gate, derived from GATES (single source of truth):
+  // U = [ GATE(|0⟩) | GATE(|1⟩) ] as columns.
+  function gateMatrix(name) {
+    const g = GATES[name]; if (!g) return null;
+    const c0 = g({alpha:{r:1,i:0}, beta:{r:0,i:0}});
+    const c1 = g({alpha:{r:0,i:0}, beta:{r:1,i:0}});
+    return [[c0.alpha, c1.alpha], [c0.beta, c1.beta]];
+  }
+  const matMul = (A,B) => {
+    const o = [[null,null],[null,null]];
+    for (let i=0;i<2;i++) for (let j=0;j<2;j++)
+      o[i][j] = C.add(C.mul(A[i][0],B[0][j]), C.mul(A[i][1],B[1][j]));
+    return o;
+  };
+  const dagger = U => [[cConj(U[0][0]), cConj(U[1][0])],
+                       [cConj(U[0][1]), cConj(U[1][1])]];
+  // Apply a unitary gate to a Bloch vector via ρ → UρU† (valid for mixed states).
+  function gateBloch(r, name) {
+    const U = gateMatrix(name); if (!U) return r;
+    return blochFromRho(matMul(matMul(U, rhoFromBloch(r)), dagger(U)));
+  }
+  // Born-rule projective measurement in the Z basis.
+  const measure = r => Math.random() < charge(r)
+    ? { outcome:1, bloch:{x:0,y:0,z:-1} } : { outcome:0, bloch:{x:0,y:0,z:1} };
+
+  // Map the game's coarse decoherence rate to physical T1/T2 (in turns).
+  function timesFromRate(decoRate) {
+    const dr = Math.max(0.25, decoRate || 1);
+    const T1 = 10 / dr;          // amplitude damping: charge relaxes ~e^(−t/T1)
+    const T2 = 0.75 * T1;        // dephasing slightly faster (T2 ≤ 2·T1 ✓)
+    return { T1, T2 };
+  }
+
+  // ── falsifiability harness (critique rec #2) ──
+  // Prepare a unit in |1⟩, evolve N turns, fit charge-vs-turns to an exponential
+  // and to a line. A physical model ⇒ R²_exp ≈ 1 ≫ R²_lin, and the fitted T1
+  // recovers the input T1.
+  function linregR2(xs, ys) {
+    const n = xs.length;
+    const mx = xs.reduce((a,b)=>a+b,0)/n, my = ys.reduce((a,b)=>a+b,0)/n;
+    let sxy=0, sxx=0, syy=0;
+    for (let i=0;i<n;i++){ const dx=xs[i]-mx, dy=ys[i]-my; sxy+=dx*dy; sxx+=dx*dx; syy+=dy*dy; }
+    const slope = sxx ? sxy/sxx : 0;
+    let ssRes=0; for (let i=0;i<n;i++){ const f=slope*xs[i]+(my-slope*mx); ssRes+=(ys[i]-f)**2; }
+    return { slope, r2: syy ? 1 - ssRes/syy : 1 };
+  }
+  function diagnose({ decoRate = 2, turns = 20 } = {}) {
+    const { T1, T2 } = timesFromRate(decoRate);
+    let r = { x:0, y:0, z:-1 };                  // start fully excited |1⟩
+    const t=[], q=[], lnq=[];
+    for (let k=0;k<=turns;k++){
+      const c = charge(r); t.push(k); q.push(c);
+      if (c > 1e-9) lnq.push(Math.log(c));
+      r = lindbladStep(r, { T1, T2, dt:1 });
+    }
+    const expFit = linregR2(t.slice(0, lnq.length), lnq);   // ln(q) vs t
+    const linFit = linregR2(t, q);                          // q vs t
+    const report = {
+      model:'Lindblad amplitude damping', decoRate, T1, T2,
+      R2_exponential:+expFit.r2.toFixed(5), R2_linear:+linFit.r2.toFixed(5),
+      T1_input:+T1.toFixed(3), T1_recovered:+(expFit.slope?-1/expFit.slope:Infinity).toFixed(3),
+      verdict: expFit.r2 > linFit.r2 ? 'EXPONENTIAL (physical) ✓' : 'LINEAR (non-physical) ✗',
+      charge_by_turn: q.map(v=>+v.toFixed(4)),
+    };
+    if (typeof console!=='undefined' && console.table)
+      console.table({ R2_exp:report.R2_exponential, R2_lin:report.R2_linear,
+                      T1_in:report.T1_input, T1_fit:report.T1_recovered, verdict:report.verdict });
+    return report;
+  }
+
+  function selfTest() {
+    const approx=(a,b,e=1e-9)=>Math.abs(a-b)<=e;
+    const Z0={x:0,y:0,z:1};
+    const hp=gateBloch(Z0,'H');
+    const T1=5,T2=3;
+    const r1=lindbladStep({x:0,y:0,z:-1},{T1,T2,dt:1});   // |1⟩ → one step
+    const rp=lindbladStep({x:1,y:0,z:0},{T1,T2,dt:1});    // |+⟩ → one step
+    const clamp=lindbladStep({x:1,y:0,z:0},{T1:2,T2:99,dt:1});
+    const tests=[
+      ['H|0⟩→|+⟩ (z=0,x=1)', approx(hp.z,0)&&approx(hp.x,1)],
+      ['X|0⟩→|1⟩ (z=−1)',     approx(gateBloch(Z0,'X').z,-1)],
+      ['Z preserves z',        approx(gateBloch(Z0,'Z').z,1)],
+      ['charge(|1⟩)=1',        approx(charge({x:0,y:0,z:-1}),1)],
+      ['charge(|+⟩)=½',        approx(charge(hp),0.5)],
+      ['charge relaxes e^(−1/T1)', approx(charge(r1),Math.exp(-1/T1))],
+      ['transverse decays e^(−1/T2)', approx(coherenceL1(rp),Math.exp(-1/T2))],
+      ['T2 clamped to 2·T1',   clamp.x<=Math.exp(-1/(2*2))+1e-9],
+    ];
+    const passed=tests.filter(([,v])=>v).length;
+    const fails=tests.filter(([,v])=>!v).map(([n])=>n);
+    (passed===tests.length?console.log:console.error)
+      (`QPhysics self-test: ${passed}/${tests.length} passed`+(fails.length?` — FAILED: ${fails.join('; ')}`:' ✓'));
+    return { pass:passed===tests.length, tests };
+  }
+
+  return { blochFromPure, pureFromBloch, charge, guardCritProb, radius, purity, coherenceL1,
+           lindbladStep, gateBloch, gateMatrix, rhoFromBloch, blochFromRho, Bell,
+           measure, timesFromRate, diagnose, selfTest };
+})();
+if (typeof window !== 'undefined') {
+  window.QPhysics = QPhysics;
+  window.runDecoherenceDiagnostic = o => QPhysics.diagnose(o);
+  try { QPhysics.selfTest(); } catch (e) { console.error('QPhysics self-test threw', e); }
+}
+
+// ═══════════════════════════════════════════════════════
+// PIXEL ART SPRITES  (7 cols × 9 rows bitmaps)
+// ═══════════════════════════════════════════════════════
+const SPRITES = {
+  // Qubit orb — a round node that reads as a glowing sphere once beveled/tinted.
+  qubit:[[0,0,1,1,1,0,0],[0,1,1,1,1,1,0],[1,1,1,1,1,1,1],[1,1,1,1,1,1,1],[1,1,1,1,1,1,1],[1,1,1,1,1,1,1],[1,1,1,1,1,1,1],[0,1,1,1,1,1,0],[0,0,1,1,1,0,0]],
+  // Qubit unit — a little pixel fighter (round head + body + legs).
+  unit:[[0,0,1,1,1,0,0],[0,1,1,1,1,1,0],[0,1,0,1,0,1,0],[0,1,1,1,1,1,0],[0,0,1,1,1,0,0],[1,1,1,1,1,1,1],[1,0,1,1,1,0,1],[0,0,1,0,1,0,0],[0,1,1,0,1,1,0]],
+  K:[[0,1,0,1,0,1,0],[0,1,1,1,1,1,0],[0,0,0,1,0,0,0],[0,1,1,1,1,1,0],[0,0,0,1,0,0,0],[1,1,1,1,1,1,1],[0,1,1,1,1,1,0],[0,0,1,1,1,0,0],[0,1,1,1,1,1,0]],
+  Q:[[1,0,1,0,1,0,1],[1,1,1,1,1,1,1],[0,1,1,1,1,1,0],[0,0,1,1,1,0,0],[0,1,1,1,1,1,0],[1,1,1,1,1,1,1],[0,1,1,1,1,1,0],[0,0,1,1,1,0,0],[1,1,1,1,1,1,1]],
+  R:[[1,0,1,0,1,0,1],[1,1,1,1,1,1,1],[0,1,0,0,0,1,0],[0,1,0,1,0,1,0],[0,1,1,1,1,1,0],[0,1,1,1,1,1,0],[1,1,1,1,1,1,1],[1,1,1,1,1,1,1],[0,1,1,1,1,1,0]],
+  B:[[0,0,0,1,0,0,0],[0,0,1,1,1,0,0],[0,1,1,0,1,1,0],[0,0,1,1,1,0,0],[0,0,0,1,0,0,0],[0,1,1,1,1,1,0],[1,1,1,1,1,1,1],[0,1,1,1,1,1,0],[0,1,1,1,1,1,0]],
+  N:[[0,0,1,1,1,0,0],[0,1,1,1,1,1,0],[1,1,0,1,1,1,0],[1,1,1,1,1,0,0],[0,1,1,1,1,0,0],[0,0,1,1,1,1,0],[0,0,0,1,1,1,1],[0,0,1,1,1,1,0],[0,1,0,0,1,0,0]],
+  P:[[0,0,0,1,0,0,0],[0,0,1,1,1,0,0],[0,0,1,1,1,0,0],[0,0,0,1,0,0,0],[0,0,1,1,1,0,0],[0,1,1,1,1,1,0],[0,0,1,1,1,0,0],[0,0,1,1,1,0,0],[0,1,1,1,1,1,0]],
+};
+
+// Tint helper: scale an "rgb(r,g,b)" string toward dark (<1) or light (>1)
+function shade(rgb, f) {
+  const m = (rgb.match(/\d+/g) || [200,200,200]).map(Number);
+  return `rgb(${m.map(v => Math.max(0, Math.min(255, Math.round(v*f)))).join(',')})`;
+}
+
+// Beveled, extruded faux-3D pixel sprite with a soft ground shadow.
+function drawSprite(cx2, cy2, sz, type, baseCol, hlCol, sdCol) {
+  const spr = SPRITES[type];
+  const rows = spr.length, cols = spr[0].length;
+  const sc = Math.max(3, Math.round(sz * 0.44 / cols)); // pixels per sprite-pixel
+  const depth = Math.max(2, Math.round(sc * 0.85));      // extrusion depth (down-right)
+  const w = cols*sc, h = rows*sc;
+  const ox = Math.round(cx2 - w/2);
+  const oy = Math.round(cy2 - h/2 - depth*0.6 - 2);
+  const bev = Math.max(1, Math.round(sc*0.34));          // bevel band thickness
+
+  const filled = (r,c) => r>=0 && r<rows && c>=0 && c<cols && spr[r][c];
+  const sideHi = shade(sdCol, 0.74);
+  const sideLo = shade(sdCol, 0.52);
+  const spec   = shade(hlCol, 1.18);
+
+  const prevShadow = ctx.shadowBlur, prevCol = ctx.shadowColor;
+  ctx.shadowBlur = 0;
+
+  // ── Ground contact shadow ──
+  ctx.save();
+  ctx.globalAlpha = 0.20;
+  ctx.fillStyle = '#1b2440';
+  ctx.beginPath();
+  ctx.ellipse(cx2, oy+h+depth*0.35, w*0.46, sc*1.05, 0, 0, 2*Math.PI);
+  ctx.fill();
+  ctx.restore();
+
+  // ── Extrusion sides (stack offset copies down-right) ──
+  for (let d=depth; d>=1; d--) {
+    ctx.fillStyle = d > depth*0.55 ? sideLo : sideHi;
+    for (let r=0; r<rows; r++)
+      for (let c=0; c<cols; c++)
+        if (spr[r][c]) ctx.fillRect(ox+c*sc+d, oy+r*sc+d, sc, sc);
+  }
+
+  // ── Top face with edge-aware bevel ──
+  for (let r=0; r<rows; r++) {
+    for (let c=0; c<cols; c++) {
+      if (!spr[r][c]) continue;
+      const px = ox+c*sc, py = oy+r*sc;
+      ctx.fillStyle = baseCol;
+      ctx.fillRect(px, py, sc, sc);
+      // light from top-left
+      if (!filled(r-1,c)) { ctx.fillStyle = hlCol; ctx.fillRect(px, py, sc, bev); }
+      if (!filled(r,c-1)) { ctx.fillStyle = hlCol; ctx.fillRect(px, py, bev, sc); }
+      // shade on bottom-right interior/exterior edges
+      if (!filled(r+1,c)) { ctx.fillStyle = sdCol; ctx.fillRect(px, py+sc-bev, sc, bev); }
+      if (!filled(r,c+1)) { ctx.fillStyle = sdCol; ctx.fillRect(px+sc-bev, py, bev, sc); }
+      // corner specular glint on the very top-left pixel of the silhouette
+      if (!filled(r-1,c) && !filled(r,c-1)) { ctx.fillStyle = spec; ctx.fillRect(px, py, bev, bev); }
+    }
+  }
+
+  ctx.shadowBlur = prevShadow; ctx.shadowColor = prevCol;
+}
+
+// ═══════════════════════════════════════════════════════
+// PIECE DEFINITIONS
+// ═══════════════════════════════════════════════════════
+// Charge / control pulses a unit can apply to its own qubit.
+const CELL_GATES = ['H','X','Y','Z','S','T','Rx','Ry'];
+
+// ═══════════════════════════════════════════════════════
+// UNIT FACTORY + ARMY SETUP
+// ═══════════════════════════════════════════════════════
+// Each unit is a qubit soldier: a board position, HP, and a quantum state whose
+// |1⟩ amplitude ("charge") powers its attacks. Units start in |0⟩ — ground
+// state: safe, but unable to strike until charged.
+let _uid = 0;
+function createUnit(owner, row, col, walkIn=false, role='warrior') {
+  const ctr = tileCenter(row, col);
+  // Spawn off-screen beyond the home row so the unit walks in on placement.
+  const spawnY = walkIn
+    ? (owner==='white' ? BOARD + CELL : -CELL)
+    : ctr.y;
+  return {
+    owner, row, col, role,
+    state:         blochToState(0, 0),   // |0⟩
+    bloch:         { x:0, y:0, z:1 },     // open-system Bloch vector (z=+1 ↔ |0⟩)
+    hp:            role==='guardian' ? MAX_HP+1 : MAX_HP,
+    maxHp:         role==='guardian' ? MAX_HP+1 : MAX_HP,
+    moveRange:     role==='guardian' ? Math.max(1,MOVE_RANGE-1) : MOVE_RANGE,
+    coherence:     100,
+    maxCoh:        100,
+    entangledWith: null,
+    bell:          null,   // shared 2-qubit Bell state ref when entangled (QB-6)
+    inSuperpos:    false,
+    guarding:      false,   // GUARD ability active this turn
+    id:            `u${_uid++}`,
+    // 2D-character animation state
+    px: ctr.x, py: spawnY,
+    facing: owner==='white' ? 1 : -1,
+    anim: 'idle', fi: 0, ft: 0, oneShot: false,
+  };
+}
+
+// Populate terrain from DECOR positions (trees block, quantum wells give bonus).
+function initTerrain() {
+  // Clear previous terrain.
+  for (const k in TERRAIN) delete TERRAIN[k];
+  DECOR.forEach(d => {
+    const row = Math.round(d.rf*(GRID-1));
+    const col = Math.round(d.cf*(GRID-1));
+    if (!inBounds(row,col)) return;
+    if (d.k==='tree') TERRAIN[row*GRID+col]='tree';
+    if (d.k==='flowers') TERRAIN[row*GRID+col]='well';
+  });
+}
+
+// Place each side's army on its back row, centered.
+function initBoard() {
+  _uid = 0;
+  const n = (GAME.unitCount|0) || 6;
+  const startCol = Math.max(0, Math.floor((GRID - n) / 2));
+  const out = [];
+  for (let i=0; i<n; i++) {
+    const c = startCol + i;
+    // Middle units become guardians (tankier, shorter range).
+    const role = (n > 2 && (i === Math.floor(n/2))) ? 'guardian' : 'warrior';
+    out.push(createUnit('black', 0,      c, true, role));
+    out.push(createUnit('white', GRID-1, c, true, role));
+  }
+  return out;
+}
+
+// ═══════════════════════════════════════════════════════
+// CHARACTER SPRITE SHEETS  (Elite Knight vs Elite Mage, animated)
+// White army = Knights · Black army = Mages. Both face right in-sheet.
+// ═══════════════════════════════════════════════════════
+const tileCenter = (r,c) => ({ x: c*CELL + CELL/2, y: r*CELL + CELL/2 });
+const ASSET_KNIGHT = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAACQAAAAKgCAYAAADORUJQAAAKKmlDQ1BzUkdCAABIiZ2Wd1RT2RaHz703vVCSEIqU0GtoUgJIDb1IkS4qMQkQSsCQACI2RFRwRFGRpggyKOCAo0ORsSKKhQFRsesEGUTUcXAUG5ZJZK0Z37x5782b3x/3fmufvc/dZ+991roAkPyDBcJMWAmADKFYFOHnxYiNi2dgBwEM8AADbADgcLOzQhb4RgKZAnzYjGyZE/gXvboOIPn7KtM/jMEA/5+UuVkiMQBQmIzn8vjZXBkXyTg9V5wlt0/JmLY0Tc4wSs4iWYIyVpNz8ixbfPaZZQ858zKEPBnLc87iZfDk3CfjjTkSvoyRYBkX5wj4uTK+JmODdEmGQMZv5LEZfE42ACiS3C7mc1NkbC1jkigygi3jeQDgSMlf8NIvWMzPE8sPxc7MWi4SJKeIGSZcU4aNkxOL4c/PTeeLxcwwDjeNI+Ix2JkZWRzhcgBmz/xZFHltGbIiO9g4OTgwbS1tvijUf138m5L3dpZehH/uGUQf+MP2V36ZDQCwpmW12fqHbWkVAF3rAVC7/YfNYC8AirK+dQ59cR66fF5SxOIsZyur3NxcSwGfaykv6O/6nw5/Q198z1K+3e/lYXjzkziSdDFDXjduZnqmRMTIzuJw+Qzmn4f4Hwf+dR4WEfwkvogvlEVEy6ZMIEyWtVvIE4gFmUKGQPifmvgPw/6k2bmWidr4EdCWWAKlIRpAfh4AKCoRIAl7ZCvQ730LxkcD+c2L0ZmYnfvPgv59V7hM/sgWJH+OY0dEMrgSUc7smvxaAjQgAEVAA+pAG+gDE8AEtsARuAAP4AMCQSiIBHFgMeCCFJABRCAXFIC1oBiUgq1gJ6gGdaARNIM2cBh0gWPgNDgHLoHLYATcAVIwDp6AKfAKzEAQhIXIEBVSh3QgQ8gcsoVYkBvkAwVDEVAclAglQ0JIAhVA66BSqByqhuqhZuhb6Ch0GroADUO3oFFoEvoVegcjMAmmwVqwEWwFs2BPOAiOhBfByfAyOB8ugrfAlXADfBDuhE/Dl+ARWAo/gacRgBAROqKLMBEWwkZCkXgkCREhq5ASpAJpQNqQHqQfuYpIkafIWxQGRUUxUEyUC8ofFYXiopahVqE2o6pRB1CdqD7UVdQoagr1EU1Ga6LN0c7oAHQsOhmdiy5GV6Cb0B3os+gR9Dj6FQaDoWOMMY4Yf0wcJhWzArMZsxvTjjmFGcaMYaaxWKw61hzrig3FcrBibDG2CnsQexJ7BTuOfYMj4nRwtjhfXDxOiCvEVeBacCdwV3ATuBm8Et4Q74wPxfPwy/Fl+EZ8D34IP46fISgTjAmuhEhCKmEtoZLQRjhLuEt4QSQS9YhOxHCigLiGWEk8RDxPHCW+JVFIZiQ2KYEkIW0h7SedIt0ivSCTyUZkD3I8WUzeQm4mnyHfJ79RoCpYKgQo8BRWK9QodCpcUXimiFc0VPRUXKyYr1iheERxSPGpEl7JSImtxFFapVSjdFTphtK0MlXZRjlUOUN5s3KL8gXlRxQsxYjiQ+FRiij7KGcoY1SEqk9lU7nUddRG6lnqOA1DM6YF0FJppbRvaIO0KRWKip1KtEqeSo3KcRUpHaEb0QPo6fQy+mH6dfo7VS1VT1W+6ibVNtUrqq/V5qh5qPHVStTa1UbU3qkz1H3U09S3qXep39NAaZhphGvkauzROKvxdA5tjssc7pySOYfn3NaENc00IzRXaO7THNCc1tLW8tPK0qrSOqP1VJuu7aGdqr1D+4T2pA5Vx01HoLND56TOY4YKw5ORzqhk9DGmdDV1/XUluvW6g7ozesZ6UXqFeu169/QJ+iz9JP0d+r36UwY6BiEGBQatBrcN8YYswxTDXYb9hq+NjI1ijDYYdRk9MlYzDjDON241vmtCNnE3WWbSYHLNFGPKMk0z3W162Qw2szdLMasxGzKHzR3MBea7zYct0BZOFkKLBosbTBLTk5nDbGWOWtItgy0LLbssn1kZWMVbbbPqt/pobW+dbt1ofceGYhNoU2jTY/OrrZkt17bG9tpc8lzfuavnds99bmdux7fbY3fTnmofYr/Bvtf+g4Ojg8ihzWHS0cAx0bHW8QaLxgpjbWadd0I7eTmtdjrm9NbZwVnsfNj5FxemS5pLi8ujecbz+PMa54256rlyXOtdpW4Mt0S3vW5Sd113jnuD+wMPfQ+eR5PHhKepZ6rnQc9nXtZeIq8Or9dsZ/ZK9ilvxNvPu8R70IfiE+VT7XPfV8832bfVd8rP3m+F3yl/tH+Q/zb/GwFaAdyA5oCpQMfAlYF9QaSgBUHVQQ+CzYJFwT0hcEhgyPaQu/MN5wvnd4WC0IDQ7aH3wozDloV9H44JDwuvCX8YYRNRENG/gLpgyYKWBa8ivSLLIu9EmURJonqjFaMTopujX8d4x5THSGOtYlfGXorTiBPEdcdj46Pjm+KnF/os3LlwPME+oTjh+iLjRXmLLizWWJy++PgSxSWcJUcS0YkxiS2J7zmhnAbO9NKApbVLp7hs7i7uE54Hbwdvku/KL+dPJLkmlSc9SnZN3p48meKeUpHyVMAWVAuep/qn1qW+TgtN25/2KT0mvT0Dl5GYcVRIEaYJ+zK1M/Myh7PMs4qzpMucl+1cNiUKEjVlQ9mLsrvFNNnP1IDERLJeMprjllOT8yY3OvdInnKeMG9gudnyTcsn8n3zv16BWsFd0VugW7C2YHSl58r6VdCqpat6V+uvLlo9vsZvzYG1hLVpa38otC4sL3y5LmZdT5FW0ZqisfV+61uLFYpFxTc2uGyo24jaKNg4uGnupqpNH0t4JRdLrUsrSt9v5m6++JXNV5VffdqStGWwzKFsz1bMVuHW69vctx0oVy7PLx/bHrK9cwdjR8mOlzuX7LxQYVdRt4uwS7JLWhlc2V1lULW16n11SvVIjVdNe61m7aba17t5u6/s8djTVqdVV1r3bq9g7816v/rOBqOGin2YfTn7HjZGN/Z/zfq6uUmjqbTpw37hfumBiAN9zY7NzS2aLWWtcKukdfJgwsHL33h/093GbKtvp7eXHgKHJIcef5v47fXDQYd7j7COtH1n+F1tB7WjpBPqXN451ZXSJe2O6x4+Gni0t8elp+N7y+/3H9M9VnNc5XjZCcKJohOfTuafnD6Vderp6eTTY71Leu+ciT1zrS+8b/Bs0Nnz53zPnen37D953vX8sQvOF45eZF3suuRwqXPAfqDjB/sfOgYdBjuHHIe6Lztd7hmeN3ziivuV01e9r567FnDt0sj8keHrUddv3ki4Ib3Ju/noVvqt57dzbs/cWXMXfbfkntK9ivua9xt+NP2xXeogPT7qPTrwYMGDO2PcsSc/Zf/0frzoIflhxYTORPMj20fHJn0nLz9e+Hj8SdaTmafFPyv/XPvM5Nl3v3j8MjAVOzX+XPT806+bX6i/2P/S7mXvdNj0/VcZr2Zel7xRf3PgLett/7uYdxMzue+x7ys/mH7o+Rj08e6njE+ffgP3hPP7l7FYAQAAIABJREFUeJzs3U+MlPed5/EPOHNwYltIE+0obJAF2o1ywF0Ecxj+WI198DI+DN7WEDEWSg4xSSyYAUc9MLKUWIm0kUFo3UxAkRLPxULYCqMO5OBxWMmmZYf4QICGPljOCAuhMIq0o7EcW9oL9B6Kp6hu+k9VdXX/qtuvl2SFrq5uVd6/qudp6furehIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAJMtKPwCWrlqtb7yV+42OXvE8nAf6l6V/WfoDAAAAAAAAnyWfK/0A5pMBcBlV9/79R7LrybUz3nf3U9sW5DF9luhflv5l6d8bnH/L0r8s/QEAAAAAgBKW5AYgA+Ay2ul+4uzYgjymzxL9y9K/LP17g/NvWfqXpT8AAAAAAFDSktoAZABcRqfdR4YGvfu9C/QvS/+y9O8Nzr9l6V+W/gAAAAAAQC9YEhuADIDLqdX6xg28ytG/LP3L0r8859+y9C9LfwAAAAAAoJcs+uHDXAbABjBzU6v1jf/8jTdnvM90g3ftW1MNF5tbVbdNp3lN9J8b/cvSv6y59q84/84Pf/+UpT8AAAAAANBren74YABcVqf9Z/rEDe1bU6v1jY+MvJUk6e9/onF7//4jSTJh6Hji7FhGhgZz/Njh7Nl7oHGfqejfGv3L0r+sufSvzsHOv3Pj75+y9AcAAAAAABabnh5AGACXNR/9tW9NrdY3fvzY4STJ2kc2JEnGrl7IS6+8lyRZs3VTkolr8KMXfpYbl4eTRP850r8s/cuar/6JNWiVv3/K0h8AAAAAAFiMenYIYQBc1nz01751kz9loBpEJskPfnkx186dv2cNTpwdy7Vz53Pj8rD+c6R/WfqXNR/9E2vQKn//lKU/AAAAAACwWPXsIMIAuKxu9h8ZGkwS7dtUrUH//iONhsePHc7GVefzwfuX8pWvfi1J8qcVf58kefCjf8oH719Kkuw8eL2xBvp3Rv+y9O8d1Vp00r/i/Ns6f/+UpT8AAAAAALBY9fQwwgC4jObu1XBr91PbkrTXv6J7e6brv2rdQJLkzA9vZ/3209P+/L4dt3P01PLG1/q3R/+y9O8Nk8+/7fZ3/p0bf/+UpT8AAAAAALAY9eRAwgB44VStR0evLJuqe6WT/rrPrpP+a7ZuynNf+smETVaV5ue+/rPTvyz9e89s599W+1esQ3v8/VOW/gAAAAAAwGL2udIPoNUBcLPn396S1w9dMgDukn07budo+sard6zP1D5pvT+tabd/kvzDa4/m4pn6JxBUw8iLZ57OB+9fytFT1z3326B/WfqX08n5N9G/W/z9U5b+AAAAAADAUtMTOzX27bidWq0+AG5l+JhUA8inc/HM043bLp55Ohs3rE5i+NKpye1PnB3LibNj99xP//nRav+kPoic7Kf//nfz8rg+K/QvS/+F18n5N9G/W/z9U5b+AAAAAADAUlL8E4Amm2oAPJ3n396Slx9/d8Jt9QHk4Hw8tCXrm7sGsnHDpfz2wvfy4NX6AKuVQe5M/Wu1vnFDsNZ02n8m+rdO/7L07x3tnH/pPn//lKU/AAAAAACw2PXEJwB9c9dAXj/0cNb94Xt58Op38uDV78z4yQ+tqC7nwMxGR68sW7/9dL7y1a9l44bV+fqv/jEr//J0nvvST+b0e18/9LA1aIH+Zelflv7lOf+WpX9Z+gMAAAAAAEtJ8Q1ABsC9oVqDJNnywnsTvjcyVH9H+43Lw7P+npGhwQmXxaA1+pelf1n6l+H8W5b+ZekPAAAAAAAsNT1zCbD120/XB7e/qg+Af/HXd7/XPABetW5gxt9TDYA/eP/SfD7cJaNW6xvv338kSbJ++2Aun0k+eP9Sfnvhw4ycqnfv33+kcamL9duHs2brphl/5/Nvb8m1c8uTXJ/Xx74UzLV/8/O8+rf+rdO/LP17Q6fn38n9R4ZOO/92wN8/ZekPAAAAAAAsFcU3ABkA945V6wayfvtw4xM0jp663hh4Pf/2ljv3Oj3hZ6bqT2da7d88kBxp+vmdBz3f50L/svRfeJ2cf6tPYpquv/Nv6/z9U5b+AAAAAADAUlN8A1AzA+Byrp07nyQ5fuxw1m8/kCTZt+N2jp6qD3ubh176d187/W9v/mnj3x9/+E6SZMXNk3n90MPWoEP6l6V/ea2ef5v7V5b/5jn958jfP2XpDwAAAAAALAU9swHIALiM0dEryzI0OF59vfaRvRkZeStJ0t//RJK77UeGBhvtq+7bv76+8buqwVj1M2u2bkqGBsdHR68sm+f/G4tW9/qvz86D+rdL/7L07w3tnH+bNc6/C/AYlzJ//5SlPwAAAAAAsFT0xGC0VutrDICr4W9ydwBcXaKh1Q0o1f2r2wyAW1Or9Y0fP3Y4ax/ZkCQZu3ohe/YeaHz/o5XPJLnbfNeTa+/5HSfOjk3YCJRE/xbpX5b+ZelfhvNvWfqXpT8AAAAAALCU9NRgwgC4vGoNmlVrsGrdQM788HbT5TAmrsGJs2NJ6kOvah37+5/Qvw36l6V/WfqX4/xblv5l6Q8AAAAAACwFPTeYMAAur/kd8Ul98LXi5smsWjeQNVs35eXH3218r3ktqtvXbz/d6F8N0axB6/QvS/+y9C/H+bcs/cvSHwAAAAAAWOw+V/oBTDY6emXZnr0HphwAJ/WB74QB8Nm792sMgIfu3nb82OHs2Xtg3BCmdVWrWq1v/PVDD2fb0Tvvfr98Zw1y79A9qa/NtXPnJ/yu6t30tE7/svQvS/9ynH/L0r8s/QEAAAAAgMWu5zYAJQbAva5qvGbrpvzuz77b9J2xxr9eeuW9JO9lzdZNC/vgPgP0L0v/svSfX86/Zelflv4AAAAAAMBi1pMbgGZjALzwqkvwVH7w429nx7Ov5swvLjZuO/XKN7J7aDBJcuPy8II/xqVM/7L0L0v/3uH8W5b+ZekPAAAAAAD0skWzAcgAuLw1Wzdl15NrkyQ7nn01D61+bML3dzz7ak698WZ2P7WtsVY3Lg/H5S+6Q/+y9C9L/3Kcf8vSvyz9AQAAAACAxWLRbABKDIBLGxkazMjQnS9WPpOPP3wnD61+rPG/SbL7qW1J7g7AtO8e/cvSvyz9y3L+LUv/svQHAAAAAAAWg54eTNRqfeOvH3o4245uzoqbJyd876OVzyTJhAHwxx++c8/9DF8609w+qb8D/r77luX++z+fJPnkk0/v+ZkHHvhC43u6z43+Zelflv7lOf+WpX9Z+gMAAAAAAItRz34C0OQBcJIJA+D7/vhabt0aT26ezIo7X3/5/s8nD3zBAHgB3HffsvzHX/xt4+s//+NrBR/NZ4/+Zelflv7zy/m3LP3L0h8AAAAAAFislpd+AO3YO3Arr3z/i/nkk0/zH3/xt/lo5TON/27dGs+3/upPeeX7Xyz9MJesyf2b6T//9C9L/7L0L8v5tyz9y9IfAAAAAABYDHryXcpTXf5l1bqB/Oe//TqffPJp4/ILk02+n3dhd27y5S/0X1j6l6V/WfqX4/xblv5l6Q8AAAAAACxmPXsJsCR5cfOJJMnRU/UPKnr02R9mZGiwcftkk+/H3L24+YT+Belflv5l6V+O829Z+pelPwAAAAAAsBj15DuUa7W+8W78Hu/A7lw31kD/zulflv5l6V+O829Z+pelPwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsJstKPwBgftRqfeOt3G909IrjwDzQHyjF8acs/QEAAAAAgBI+V/oBzCcDmLL0L6Pq3r//SHY9uXbG++5+atuCPKbPEv17g+NPWfqX4fhTlv4AAAAAAEBJS3IDkAFMWfqX0U73E2fHFuQxfZbo3xscf8rSvwzHn7L0BwAAAAAAesGS2gBkAFOW/mV02n1kaNCnb3SB/r3B8acs/ctw/ClLfwAAAAAAoJcsiQ1ABjDlNF/mRf+FV6v1jRu4l6N/eY7/ZelfjuNPWfoDAAAAAAC9ZtEP3+YygDGAnF3zBp+qVfNtU/n5G2/ec5v+nZlr/+kGj9q3Rv/e5vg//6rn+2zP/6mO+xX9OzeX/o4/c6c/AAAAAACwmPT8AGLy8KX5tukYwHdPrdY3PjLyVsauXsievQeSJKvWDWTN1k0Thu4nzo5lZGgwx48dzp69BxproP/cdNq/f/+RaX+n9q3TvyzH/7Kq53+S9Pc/kaT+/E9yz2tg91Pb7tkEof/cdNp/pk+c0b51+gMAAAAAAItNTw8hphq+JGkM1w3g51/zGoxdvZCXXnkvyb3DrxNnx3Lt3PncuDyckZG30t//xLRroH/rut1f+/boX47jf1m1Wt/48WOHkyRrH9mQ5N7XQJIpN0HYADF3nfb33O8O/QEAAAAAgMVoeekHMJ1q+DJ29UKSZGTkrRw/djir1g3k2rnzSSa+y3rXk2uzat1A41M6pmMA057R0SvLquH72kc25MTRvY3vTR7yrtm6qfHu+Ono355u9te+ffqX4fjfG/bsPVDfUDXFa2CqdejffyS7n9o27e/Tvz2d9B8ZGpzyd2nfPv0BAAAAAIDFpmeHEZMv81J9EkSS/OCXF3Pt3Pl73oHd/CkcPn2je5rX4uKZp/PB+5fyla9+LUnypxV/nyR58KN/ygfvX0qS7Dx4Xf8uqLo3DxU76V/9rPbt0b8cx//eMXktjh87nI2rzs/4OpjqHKB/e6Y6/iTt93f86Yz+AAAAAADAYvS50g9gOqOjV5Y1D2Cqd2AfP3Y4Lz9+Ph986VK+8tXbSZI/fWF9kuTlx9/NB1+6lPztw9l5cNAAZo4mD8Dqn25yOzsPXk9y/c69Tk/4mX07bmfyB0vp357m7tXmhpGhtN1f987oX57jf3lTH/+Tl155L2d+mGlfB5PPAfq3Z+bjT+v9de+M/gAAAAAAwGLWkxuAZhrAzDZ8SQxg5mq6/kny/Ntb8vqhS3f6T7Rvx+0M//5vkgzf+Rn9Z1O1nrzhoeo+Wav9fdpGa/TvPY7/Zc10/K9M9zrYt+N2jp5aPuFTU/SfXrvHn8ps/avfOS8PegnRHwAAAAAAWGqKbwDqZAAz2xDeAKZ1nfT/h9cezcUz9UtfrN9eH75Xl0Ya/n39PjZAtG7fjts5mr7x6hNLZhs+ttJf+9bpX47jf1mdboBIpn4dfHPXQI6eOu3434Z2jz+Vmfpr3zr9AQAAAACApWT57HeZf/t23E6tVh/AtDd8fDoXzzzduO3imaezccPqJIa/7eik//Nvb7nntp/++981/q1/Zya3P3F2LCfOjt1zv9n60xn9F57jf1md9K9M9TpI9O9Uq8efynT96Yz+AAAAAADAYlf8E4Amm2oAM53n396Slx9/d8Jt9SH84Hw8tM+EdvrTHd/cNZCNGy7ltxe+lwev1jcwzHUzSa3WN24I3xr9e4fjf1mO/wtvPo4/tE5/AAAAAABgKemJTwD65q6BvH7o4az7w/fy4NXv5MGr35n1ndezqS5nwuz0L2d09Mqy9dtP5ytf/Vo2blidr//qH7PyL0/nuS/9ZE6/9/VDD1uDFuhfnuNPWfPRn9bM1/HH8781+gMAAAAAAEtN8Q1ABvBl6d8bqjVIki0vvDfheyNDrX+iyY3LwxMui0Rr9C/D8acsGyB6QyvHnxuXhxv/zcbzvz36AwAAAAAAS0XPXAJs/fbT9cH5r+oDmF/89d3vNQ9gVq0bmPH3jAwN5uKZp/PB+5fm8+EuOa30n6y5cf3fWxobIPRvTa3WN96//0iSZP32wVw+U2/52wsfZuRUvXu1oWT99uGs2bqp8bOT+48M1dfw+be35Nq55UmuL9z/kUVK/97g+F9Wq/0rM70OkvoGiJ0H4zJ4s2jl+NO//8iES92t3356wu+Yqv8/vPZoHH9mpz8AAAAAALDUFN8A1O4AZrYhfBID+Da0uwGiGgLfuDyckabfs/Pg9SSDNkDMwap1A1m//e4nyBw9dT2r1g3k+ber5/vpCcP4e/vXn/t0Rv+F5/hfViv9k0z4VKv122d/HdgA0b7pjj/J5OPK7P1pn/4AAAAAAMBSUHwDULPWBjCGL/Nlqv79+4/k+bere5zO7c0/bdz/4w/fafx7xc2TSWyA6NS1c+eTJMePHc767QeSJPt23M7RU/UNV9Wmh9n6N/8uWqd/eY7/ZU3VP8mkc0Ay1Xlgxc2Tef3Qw0msQydmO/4kEz91Sf/u0h8AAAAAAFgqemYDUKsD+GTqIXw1gDF86cy0/YcGs2rdwIT+VfPtX1/f9BvWNwbzNkC0bnT0yrIMDY4n9fZrH9mQkZG3kiT9/U8kqT/3R4YGG8/72fpXa9V8yR6mpn9vcPwvq+o/MvJW1t953tf7L298b6pzQFK9DtZn58GpLxXJ9JqPP0my9pG9Ux5/KtUxZrb+a7Zuqv/c0KDLsM1AfwAAAAAAYKnpicFErdbXGMBUw5fk7gCmukTJbEP4ajhT3b+6zQBmZlX/agNEpepf+WjlM0nqzXc9ufae37P7qW33tE+if4tqtb7x5jUYu3ohSbJnb31DxGz9T5wdazRP6q+l/v4n9G/RfPVPvAZm4vhfVnP/5O55YHL/JDnzi4tJ7naf7Tygf3uaj0GTjz/JxGNQMn3/Zvq3Tn8AAAAAAGCx66nBxFQD+HaHL5OH8IkBTKtm2wCxat1AzvzwduNyPM39T5wdS5J7NkBUa2gNWlOtQaX5+d9K/5cffzfrt59O8xBT/9Z1u38Sa9CidjZgJa0d/22Ca1/zhtDm53+SxuXBmi/1OPl1MPn8mzgHt6O5f2XP3gON408ye//mTVzat6cb/R13AAAAAACAUnpuODF5AJ9MvwElmX4TigFYZ6baAPHRymey4ubJxqXAXn783SQTh2DNtzX3T2IN2tT8iRzVpoe59LcBpT3d7p9Yg1Z1+/ifaN+pyZ8M1HwpyOr5ntz7OrABrju60V/7zs2lv83PAAAAAABAKZ8r/QAmGx29smzP3gMTBi/VBpSkPmyZMHw5e/d+1e3rh+7edudTDMYNYVozuf/rhx7OtqN3NkJcvrMGqQ+8phqCXTt3fiEf7pI0OnplWa3WN161T9rvv2fvgRw/djgvvfJekjuX8Rka9DpoUb395sbXnfRPYg3a1K3j/569BxqXE1v7yAbngQ5NeB3cef6v2bppys1vSfU6ON04/qx9ZMOEjXC0p9P+Fe3nZi79tQcAAAAAAErouQ1Ayd3LhTRvgphqAJ/cO3yZvAHFEKZ9zf2n+n7V+HdPfrfptp8lSW5cHm4M8VetG0hi40O3tdI/SSZvpGB2d485m6e9T6v9E2vQqVY2YCXTH/9HR68s6+9/YtwGrO5rPsf+4Mffzu+ytul79deBc8D8aaV//Tn/XuMTa+ieVvrv2ndMewAAAAAAoIie3AA0m2oAs2brpvzuz77b9J2xxr8MwLqrugRSUh96JcmOZ19tfP/UK9/Oj1742YSfuXF5eOEe4BLXSf8kjZ+ZvDGF9nTaP7EG3dbK8T+Z+tOEaM3kjXDNz/9k6tdAUn8d7H7q7nHfOaAzc+2ve3fpDwAAAAAALBaLZgPQVAOYHc++mjO/uNi47dQr38juocEkBo/zYc3WTdn15NrG0Ouh1Y81vvet//Vh/vnH386Js5uSocHxxMaHbmun/+jolWV3mo8n0b8L2u2fNLpbgxZN9wlM7R7/mzkOdUf1/E/qGx8eWv3YhNfAxx++k91PbZvQWPvuabV/ovt8aLe/9gAAAAAAQAmLZgNQMvUAptmOZ1/NqTfezO6nthmAddGKm/VL74wMDebdnyzLl+//fJLk4zyWjz98Jw+trv/vjmffadzXxofua6d/Rfvu6aR/Yg26pZ3jf7NqM6h1aM10m7BGhgYzMnTni5XPJMmE5/9Dqx9LJj3/te+edvrrPjdTvQba7a89AAAAAABQQs9uAGplAHPP8CVpDH8NwLpr1bqBrNm6Kev+8L1s3PDF7Dx4Pct/81xWJMnNk/nz+5bl/vs/nzzwhXzyyadJtO+mj1Y+kxU3T2blI/8zA//9X7Jxw+rsPDhzf7rnozsD36S+IW7fjtvZuOGl7Dx4Xf8F0s7xv+IY1B3V83/FzZO5775l+fLHZ5LRM3n4v/2P5NP/k4HN/5KNG36Tnb+5+zPad2aqv32q4/99d44zD3x8Jp/85mRWJFn1X/7fhP66z4+qfZLc98fXcuvmycb5d0WSfZtPZOOh1dl58Lo1AAAAAAAAiunZDUBTqQ/d6wOWP//ja7l1a7wxfLnvj6/lxYFbje8bwHTXjcvDuXF5OCNZnqOnrk/YEJHUB8Pf+qs/3elvA8R8uvxf/3eOHhycMJTfO3CrsTHLc79zo6NXlu08mPE3D+WeT0BpNvz7v8nRU8ONwbz+82vyBqwXN5+4c6yZOIRPbICYi+k+/adZ83P90a2bMjI0mKOX6+cF7edXc/vq2JPcPSfoP3fTvQYmt5/s6KmTGf79o3nggf+bWq1v3FoAAAAAAAAl9OQGoMkDmBU3T2bVuoH887/+esrNJxUDmO6ZsAYrpx8GNxv+/d/kn//11/P8yD7bqo1Yk18D2ndPq5uA+vcfycjQ4IRjk2PO/Pto5TMTjvWffPKp7guo+VgzMjSYxKarbpltA9bk4/xHK59JLp9sfOIh86fVc+yjz/6w8boAAAAAAABYaD25Aajy4uYTSZKjp5YnuTtYqW6fbPL96Ew1hPzthQ/z4uYPW/oZ7bur2oTy4o7p+t99DWjffc2bgH574d41OHpqeMLQXfvumK17xXN+/sx03J/cfd+O243b6I7p+s/0d9DRU8ttwuqyyX2TVv4GHbYZCwAAAAAAKKonB0a1Wt94N36PgVhnutFf+7nrdB20755210D7uevkea97d2hflmN+eXP9+8daAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANB9y0o/AGB6tVrfeJKMjl5ZNvm26TTfl7nRvyz9y9IfAAAAAAAAFo+eH9QZQJalfzm1Wt/4yMhbSZL+/icat/fvP5Ik2fXk2sZtJ86OZWRoMMePHc6evQesQRfoX5b+ZelfnvNvWfoDAAAAAACLTU8PKgwg59dsg6zKyMhb+s+DdvonydjVC3nplfeSJGu2bkoycQ1+9MLPcuPycBJDyFboX5b+vatW6xs/fuxwkmTtIxuS6L/Q/P1Tlv4AAAAAAMBiVHRIYQBcVq3WN/7zN96c8T7VYCtJjh87rH+J+vH9AAAgAElEQVQXtdu/eh384JcXc+3c+XvW4MTZsVw7dz43Lg/r3wL9y9K/rFbPv8nd9on+3eLvn7L0BwAAAAAAlqLiG4AMgMup1frGp3o3+1Sa16F//xH9u6DT/hfPPJ0P3r+Ur3z1a0mSP634+yTJgx/9Uz54/1KSZOfB69ZgFvqXpX9Z7Z5/k/om0I2rzuvfBf7+KUt/AAAAAABgKSq+AcgAuKzmNUjaX4dE/7mYS//p7NtxO0dPLde/BfqXpX85czn/rt9+etr76t8af/+UpT8AAAAAALAUFR9QGACXNbl/ZS7roH/rut1f+/boX5b+ZXX7/Kt/e/z9U5b+AAAAAADAUlN8QGEAXN50a5DMvg67n9o24Wv929et/tUnE/j0gfboX5b+5cz1/Nv8aUD6t8/fP2XpDwAAAAAALDXLSz+A0dEry6YapJw4O5YTZ8em/bldT67Nz994c8JtF888nY0bVnf9MS51061BMvs6NK+B/p3pVv8k+em//11XH9tngf5l6V/OXM+/ky8Fpn97/P1Tlv4AAAAAAMBS0zPvUp7pUyCSmd+RXX0KxMUzT+f5t7dkZGjQO7A7MNsaJNOvw1TviLcG7dG/LP3L0r8c59+y9C9LfwAAAAAAYKnoqSGFAXB5raxB0vo6WIP26F+W/mXpX47zb1n6l6U/AAAAAACwFPTcgMIAuLxarW88Sbq1DtagPfqXpX9Z+pfj/FuW/mXpDwAAAAAALHY9OZwwAC6vWoPEOpSgf1n6l6V/Oc6/Zelflv4AAAAAAMBi1rODCQPgsmq1vvFV6waSJDcuDzdu78YlMkZHryyr1teaTE3/svQvS/+ynH/L0r8s/QEAAAAAgMWqZwcSBsDlNF8G49q587lxeTjHjx3O2kc2pL//icb9ZlqLqdbhxNmxJMnI0GD27bido6eW6z8F/cvSvyz9y3P+LUv/svQHAAAAAAAWq8+VfgBTmTwATtLyALga8k4exNS/vnP/ocHxagDM1K6dO581WzflxuXhjIy81bh9ZOSt9Pc/kY9WPtMYaLW6DrueXNu4nZnpX5b+ZelfjvNvWfqXpT8AAAAAALCY9eQGoMQAuLQbl4cbn7zRrL//iUbvXU9+I0my+6lt9e/NsA7PfeknSZJ1f/gwzx1ana989Ws5eur0vD3+xU7/svQvS/+ynH/L0r8s/QEAAAAAgMWqJy8/UF0eIbn7zuvKxAFwfbgy0wC4Ug2Af3vhw2zcUB8Ar99+2iUYZlCr9Y03D+D37D2Qi2eezvNvb2nc1jzgmm4dnvvST7LyL09nywvv5Rd//ZL2LdK/LP3L0r8M59+y9C9LfwAAAAAAYDHryU8AqoYi1SBm7OqFJM0D4Pr9Tpwdy64n1+bnb7yZpP0BMLPbs/dA49+r1g3k+bc35eXH323c9vzZu/e9eObpJMn67fe+M37LC+8lSaP9qnUDSTJuADYz/cvSvyz9F95CnX+1n5r+ZekPAAAAAAAsZj25AagyOnpl2Z69Bxrvxu72APjG5eF5ffxLweuHHs62o5vrX1w+mSR5Pnc/gWPCWry9JdfOnU9y91IZSbJux+0Jg6/+/Uca92Nm+pelf1n6lzPf59/YgDUj/cvSHwAAAAAAWIx6egNQrdY3bgDce6p2a7Zuyu/+7LtN3xlr/Ktqn2TCJS+qodiarZtswOqQ/mXpX5b+C8P5tyz9y9IfAAAAAABYjHp6A9B0DIAX3oqbJ6t3rSdJfvDjb2fHs6/mzC8uNm479co3sntocMIlNPbtuJ0kdy95MTTYeEe9d7+3Tv+y9C9L/97h/FuW/mXpDwAAAAAA9LJFswHIALi8NVs3ZdeTa5MkO559NQ+tfmzC93c8+2pOvfFmdj+1rXFpi6OnlufoqeuN1pp3Tv+y9C9L/3Kcf8vSvyz9AQAAAACAxWLRbABKDIBLGxkazMjQnS9WPpOPP3wnD61+rPG/SbL7qW2N+2vdXfqXpX9Z+pfl/FuW/mXpDwAAAAAALAaLagOQAXBZ9923LPff//n6v//4Wm7dGk9unsyKO19/+f7PJw98IZ988mnZB7pE6V+W/mXpX5bzb1n6l6U/AAAAAACwGPTsBqBarW/89UMPZ9vRzY3bDIAXzlT9m926NZ6PVj7T+HrFzZML9dA+E/QvS/+y9C/L+bcs/cvSHwAAAAAAWKyWl34A7dg7cCuvfP+L+eSTT/Mff/G3+WjlM43/bt0az7f+6k955ftfLP0wl6zm/s3D94r+80v/svQvS/+ynH/L0r8s/QEAAAAAgMWgJy9RMPnd1ytunsyqdQP5z3/79bTD36nu5xIMnavV+sarzvovvObXgP4LT/+y9C/H+bcs/cvSHwAAAAAAWMx69hJgSfLi5hNJkqOn6h9U9OizP8zI0GDj9skm34+50b+8Fzef0L8g/cvSvxzH/7L0L0t/AAAAAABgMerJdyjXan3j3fg93oHduW6sgf6d078s/cvSvxzn37L0L0t/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHrPstIPAJhardY3niSjo1eWTb5tOs33Ze6sQVn6l6U/AAAAAAAALB49P6gzgCxH+3Jqtb7xkZG3kiT9/U80bu/ffyRJsuvJtY3bTpwdy8jQYI4fO5w9ew9Ygy6xBmXpX5b+5TkHl6U/AAAAAACw2PT0oMIAsvtmG141035+tLoGx48dztpHNiRJxq5eyEuvvJckWbN1U5KJa/CjF36WG5eHkxhAtqrVdaheB9agu/TvXbVa3/jxY4eTxDGoEH//lKU/AAAAAACwGBUdUhgAL7xarW/852+8OeN9qmFWov186HQNkuQHv7yYa+fO37MG/5+9+wuR87rzBv+TnLlIYhvBDO9g8QojsxhfyN1yWwuRrUzbvvBodGFpxcgoWjHDMlYywspIHjpSMExCBjZYXvG6e2JjZuyXZYOQjRs0ki+8jhZiN3FksSiSWtKF0bxICDEygR1eETsz743Ve1F9qp+qrqqu6vpzqqs+HzBWV1W3St/z9HmeOuf3nHP8zNW4/vHZuHXppPybtNx20AadIf+8llMMGiH/TnH9k5f8AQAAAACAQZS9AMgEcG+Njo7M1bqDvRbZd8dy2+CN11+NzevOxrXPLsbDjzwWERFfrPmbiIi4784/xLXPLkZExO4jN7VBE5bbDhdO79AGHSD/vFo9/0bogzrJ9U9e8gcAAAAAAAZR9gIgE8C9V8w9QvY5tNMGjRzcdTemplfLv0ndaAdt0Dz559PO+Xds+6m6r5V/c1z/5CV/AAAAAABgEGWfoDAB3HvVmSey751utIHsW9fpdtAGrZF/Xp0+/8q/Na5/8pI/AAAAAAAwaLJPUJgAzqNe7hFLZ79v29aaj8u+NZ1sg7QqgZUHWtepdtAGyyP/fNo9/xZXA5J/61z/5CV/AAAAAABg0KzO/QZmZy+vqjWRcvzM1Th+5mrd79v77IZ464MPKx67cHpHbN60vuPvcRDVyz1i6eyrc4+Q/XJ0ug3e/Pz7HXtvw6ST7aANWif/fNo9/1ZvBSb/1rj+yUv+AAAAAADAoMleABRhAjiXRrlHNM7+rQ8+jOo751P2o6Mjc517l4OtU21QnIiXf+s60Q5j20+VV4XQBq2Rfz6dLkSkNa5/8pI/AAAAAAAwSPpqm4JGW8Ek9bZmqLUlg20YmtNM7hHNZ//u0QdtA9OiTraB/Jev078L2qA18s/H+Tcv+eclfwAAAAAAYBD03QSFCeA80ooZss+n020g/+XRDnnJPx/n37zkn5f8AQAAAACAla4vJydMAOcj+/y0QX7FLaS0Q+/JPx/9T17yz0v+AAAAAADASta3ExMmgPMpZh+xdP7NZp9+rnZobHR0ZG7dxp1x69LJ8mPaoLdSG0SEdshA/nk5/+Yl/7zkDwAAAAAArFR9OyFhAjiP4hYY1z8+W5F9ROP8a2V//MzViIiYmZyIg7vuxtT0apk3UCv/N15/NV48cLj8Gm3QXfXaYMOjm2J8/Jny67RDd8g/P+ffvOSfl/wBAAAAAICV6mu530At1RPAEdH0BHCa5K2eiCl9Pf/6yYm5NAHMYtc/PhsPPfVE3Lp0MmZmflnxXMq/2ez3Pruh/DjNqZV/+v/4+DPliURt0D31fgdmZn4Z4+PPxJ21e7RDF8k/H+ffvOSfl/wBAAAAAICVrC8LgCJMAOd069LJ8qobRePjz5Szbib7/Q/8LCIiNv7rjdh/dH08/MhjMTV9qptvfSA0k//eZzfEvm1bS49rg45rrg3+IiJCO3SB/PNy/s1L/nnJHwAAAAAAWKn6cvuBtD1CxMKd10l1EURE4wngJE0Af3r+RmzeVJoAHtt+yhYMdYyOjswVJ99fPHA4LpzeES99tKX8WKMilP0P/CzWfutUbHn5XLz33CvyblGz+UfUP/61QXtaaYMI7dBp8s/D+Tcv+eclfwAAAAAAYCXr68mHbk8AR4QJmAaKE2HrNu6Mh556Il57+pPy88V2qL4bfv8DP4vn3/9hRERcOvyLGNt+KtZt3Bm3Lp2UeZNayf+1pz8pH9PaoDOK+Uc01wYRoR06RP55KcDKS/55yR8AAAAAAFiJ+nYLsOTFA4fLf163cWe89FHVBPCZhddeOL0jIiLGti/emmHLy+ciIsqTL2kCmMbePfpgbJ16MuLSiYiIeCkWT7iXHj8W1z8+Wy4E2rjrbsVk1/ih0vO0pun8P9oS6zauLm1Zog06ppx/RFNtkPJNW8VEaId2yD+vbp5/I2JOEURj8s9L/gAAAAAAwErT9wVAJoD7S8rtoaeeiN/8wV8Xnrla8briNhdpIuyhp55QdNWmZvOP0Abd0kwbpL4nQjt0mvx7x/k3L/nnJX8AAAAAAGCl6fsCoFpMAPfWmtsn0h3rERHxo59+N3a98PM4/d6F8mPTb/9F7JtfeebgrrsREQvbXExOlLfyccd761rJf3b28qrR0ZE5bdBZrbZBRGkLGe3QGfLvH86/eck/L/kDAAAAAAD9bMUUAJkAzuuhp56Ivc9uiIiIXS/8PO5f/+2K53e98POY/uDD2Ldta0xNr46p6ZvlfOXcvhbyn4sIbdAFrbRByls7dI7883H+zUv+eckfAAAAAABYKVZMAVCECeCcZiYnYmZy/ou1e+J3N34V96//dvn/ERH7tm2Ne+/9Znz55e/l3GHN5h/hGO+WVtogQjt0mvzzcv7NS/55yR8AAAAAAFgJVlQBkAngPO6s3RNrbp+Ie+5ZFV//+jfint++E199NRdx+0SsiYh7fvtOrPlqLu6995u53+pAaib/P4yIr8/nPzo6MufY77yUf0TUbIP//PVvRMwXwNF58s/L+Tcv+eclfwAAAAAAYCXo2wKg0dGRuXePPhhbp54sP2YCuHdq5Z98/evfiC+//H3cWbun/Nia2yfir/7si9i8aX3sPiL/di0nfzqnUf4REV99NSf/LpJ/Xs6/eck/L/kDAAAAAAAr1ercb6AVB3Z+FW//3R/Fl1/+Pv7tj78Td9buKf/31Vdz8Vd/9kW8/Xd/lPttDqxi/sXJ94jSKjVT06vjB+88Hvfe+80YHR2Zy/Q2B1aj/CPC8d9l8s9L/nk5/+Yl/7zkDwAAAAAArAR9uUVB9d3Xa26fiHUbd8Z//2+/qDv5W+t1tmBYvmIbtJr/Q089ETOTE/JvQzv5O/7bJ/+85J+P829e8s9L/gAAAAAAwErWt1uARUT8+MnjERExNV1aqOjxF34SM5MT5cerVb+O9nx6/kb8+MkbTecfETE1fTJuXTrZq7c40FrN3/HfWfLPS/55Of/mJf+85A8AAAAAAKxEfXmHcqe2j3IH9vK10wZyb18nfge0w/LJPy/55+P8m5f885I/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADQNatyvwHyGh0dmYuImJ297FgAAAAAAIAVKI31Rxjv7xfmXwAA6JnR0ZG5//dfb8/9zf95Zq744QAAAAAAAFg5jPf3F+0BAOSwOvcbgEE3Ojoyl/7L/V4AAAAAABgso6Mjc2998GH56/FDx8J4NADA8FEANKR8IOittz74UMYZKL4CAAAAAKCXzL8AALkoAIIecqHfe4qvAAAAAIBhY0wUAGD4KAAaQtXV54kPBN2199kNESHnXOQOAAAAAEA3mX8BAHJSAAQMPMVXAAAAAMAgqldwAgDA8FEABF00OjoyN37o2KLHFaIAAAAAANBNxqEBAIaLAqAhs9TdAD4QdF5afYbeUnwFAAAAAAwb49H5mH8BAHJTAAQ9VPzw5WK/+3zYBQAAAAAAAGAYKAAChoLiKwAAAAAAAAAGlQIgyEghCgAAAAAA3WIMGgBgeCgAgi47fuZq7rdADT74AgAAAAAAADAoFABBF83OXl41MzlR8VhxKyq6S/EVAAAAAAAAAMNAAdAQalQUoTiFQaH4CgAAAAAYRsZB8zH/AgDkpAAIMrMVFQAAAAAAyzE7e3nVvm1bc78NAAD6gAKgIVNrVZSifdu2xuzs5VU9fEtDwVZU/UnxFQAAAAAAnWD+BQDI7Wu530A3NTux74KLbpqdvbwqJifm9j77Yfmxvc9uUBTUI8fPXLW0KgAAAAAAwAAw/5uX/KG/DWQBUOp4xg8dW3Li39KYMLgUXwEAAAAAg25+G7C5tz74cOkXA21TAJGH+d+85A8rw0AVALXS8SgAoNesRAMAAAAA5GTSGmD5FEDkYf43L/nDyjIQBUDL7XhmJid8kKEnaq1EQ+8ovgIAAACAkvFDx5Z+0eTEXIRCIIAIBRC5mP/NS/6wMq34AqDR0ZE5J1xWouJWVOOHjkVMTsw5IXae4isAAAAAWJDG0huNmZeLhBQCrVjGn6F9CiDyMf+bl/xh5er7AqB0ci2eKKuXKZ2ZnIiZyYWvi/vc1ut4nHybU8w65bXUMrFyrc9KNP3Bh9/m5F4SWv+TVzPn32ry77xmfg/l3n3aIS/556HPz6P6/FuvHeTfHa5/gFz0P3kNW/6zs5dX7du2de6tDz7si0KgYcu/m4pt2yz55yX//qYAorvM/+YlfxhcfV0ANDo6Mjcz88uIiBgff6bc6aQPHcWT7vEzV2NmciLeeP3V2Ldta8NlTHU+rZmZ+WVcvXI+XjxweC4iYt3GnfHQU0/Uzf/FA4cVU9TQzko0zV701yqYoETx1fIsNWBw/MzVrt4Jpv/JY7nnX/l3TurPC78D5TuN9m3bGoX2idHREbl3UbEtIkqZv/XBhxXH/oZHN5V/V7RFZ8m/91rof2TeYbXOv+s27oyIWHT9s2/b1q72/bkLwXNw/ZOfCbC85J+P/icv+Ze0WgjUqX+7/POSf17yz08BRD7mf/OSPwy2vv0lHB0dmXvj9VcjImLDo5siIuLqlfPxytvnIqI0ABpR2Qn9/cv/FLcunYyI+vsY63xK2da7SKnOp3gSqM6/+gRw/eOzcevSyZiZ+WWMjz8z9DnX0kr2xe+Zv7BftMxkMfeIKE6Cyb/KcrJP39fo5w5y8VW6wyEimrrLYWZyIiI69+/X/+TR7vlX9u1Lx/7VK+cjIuLFA4dj3cad8aOffjf2bdsatdrnxQOHZd8F6fehmHVEqU3e+uDD8rFfbBN9UOfIv/f0P/ks5/y7b9vWrt2B38xdrt34+3Nx/ZNf1QB0+fEmJsDk3wHyz0f/k9ew5189Vla01GoWnRhjH/b8u6XZMVD5d08zbSD//Nq5/lEA0R7zv3nJHwZf3/4iLqqynT8RR0T86J8vxPWPzy7qhIqTwLU6IJ1PSauFEMULoYiIvQdfr5l9RMT1j8/G8akDJl/qqLVkZDMFWOPjz9Rd+eT6x2cjIuKHL3yrfLKW/2KKr5anWAQU0ftCIP1P77V7/pV9e6oL39Lke+r/923bWvH6Yvs49juruv8pDgZFRHkVmnTsFwtVtEX75N97+p+8Gp1/9x58PSIWD8J18rqrlcKfdO01SJ+vXf/kZQIsL/nnpf/JS/6Ni4AiGhcCtXsdIv/uaKUAqPh98u+cZguAit8j/95SAJGX+d+85A+Dr2+3ACteBI0fOlYe9H/j9VfjtafPxrUHLsbDj9yNiIgvvjkWERGvPf1JXHvgYsR3HozdRybKnVCnV6UYNrOzl1elJeAunN4R/8d36mT/2cWI75gAaGS524ClyZei4geH41MHyn+Wf33FbcD2PruhnOH4oWOLli+uLr6qZ93GnRXFV4MuZVZvYmjvsxti77MflrcGa/dYXE7/Q3uq2yzl3/z5NyxD3KZGx3EqeogoFb0Vr4/ovFQEEVF5Lq7VB6bX0Tny7z39Tz7V16HFfE//5G5c+6ze+ffB2H3k5rL/3uUU/kQM3uCe65/8iv34zMwvY8Ojm+L41KaKAeji57l0TkiTMLRH/vnof/KSfymDfdu21i0CarQ1WHFLsPSzWv27K37eEOafk/zzkn9+nb7+GbTPSN1k/jcv+cPg68sCoFqDkDOTpYH/V94+F6d/EvODnGmg81TF9x/cdTciVut4OqxUBHG3qezpjFT88O7RByPiN/HwI49VnHAjIq49cDHuu/MPMbb9VPl7cr3ffqb4anlSbtVV3c0WAu3btrUjH0b1P3m1ev5l+Wqtwtfo9eOHjsX1j8+W71Cis155+1z5PJBW3Ktn0Pr/fiD/3tL/9JdUgL7U+bedc2+t1UlrWWoLkEHl+qd3TIDlJf/+o//JaxjzX6oIKKK7hUBFw5h/P5F/XvLvHQUQ+Zj/zUv+MByyFwClzqb6hNtoEPKlj7bEu0cv1rzT8eCuuzE1Xbr40fF03lLZn/yXP48Id4AtpVg53oxPz9+YP65vRvUJNyLiwunHYt3Gne6+6yDFVwvqFQFFLF0I9NYHpSKg8s9pQ7P9z6C2Qz9o5vwrfwDorHrn33bOvUtt9xFRv/Bn2O5sdf2ThwmwvOTfH/Q/eQ1b/qkIKKI0llNPrwqBhi3/Tqou6FpqFfRa5J+X/LtLAUTvmP/NS/4wvPriU/rBXXfLdx82cwdiRMQP3nk8LpzeERdO7yg/duH0jti8aX1E6Hy6aansaWx29vKqdHEYUVk4MX7oWM27rU/+y5/PX1gu9u7RB+Olj7Z04Z0OplbvYP70/I3YfeRmjG0/FePjz8T4+DMxtv1UjG0/Vb4IarRF2KCoPm6rHT9ztW62b33wYfnYXmo1gaXof/LTBgDQe7XOv3+5t/Vr0HQ91mhir9F13bAV/ySuf/IpDUA/WPM5E2DdJ//8Br3/SeelRv/lfH+Dnn+12dnLq+aLR2Lftq0NX1ta+bn2GH4a42+3DYct/34j/7zk3xnFfij9efzQsXjrgw/r9mHNXP9ELPSZXXrrA8P8b17yh+HUFwVARdWdT6PBx1pFD29+/v2uvK9Bdd+V78X+B35W9/l6H9SWyr4fPqQPms2b1i864V44vSN+8M7jGd/VyqL4qj1LFQFF1O+z9z67oeVCIP1PXo1ydP7trnaOYcd/6zqVmeyXrxPZyb+zZNmf2rnurB7srqXRZ++I4Sj+cf3Tn0yA5SX/3hiW/qe6uCdNRtX6760PPoy3Pviw4nu6/b5qPTdI+TeruhCoUTFQq4VAtbKWf3el8f/iHECzxXbyb99y518i5N8pCiD6h/nfvOQPwyP7FmARpTsXN2+6GJ+e/9u470rpBNpuRzI6OmIP8irVF5L3XflePP/+D+OTn34r9p/bUXlk6KUAACAASURBVM68+LpU6VxrubdGFr7PXvDLVd1eb37+/XjtkU8qXlM6CZ/t5dsaSps3rY+/3PtYeauvdOG//cer46Gn8r2vHNJ2YBGFpZ1rqLc1WGlg6MPS8w2WhB4dHZnT/+TTTv7Dcv5davC53QwO7robU1H5dzSzgpnjf3lS3imzpdq3VlvIvj3FNpB/XukcUOz/m+l/hqX/70eNsm9mme9m2ndYin9c/+TVqP9/6aMt5a2Yk9IYRuMbFGie/PMZhv6neD5qVnHLonQOS1tUJa3+24tbYRQfG/T8l6v4bytmX6uYuNmtwYqrZ0TIv9uK4/+3z+0oFQIdfTA+PX8jIiKmplcve/xf/ov1cv5F/stTqwCiHtc/nWH+Ny/5w3DKXgA0O3t51dj2mEsT6rUuiJajNGhtAqDawV13S1XKV75XfmzLy+fiveei4gPA1PTq+W2NftPyxWdE6YL13aMPpq2RtEMNx89cLV9wprsAPj1/I+LQfykXRlRPvjRy69JJx32HKL5qrHx8dakQaHR0ZE7/k0+tid9WDHI/VOwbGq2eEBHl43q50iBcsR0aDagm6fWD3A7dVvwduHXpZM1tHmu1Rep7aI/8O2+5BYsXTu+Ise0n46Gnnmiq/9HvdMZyVjeolX0nC38iBv8OV9c/+ZkAzkv++QxT/9NK8U+1YjFQhTqfu+rdaFSv+GQY8m9XrWKgVguBqsm/d7a8fC4uHX6s/HXl2IH8O6mV+Rf594YCiHzM/+Ylfxhe2QuAkrHtp0qrary/cEGUpEHHepMARTOTE3Hh9I649tnFbr7dFWl29vKqqRiZ27wp4uFHShf878UrEbHw9bXPLlZ8EKZ7ZiYnYmaydLJMJ97NsSM2R+mDwO4jN5f1AUDRw9IUX3VGdSFQRP0BvVYKgSJKme6+1Pn3THOqB4KG/fybJlHrFf0UpWN877NLv7aRtMR6cQK+0QDqrUsnI2LhzrHS9pDLG0QaFsVJ9oWV3qL8WPpwnPJ/6Kkn4vrHZ+PWpZMxM7n456XsnYebV7sNKlfbS/lHLHwmKOaf+ib5V2q3YPEH7zw+n3upPYrbPqRz/VLbgrJ8pfNvqV9f6vxbTeHP8v3gncfj3aOlP3f7+qeZQq9hyt4EcF7yz6+X/U9OjbZcaebcVEvdoqI6hUGbN62PqenKY31Y8u+k9PveTCHQffNFEJ+evxH7j66Phx95LKamT5VfJ//OS9cZ9135Xjz8yGNx6ZFflJ9Ln7fSyqvy76xW51/k330KIPqD+d+85A/DJ3sBUNp7MyJibPtEXDpdugj69PyNmJkudTzjh46Vl9orTgJEREVHk/780kdb4vrHq8PE12Kzs5dX7T4Sc4uzuVnxmvRB4c3Pvx8XTjeb/Za4delkecJmmFdIaSTdcZT2i03SiTfdAVCa9D1V56dUMgHTGsVXnVXx712iGKhRIVDEwoRiuiuv1gRwhP4nojdbUKXfg2IRSlLv/BuxJQZlKdxWCn86KQ2Qvvn59yM+j0gT8LX6+oeeeqLGsR8x6Md/sxr9nlS0a+HOvIhi9hERpyqyv7N2T9y//tsVr1/96/2FgSPZFy2nDerlf/fJNxf9jFu/3h8XTu9w7M/rRMFisdgnotT3FI/7mcn9ERGLVlyyFHrnVE4EnCwXed66dDLGCgVw6bNCyj59tl5u4U+xrxu269kk9eXNfwZu/vqn2B+m6+RGk+HtbnOz0pgAy0v++XWz/+kHs7OXV+3btnWu3jVKO0WrtdQaj9j/wM/mJ+AXj/cMev7dslQh0H1Xvhdrv3VqfszzlXj4kVLBf/U5Tf6dUxx3TgUnxfHl8UPHFo0tyL/zSuNp9edfiuTfGwog8jD/m5f8YXhlLwAqWrdxZ4xtX5jEmpq+WT7hLgzqn6o4Ic8Uvn+5dysNm+I2O6nzT3e01xpUbD77iarXU8/U9OqYmr5ZPtbTnRjXPovyHQDFO+DTiVfRQ3sUX3VfrWKgZguB9j67YdHgnv6nUi+3oNq8aX1s3lTKt5TrcJ1/R0dH6g5Od1PaH3517K94fGZyombxQ5qILx771z8e/PNAs1vkNNOG9xUKT+r1/8Xih/sj4nc3flXx/P1Pvhkzk/vb2tZgpelWG9RS69gvPje2fX+MHxrs/n8p3ShYTH3J3SffjPsLj99ZuyfW3D4xv9JYVAwO0TlpFaY0ERARNfung7vuxtTkRMOCkkaTp4p+Kl3/+Gw89NQTHRl/qO4nmyn6Kar+fU6Tq4PcTibA8pJ/96T+oNHvbyf7n36VioAimr9m6cSqQWnl51QMUcsw5N9NjQqBtrx8LiKiXPwzfuhYxORExc1z8u+sNO5cnJxdt3Fn3et2+XdW9ba8xXGCmcmJirmZCPl3mwKI/mH+Ny/5w3DpmwKgNMD8xuuvxtj2wxExP5g5XbrbsXjSLU4CpAmYNbdPtLVnKgtGR0fmUsefLkCT6uzX3D5R/ro6/9Smw7oqSj3FHIpbjRQVC7PGtpd+B2YmJ4a26KGTFF/1TvUWYY0KgdKA3MZ/XbwkdHFiqtn+f9D6nxxbUMX8UtERN2u2Qb38B6n4ZLl3m7Zj/wMRn/z0W/En45Xn4Dtr90QUik5SMcrdJ9+M1b9eKBZK+actq6oHVleq6knUThdnrf3Wqdj48rlY/ev9sW7jzkXXP9WqVwBK0vcNUvZJL9pgbPyxJfP/XY3fg2SQ82+kkwWL+7Ztrdji687aPRXFPxHzud8+UV6VJm2PFzE4591+cf3js/FSFK/zS9dGqQirWvUkaTOFP9pq8Y0xtfqgtDrlnbV7IqLy+qd4ndRMsfZyvfXBh4tW6Bo0JsDyGvb8e7HC6lRUFgIt1f808/l3pX3+qi4UiVh+f9lMcdD+B34Wz7//w4gojf8UV58Zxvy7rbp9D+66W7HyT3FcSP7dUauvKhaaFB+Tf29d//hsvPH6q/HigcMV46Ty7x0FEPmY/81L/jB8shcAzc5eXlVcpWDDowdiZuaXERExPv5MRCx0PsW731PHs/35sfnvHIvdRxYG3oZx8H+5ip1/ugCtHvCslf2a2ycqLlR3H1koVBk/dKziZ6QJAiql7daqV2Kq9sbrr0ZExIZHNy16Lv2epO+PMPlSj+KrPJYqBNr/wM9qLgkdsdCfRMz/fhQKHdYUfka6+By0/if3FlRJrTaolX/E4Jx/i9cnvVzV5c3Pvx8z448t+jvX3D5R8wPY/eu/HXcLq88Uj/2VPhjUzUnUiOKkQOmu1NW/bn4Fn3pFKCn/lZ590ss2+JMax30t9YqvIgYv/1Z0smCx2dUNi0ujD8p5N7fqzwXF/9+6dLJcfBKxsGLZX+7dGZs3XYxPz/9t3HeltMrlwpaEiyn8qa2igHBe+gy8+tf7Y/Om9TE1fbOi8Cpd/3S6f8xRgJyTCci8hj3/WlvzVUtFJtXb8rWquMJqUaP+J2Jwxz+L77U62070q+XioCulGyzSKjQRpXZPf/+w5t9tabwzbUM1tv1UudC/SP69MZ/NXETMz7sciIjSmHL1OIL8uyMd+xse3RQzM7+M8fFnHP89pgAiD/O/eckfhldf/WKOjo7MvfH6q+Uih6tXzseLBw6Xn08DnqnTqbe8efWgtQ6ovjTYkTr96syL7qzdU5F98Q7hVLhSffIo0g611SoAKk6o3Lp0smEBUGqz6sGq4pKi1FYr++qvlyq+qp6kiYi62+lRkvqdlF3FHXmHf1G+K2y5bVLLSmyP3FtQRUS899wrsfvIzabboDr/lZh7LdXHbLdVX8dUf/iqVQCR2qqWldYOnSx8a2VbgEaDOLUGf5LUHsWVmJKVln2Sow3qFZ28e/TBcp/USvYRKzf/5ehGPzUzOREXTu+Ija/+ac3n6+UeMVzZd1JxJdZaN2Skz8PX3/z3GNt+qrwizIXTO+LaZxfj+fd/GJ/89Ftx+9yORUVACn/qq7fqR3G1n5TxF4/+Y8f+3lYLfQb181067pu5CWlhAHrhmK63rQbNGdb8e319H1G63ize7JIKJGq9dtjHP7ux1Wza/iuNNzQqeB72/DthdHRk7uCuu7F50/rYfeTmouM9jSnUGoOWf/dUz71ELB7HkX/npWO/0bxXIv/uKPY/af4qYuH4L66CO8jXP7mZ/81L/jBcsq8AVDQ7e3nViwcOz6UPARHlVWkiIuLR//Q/4vRP7sZLH5WeO37makUnVBxASx1ZvclgStIHsKtXzseGRzeVq9CvXjlffk3K//qb/16RfUT9O71Su+n8m1ddQFL04oHD8cbrr1a0S/G5iObv1qaxVu5eLB3ng7XiTC9Urwi0scGS0BHLaZPDlX/PCpZzC6riHZLNtkGxCHQQ8k+qj9mIpu4QbuvvrBhwqCp6qC4EKhb/pDvJVmr+yyl868TvyZuffz/GDy2emCkWn0QsLkBJ3nvuldj969KfV2r2Sa42KBaFFtug6P71367ZBukuvJWefTua2XazHb+78atFxYcp93Ubd1YUsLsOWr7i3dnVOdYq/knGtp8qLWP/fsyvqLjwfQp/lpY+ExcHQ8fHnymPP4xtL73u4Ucei2vzE8nNFgJ1on8chja8delk7WP+xq9KA9D/89iiAei9z35YcwCa1g1T/jkKfyIWtrxOxg8dK5+za03GL2f8c34SZyDuwm7239BoVaZ0nvzi0X8sFwFVjzek8c8XDxyu+Cxr/LkzpqZXx9T0wjV68XwbUbkSivx7o3ruJbVBIv/uSL8DLx44PFfMuzgHlnKUf3cUt35M82ARC+PI6XpmUK9/+oX537zkD8OlrwqAIhY6oeJjd9buKS+1/dJHW+K1pz8pP/fSmYXXpcfHJhceS9taDcIH4G4pdvzVqzm8eOBweXB/+49Xx+mflDJ+6aMtS94xQ3OKy/ClZVhrFWDVW5kp7VmbFO8m68b7HUSKr/KotSR00k6bDMqxn3MLqv3ndsR7z6W7JG8ObRtUq/h3FYqBimYma7y2geJdSO8efTAiIp5//4d1C02S6uKfdE4e5OKfThfE1eq7S9s9loqplir+abQV1UrVL23w7tH63zOIuXdStwoWq4uvtEN3pWKflHNl4ecvIqKy3cYPHYux7RNx6XTEtc8uxqfnb8TM9OAXjXRTGgh96aNjceH0QpFVeZXE+F65CKgbBdvF/nEY2rA4CB1Rup5cKMAqZTEzWbnaR60B6IiI8fFnjP+0qNad8MuZAJj//r7Nv7gCcC8VV7x9L16peC4d+8XJyKTZ8c/0fbVWyB10jY61YnFQ+pwVsfjmlg2Pbqpoh8T4c3vq5VBr8rHYByXy757i3EuxHYrjzvLvjtnZy6vGx59pmH2E/LtJAUR+5n/zkj8Mj74rAIqorMh99+iDsXVqfhD00nwnFFvKr63ojD7aUvODHEur1fEXpfy3/7i0NHQ596dLxScvfVRqExc8y5OO+fHxZ+ZqfQAo3mF9+id3K743ZR/R2kopdKb4qjp/d703Ly0JHVGaVKk1aRmxcBFaXJr+xQPDUXTV7RUd6nnz8+8vuku1emuAem0wLBf87f47U+FPKjL53Y1fxdap9Gzj4p+kWPyT+v+Vnn+3J1GLqrOqbpPn3194rlHxT3EFppWef0TeNogotcOn529ExOqGRVgKUBrrVMHi2PaYu3Q6YuOrf7oo8+ff/2GsjoVtwNI10CD8HvSj6vzTZNneg69HxEIRULo5oHjHPc1LnwWKqxIUBzgjYn6btc72l5ZRr/2Za2z7qXj36IPx6fkbMTW9uiLzWgPQEeXVEA1CzysWm7eaSasTABH9PwlQayuDrrtSf4XV4hYMEaUxtVbHP2sVD1E5tvzp+RvF1SIXiqTHn6ko/nnxwGHjzz3QqABF/r1RXJEmPZYK0OXfXbWyL81/PVn6Qv5dpwAiP/O/eckfhkNfFgAtJXUyDz31RPzmD/668MzCYNArb5+LiHOL9jGnvnqTMNWPXf/4bPzm2b+ueuyfGv4cmlN9AVprT/jKY74y+1uXTpaLhWhOo+KrlH+xAOtHP/1u+TW/Cfm3q3pJ6IjaF6FJ6v/HDx1bdAfGIBdg5diCav/RB+PaZxcrHiuef6vvwB7k/DupXpFJo2KGWkUPqejkrQ8+zLJVXLfMTE60XejW6iRqo8KfiMZFJ6kd0hZIgyBHGySpLaamGxf/FBULsKitm9fmpesehT/dtlTBW3EQLhVMHNx1N6ZixEB0k2qtinv1yvlyf5j6tUuHfxHXzr1S9+dUa3al0GFup5R9sdh8ZnIibl06GRdO74hrn12MqenVMX7oWN0B6LR9T7EgLiYnHP/zDu66G5s3rY/dR6Iik7QVT/Wqnq1OAKTVQdO28v1qdvbyqrQqTKvbnbbji0f/MW7XWWG1+ia68gT8vGbGPyPCsd+C6mxqFkDMM/7cPQ0LUObJv/uK457FsbcI+Xdbceyz1vPy7y4FEP3N8Z+X/GEwrJgCoLT6Q/Kjn343dr3w8zj93oXyY9Nv/0Xsmx9gG5RJmH5RzD9lXzT9dqkoYt82uber1kBNsfikXvZ///I/VX8bLahVfJX+LP/uaHZQspX+f9AHOruxBVUt6S7JqenVERHy75A0sJC891zlBGKx2KGoerWZiFK/dGftntj1ws8HJv96q4A1U4zS7lYpqV2q2ySifrsUi7D2bdu64vOPyNMG9bbBa7QCUy2DkH+/qTUYXa8gTv69cenwL2Js+6mKbTiLn3vT+bpUlLU6x1tc0WptCZBUr7D05uffLz/XqMjH78bypeKftCrczORE/ObZYtHGwgB0cUsNKs3OXl41FSNzmzeVMh3bvrD6SVpJLPUn5dU3CpotQIlYGUUo6T31uhDoi0f/Me678r1F7yMpTkC2+vm30WrelExNr264JVU7+UdhRSFaJ//+Iv+85N8/FED0nvnfvOQPg2fFFABFlE64aWWDXS/8fNGdkLte+HlMz0/CpM7q1qWTBt06JOVfK/u/+t9vxO9u/Crl35cDPSvdQ089UTf7iIj/+tPvxt+/HOW7sGldo+O2Uf6/u/GrmH5b/t3UQv8/NP1Pt/+daQWO3Uduyr+DGq1U8t7RxisK7D5yM3b/uvTnu0++GffPPz5o+S/6N9Qpdmv4PS1aTrvsPnIz7j755sDlH9H7Nmhm27WiWithDVL+K8nz7/8w3jv6yqJVJeiu4lZJVUWIcxGKTtpVzLdeAWS7hafUllaUvHB6R2x89U8j4k/jvedeiQ3/2z/G8TNXyytc3lm7p2YBtHGgxVIxZ6mQKhUBnSrd4PLPF+Lv/5ex2PDophgffybamICPlVaEUl0IFFG/GCitttnsil71vFtjhdV6Wvn8FeHYb2Q5ebSSv+w7T/55yT8v+eejACI/8795yR8Gy4oqAJqZnCivbBBr98Tvbvwq7l//7fL/Ixa2PEknYJ1P56T810TEnYiK7NMkTbtbzlDfzORErImIu1W537/+27H61/tj37aF15Ym7U3EdFKj/CMqj335d14r/T/tq95+UP6dsVSfsPvI0ndvpbuy748Ymvy73Zcut13urN1TLsIa5Pwj8lxPF68vqx+vNuj55za2/VRcOh2x8dU/rWiXYh9Eb91Zu6fcFsXj37VnZ6R8SysuVU74j20/FQd33Y2I1XFn7Z5Yc/tEnjc5gNIYTlr5J+JP45Offitunys9v/fZDbH32dLWpzOTE7Fv24mKAlBFcJXStXwqYtv8wM9Kqxq+H3HpdMTY9vktqOoUtSznBoCVOBFQfJ/FYqClXtuq4gqrzfycVj5/OfY7z/hzXvLPS/55yT8vBRB5Of7zkj8Mlr795VxY/vPJiChV4N5zz6r4+te/ERER//Ef/x5ffbXw2bz43Jdf/l7H0wHFNpB/HqkNdh+52VL+6Xu0Q3uazT9icRtEuABqVzv5y7598u8Po6Mjc86/+ci/N6q3x6vedi0VnBRX/okorcJ0773fjAj5d0M6/r/6aq68Gke9oqy0GpM2aN/o6MhcudizRoFV2gZM/9MdKf+U/aXDv4g/+V//n4r+/+CuuzE1vVr/02GjoyNzxW2/Nm9aHxGlrZNqSYVAET53FVUX/iT7H/hZrP3Wqdjy8rl477lX4uFHHoux7afKz1ePvxUV+6TiREB6Xco//d3aY7FG2Rj/zEv+eck/L/nnJf+8auVftNT1T6Idlsfxn5f8YfCtqBWADuz8KjZv+qPYfeTmon3J19w+EX/1Z1/E5k3rY/eR32d6h4NN/nnJP69G+Udog06rKECMm/LvMfn3l2L+1R+wRkdH5mTfXfLvvtnZy6uKKy0Vt117/v0f1iz8SeTfXQd2fhVT06vLX9db8cdWYN3RaJWlr76ac/z3yJdf/r7i+mdqujToL//O+7+On4yp6dUxfui/xKXP5x/8vLT9UrobOymuCJS2qhzm/qde4U/y5uffj/3ndsR7zy3eDqyWg7vuzh/fN+MPf/tOaQLg9olYExH3/Pad+PHOr8rPJ8Oc/1Jazcb4T17yz0v+eck/L/n3RnXxQ1K8/ikX+sxf/8TtE/HjwvOuezrP8Z+X/GGw9OVJqlb14bqNO+O//7dfLBp8K6p+nZPw8lWv/iP/PNIgXnFJyWbzjzAA165W8o/wO9BJxdVn5N978u8Po6Mjc81k2uzraI388yluQVhcGShNMhYzln93VOcaEeVVgBqxElBnFFcBSoqFQGkVoIhw7u2w6hWYUtbF9lhz+0R5u1T5d87o6MhcWl2pXhFLxOJCoKS4IlDE8HwWXqrwJ6J2Zvu2bS2vZmX8LR/jn3nJPy/55yX/vOSfT63iH/n3luM/L/nDcOjrFYB+/OTxiIjyXaePv/CTmJmcKD9erfp1tO/HTx6Xfx946Kkn4vrHZyMi5J9BM/lHaINukX9e8s+v2Uxl3x3y773iViLNriwg/+4o5nrts4vx3nMXl/yeUgGplYDa9eHBX1c9svD1tc8qV+5w/HfO7OzlVaMR89sS/jqufZaO6ROFgsTSMZ6+R/6dk64nU561ilqOn2m8IlD5NfOrAkUMXjFQsVB2OcVStRh/y0v+eck/L/nnJf+85J9PMWP55+H4z0v+MNj6chCkOJjRjkEb5OmlTrSB/NvXbjtog/bIPx99UF7y7x/Ftmi0Ak3xa9l3jvzzkn9e1fm3em7QFu1ZzrlY5p0j/95rlHk7RS7FlYFWchs1W/QT0TiTfdu2RsTy+vVGVnK2ORn/zEv+eck/L/nnJf98XP/k5/jPS/4wHPyCAgAAANBXqgenh7EQqJktvpJmC3869NYAAACAPuSDPwAAAAB9rZlimGYLgfq9EEbhDwAAALAcBgAAAAAAWBHaLQTq9yKg0dGROYU/AAAAwHIYCAAAAABgRWmnEKhfi4CaKf5R+AMAAADUY0AAAAAAgBVpuUUz/VYEtNS/Q+EPAAAAsBQDAwAAAACsWMvdNqtfioAavf9GhT8RpeKf3O8fAAAA6A8GCAAAAABY0ZrZEiwpFtXkLqCpV/yzVOFPRP73DgAAAPQXgwQAAAAADITlFALlLKSpLgBqtvAnwpZfAAAAQCUDBQAAAAAMlFYKgXJtA1Ys/lH4AwAAALTra7nfAAAAAAB0UrlIZnJiLvNbaUjhDwAAANApBg4AAAAAoMfSKkVLUfgDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAirEq9xtg8IyOjsw187rZ2cuOPwAAAAAAAACANn0t9xtgcKTCn/FDx2Lvsxsavnbftq09eU/DShFWftoAAAAAAAAAgF4Z6AIgE/C90Urhz/EzV3vynoaVIqz8tAEAAAAAAAAAvTaQBUAm4HtjuYU/M5MTiq46TBFWftoAAAAAAAAAgFwGqgDIBHzvjI6OzMk5P0VY+WkDAAAAAAAAAHIbiAIgE/C9NTo6MvfWBx82fE29wh+Zd44irPy0AQAAAAAAAAD9YMUXAJmA751ioVU9jXJW/NM5irB6Ix3zxbzSY8nM5ETMTC58XWwXbQAAAAAAAABAL/T9BHQzE/DVTMC3r5j7UnknjQqD5N265R77irA6Y3R0ZG5m5pcRETE+/kz58XScF4sOj5+5GjOTE/HG66/GiwcO+10AAAAAAAAAoKf6ehLaBHwenc5d3q3rxrGvHZo3Ojoy98brr0ZExIZHN0VExNUr5+OVt89FRMRDTz0REZXt8Pcv/1PcunQyIuoXw2kDAAAAAAAAALqhbyeiTcDn0cncZyYnIiLk3aJuHPuO+9Ys2uZrvhgrIuJH/3whrn98dlE7HD9zNa5/fDZuXTqpDQAAAAAAAADoqb6djDYB33u1tpdaTu4Kf9rTyWNfWyxfaofiMf3G66/G5nVn49pnF+PhRx6LiIgv1vxNRETcd+cf4tpnFyMiYveRm+V20AYAAAAAAAAAdNvXcr+BemZnL68qTsCnbZDeeP3VeO3ps3HtSO7y0AAAGD5JREFUgYvx8CN3IyLii2+ORUTEa09/EtceuBjxnQdj95EJE/ANpGyrcy6uKhMRFblHrC4//trTn5RzT9Zt3KnIqk212mI5bZBoi9bVaoOZyVK2r7x9Lk7/pFTgE3Fz/jtOVXz/wV13I2K1fgcAAAAAAACAnunLAiAT8L1xcNfdmIqRuVQoVV38kyzkfrdceDW2/VSk3C+c3lEqvIqI3Zd68tYHQrNFWBGtt4FjvjmttEHy0kdb4t2jF+f7oEoHd92NqelSkZY2AAAAAAAAAKBXshcAmYDvD9V5Hz9ztebrKguvSkqFKAuFVzSv2SKsIm3QWctpgx+883hcOF3aAixlf+H0jrj22cWYmr6p7wEAAAAAAACgp7IXAEWYgM/lL/fujM2bLsan5/827ruyPiIi3vz8+3Vf30zhldyXr5kiLG3QXc0WwkWU2uK1pz+peKz0+zNR+xsAAAAAAAAAoEv6bqmQWhPw9SbhX/poy6LHGhWwsGB29vKqse2n4uFHHovNm9bH8+//MNZ+61Tsf+BnDb+vVHi1Iy6c3lF+7MLpHbF5U6mAKK3iRHP+cu/OePfog7HxX/827rvyvbjvyvcaHvMR2qDTltMGS9EGAAAAAAAAAPRSXxQAmYDPJxUBRURseflcU9/TqPDq3aMPyr5Jyy3CitAGndJOGzSiDQAAAAAAAADopewFQCbg8xgdLW25Nn7oWIxtPxWXDv8i3nvulfj0/I3ya2YmS1sZ3bp0csmfNzM5UbEiDc1rVISlDXpDGwAAAAAAAACwkn0t9xtIxrafKk2cv1+agH/vuYXnihPw6zbubPhz0gT8tc8udvPtDpR1G3fG2PaT5cKFqSOlvMcPHYvXnv4kIiLGtp+Mh556ouHPeemjLXH949URcbOr73dQpCKsiIix7RNx6XTEtc8uxqfnb8TMtDbohXbboNjPpD9rAwAAAAAAAAB6LXsBkAn4vK5/fDYiIt54/dUY2344IiIO7robJ//lzyOiuNXUqYrvq5U7y7eoCGv6ZrnYTRv0RrNtUCxInCl8/+4j+hsAAAAAAAAA8sheAFRkAr53Zmcvr4rJifIWaRsePRAzM7+MiIjx8WciorTdUbHYaqnc0/O0pl4R1tR0622QnosoFdfNzl5e1c33PihaaYO7T75Z/vPvbvwqIiLW3D4R7x59UB8EAAAAAAAAQBZ9UwBkAr73UnHI6OjI3NUr52PDo5siotQGLx44XM58ZnKinHnKe/vzY+Wfk4pSUgFRRMT4+DOKT5awdBFWtN4GkxPaoQWda4Ox2H1koQDuoaeeKH3f5IT8AQAAAAAAAOi6vpiYHh0dKU/AVxUvlP4/v0VYs0UQ6fXpMRPwSxsdHZl74/VXKx578UCpEOvO2j0RsZD13mc3RETEvm1bI6JUMJSKh5Lx8Wfk3oKUf8rx6pXz5fwj6rdBhHbolHbaIDl+5uqilbDkDwAAAAAAAEC39dXEtAn4vIqFWEXrNu6M0z+5W9iGrVRYtW7jzvLqKM//T3crik8UnrSuURFWrTbY++yG2Ldtq3booOW0QXL8zNWIKP1upH5M/gAAAAAAAAD0Qt9sARZRKtR58cDhign4tB1VRMSj/+l/zE/Al547fuZqzQn49H1pAp7mFLcEe/fog7F16slYc/tERES89NGWeO3pT8qvHZtc/P1Xr5yPiKgo2qJ56fgvPnZn7Z66bfDSmdo/RzssXzttkB4v/m7M91+2AQMAAAAAAACgq/qqACjCBHy/ubN2T8Sl+exjS+GZUxERcf3jsxER8eLkyfIzsl6+xUVY9dvgtac/KR/r2qFzWm2D5KWPtpTbIanekg0AAAAAAAAAuqHvCoAiTMD3q5TtQ089EW998GHs27a1/Jxik94otsFv/uCv460P/rqiHSK0RbdVt8GChRXIXnn7XEScK2/NBgAAAAAAAADd1JcFQEsxAd87a26fiHUbd5a//tFPvxu7Xvh5nH7vQsTaPRERMf32X8S+bVutstQlDdsgImLtntQGin+6ZMk2iPnfg8mJiIi4denkop8BAAAAAAAAAN2yYgqATMDn89BTT8TeZzdERMSuF34e96//dsXzu174eUyXVgRSBNQl2iC/Ftqg3FfdunRSURYAAAAAAAAAXbdiCoAiTMDnMjM5ETOT81+s3RO/u/GruH/9t8v/j4hF21DRWdogv1baIBUg6nsAAAAAAAAA6IW+npweHR2Ze/fog7F16slYc/tExXN35refKk7A/+7Grxa9zgT88hSzjyitwHTPPaviq6/mar7+4K67sXnT+th95KbMO6Be/l//+jfiyy9/X/N7tEHnNMo/Imq2wb33frP8nPwBAAAAAAAA6KW+XQGoegI+Iiom4O/57TulYpTbJ2LN/Nf/+evfiLj3mybguygVOfzHf/x7/Nsff6f8+NT0iTj5L4/Hvff+fzE6OmIbqi66995vLso/Qhv00j33rKrI/w9/+07GdwMAAAAAAADAsFud+w204sDOr+Ltv/uj+PLL38e//fF34s7aPeX/vvpqLv7qz76It//uj3K/zYFVnX8tj7/wkx6/q+HRTP4R2qBbGuWv/wEAAAAAAAAgp74sAKq1/c66jTvjv/7f98XuIzfL238V3Vm7J6amV8cP3nk87r33mzE6OlJ7rypa1kz+ERG3Lp2MmcmJHr+7wdds/hHaoBv0PwAAAAAAAAD0u77dAiwi4sdPHo+IiKnpUp3S4y/8JGYmJ8qPV6t+He378ZPHm84/otQGtp7qHPnn1Ur++h8AAAAAAAAAcunLQoFOrZ6hEGL52mkDubdP/nl1og/SDgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/397dxAb5XmnAfyB7h7apBWH1UqJiiKQtuoBGOqwUpNQOXCIWA4FWUtEI7Q9bKg2ChWhcqDqoVIvUYKQsFWjHMJeIkSieOWNc2AJh8AoiHCgGBMfIrYCISSqlVbaqEm2ewnew/gbz5ixPWN7PGPn97swzPfNp+H9J/bhffS8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAO2yptNfoJ1KpS2Tzdw3Pn5zVa8DAAAAAAAAAACr1191+gu0QxH86X3lRA48t2nOew/u3rUs3wkAAAAAAAAAANphVQWAWgn+nLkwsSzfiQptTAAAAAAAAAAA7bEqAkALDf6UB/oFTtpMG1N3EMACAAAAAAAAgNVrxQeASqUtkxp/uo82pu4ggAUAAAAAAAAAq1/Xt30UAYbaZpL52kzeOne++nq2cIn2n/bQxtQdFjIHM1ge2pgAAAAAAAAAWGpd3QBUKm2ZLJc/SpL09u6sbpr3vnIiSeqCDWcuTKQ80J9TQ8dzcPeu6j2NCDq0hzamzhPA6l7amAAAAAAAAABol64NAJVKWyZPDR3PxKfXsmnztpTLH2Xi02t5/fTV3L50JRuffTpnLkxUN9IPPLcpty/15eVDR+d8rqBDe5RKWyZrm5ca0cbUXgJY3clxeAAAAAAAAAC0W9eGLmYek1M0ASXJb//9ejUElEw3AZ25MJHbl67k3o2Rhg1AgiZLr5hTbfinaC8p3psr1GAmS0MAq/toYwIAAAAAAABguXRtA9D4+M01tRvovb07kySnho7n5I4rufXYWH7wwwdJki8e6UmSnNxxObceG0t+9kT2H+uvhoDKA/3VZy77P2SVmRnMmi3c4Ci25dEogDWTANby08YEAAAAAAAAwHLqygBQo+aM8kCyfmtfXj99NaO/S/Yfu5vk7tQn3q/7/OF9D5KsFfxpk3L5o/T27sxb587n4O5dKQ8s4BmCJ4s2W8ikaGCaK3yVmEG7aGMCAAAAAAAAYLl1PABUhH1mNv7M1Zxx5OL2vPvG2FQIqN7hfQ8yOLw2xTPb8qW/gWY2/8xs+Kmd15kLE3n5UH81KFQbRBHKWpzaOcwVMjk1dDwvH+qfNQQkaLL0tDEBAAAAAAAA0CkdDwAlU6GdVNpMksx7bE6SvPrOk7k++qMkSc+eSgPQ9dG9ufXZWAaH79pIXyIzQ1lFu8ymzdtyauh43vtj5b4zFybq5rZ+a1/dcwR/Fqc2+FMEq5Lptp9mmUN7aGMCAAAAAAAAoJO6IgBUa+YG+lyNGUcubs/JHZfr3nvzT79M0t+Or7bqNdPG9Na58+nt3Zly+aNs2rwtr58eysZnn37oWRuffToHDg8lEW5YjNkCWK02MAn+LD1tTCvLzBaz2ZhF+5gBAAAAAAAAtE9XBIB+fqAvT20byyfXfpXvfrohSRHkWbhSacukTcTWNdvG1Nu7M6eGjte9V7QAHXhuU11wyxya08pxeK00MAmYLC1tTCtLs0dLJq3PkOaYAQAAAAAAALRfxwNA4+M31/TsyeT10b1Jkuc/+HUuv/bjvHR176JCQO++8UT2H4sQ0CLM1ca0fmtfXj99NRuffTq3L11p2AJE6+YLYC2kgcn/A0tDG9PK0kroZK6mORbODAAAAAAAAGD5dDwAVOjZ836uj+5NPki2/+Zq3vvp9LViw/zejZG6ZpNGygP9uT66N7c+G2vn1121tDF1j7kCWK00MNE6bUwr10JDJ2azdMwAAAAAAAAAll/HA0Cl0nTbSc+e/twYTW59NpZPrt1JebgS/Ol95URO7rg8dc9IXeNJbdCneH3k4vbcvrQ2yd1l+lesDgtpYzq543JuPTaWH/zwQZLki0d66t7Pz57I/mPm0KxmA1gamNpPG9PKU/w+0TbTOWYAAAAAAAAAndHxAFCt9Vv70rNnJEUAZXD4brU948jF7VN3vV/XCFSu+bygydJopo2pVmXdi7V/v+7a4X0Pkqxt23ddTdp1HJ4GpsXTxtT9SqUtk2+dOz/nPbPNQvPM0jADAAAAAAAA6JyuCQDdvnQlSXJq6Hh69hxNMtXAMTySJHXNGg+eebP6+s93Pk6SrLt/Nu++oW1mMVppY+rZUzmO7cjF7Xn3jbGG616Z39oixCWE0qRWAlgamNpHG9PKUBw3NVfwZK4QluDJ4pkBAAAAAAAAdF7HA0Dj4zfXZKB/svj7ps2HUi5/lKTSrJFMh3/KA/3V8E8R/NnzfM/UJ3uy/9h0OGLjs09XPjfQL3iyAPO3MU03/bz6zpO5PvqjJJXwSpJcH92bW5+NZXBY+KRZzQawZoaAmmlg0gLUGm1M3a8Incx13NR87UuCJ4tjBgAAAAAAANA9Oh4ASlLd/CuVtkxOfHotmzZvS1JpA3r50NFq4OHzx19I7nxcCf38fc9DG44HnjufMxcmGh5TRfOaaWMqgihFOOvIxe05ueNy3XP2H7ub3ldOVJ9H8+YKYBVr30oD070bI8v6/VcLbUzdZylCJ4ngyWKYAQAAAAAAAHSfrggAFcbHb655+dDRyVNDx6vvFSGgJNn8t/+X0d89yJGLlWtnLkzUbT7WbjieGjqeTZu3VVuEmF+rbUwz3fpsrOFrbUytaeU4vEQDUztoY+o+zYRODu7e1fTzzKB1ZgAAAAAAAADdq6sCQMl0CKj2vc8ffyHr7p9N8nDTzJEL0/cV7/cMTL83FSCy4d6kltqYMh0EundjJOWa5xTtP9qYmtdKACuprHkzDUzVzwlgLYg2ps5qtm2mPNBf/e+9CNFtfPbp6meKgOjtS1fMoEVmAAAAAAAAAN2v6wJASX0I5d03nsiuwanAyY2pEFC2V++tCwNd3P7QcVNFgIXWNN/GdKJ6XRvT4rUSwCpCcYVGDUwCWIujjWl5FUGT8fGba1o5ZqoIYdWGTpLK/M6k8rPpwHObcubCRO3MBOIaMAMAAAAAAABYmboyADSf2g3GP/z1v9RcmQ6dvH76apKrD23Q0zxtTJ3TVADrzb3p2TN/A5MAVuu0MXXO4X0PMpjpI9gaBU9qA4aN1P6OmC2AooFmdmYAAAAAAAAAK8+KCQCtu3+2euxOkvz2tV9k34tvZ/S969X3hk//Uw7WHEnF0qi0MD1T/bs2puXRTADr+uj0tSMXZ87isgDWIjTbxtSINqalMTN4Ml/opFD8/BcAXTwzAAAAAAAAgJVhxQSAkspGYrEZue/Ft/O9DT+pu77vxbczfO58Du7eVQ0L3bsxEoGH9tHG1H4CWJ1THEO4/9DRNGpjKhpSkumAT6M2ptr2ID+P5vbzA315attYPrn2q3z30w1Jkjf/9MuG99aGqorASfGzvzKj/rrg6Eyl0haBuAbMAAAAAAAAAFaeFRUAKg/0p1w0mjz+Qv585+N8b8NPqn8mycHdu5JMb0TaWFx62pi6hwBW+xThn12DzySPP1M9fq2wfmtf3fq/de589dqZCxO5felK7t0YyfqtfTlweMj6N2F8/Oaanj2ZvD66N0ny/Ae/zuXXfpyXru6tC6AUoZP1W/vS93f/lqe2bcgn1+5kcHht3fPK5Y/S27tz1rWfui6AUsMMAAAAAAAAYGXq2gBQ3eb7lG99a02+/e3vVF7/1zv5+uvJ5P7ZrJv6+/e//Z3k0Ufy5ZdfCf4sgUYzKGhjar/Z1l8Aq/1KpS2TM9/7/PEXklj/5dCz5/1cH92bfJBs/83VvPfT6WvlgUqjTBEoeeqxP2T/sbtZv/Ufs37r9H0arxbHDAAAAAAAAGBl6doAUCOH+r7OU9v+JvuP3a1uxhfW3T+bf/6HL/LUtg3Zf+yrDn3D1aNR+GTd/bPV19qY2mu+9RfAap9i7ZNY/2VUhK6KYMmRi8mNox/m1mdj+eTanZSHK4Gq3ldOVJuXXnrs99l/7G7dc+7dGKk7cm2u46eYVht6MwMAAAAAAABYeboyADQz/FA0bvzrf3yYweGHwz9JpZ1jcPhsRv7zyTz66H+nVNriSJEFmi18sn5rX/7njx/W3fuXv/zvdDBiqo0p98/m+48+oo1pgeZb/y+//EoAq03ma12y/kuvCJ58/vgLdSGrpKaFJsng8N2HPzyHiU+vzXqtCK/09u5s6ZmrUe36JzEDAAAAAAAAWKG6ckO62IT/5NqdJMng8NpqI0F5oD+H9z1o+LmZ99lwb12ptGVy5vrWruvl37+apNLGVFwr2iBqw0HTbUx3zaEFC1n/2bz7xhPWvwWN1j6x/u00c82LtS4U4ani90Gj60VbU3H91NDxbNq8rdo8U9vWdObCRG5fupJ7N0aqv0cGh9d+Y2c018+bghkAAAAAAADAytCVG261R5Eshg3F1i3V2tcyh+ZZ/85px9on1n8u7VrzVn1TZ9Qt6598c2cAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQOf8P0Y8auF1/vfaAAAAAElFTkSuQmCC";
+const ASSET_MAGE   = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgAAAAFACAYAAADKyMQLAAAKKmlDQ1BzUkdCAABIiZ2Wd1RT2RaHz703vVCSEIqU0GtoUgJIDb1IkS4qMQkQSsCQACI2RFRwRFGRpggyKOCAo0ORsSKKhQFRsesEGUTUcXAUG5ZJZK0Z37x5782b3x/3fmufvc/dZ+991roAkPyDBcJMWAmADKFYFOHnxYiNi2dgBwEM8AADbADgcLOzQhb4RgKZAnzYjGyZE/gXvboOIPn7KtM/jMEA/5+UuVkiMQBQmIzn8vjZXBkXyTg9V5wlt0/JmLY0Tc4wSs4iWYIyVpNz8ixbfPaZZQ858zKEPBnLc87iZfDk3CfjjTkSvoyRYBkX5wj4uTK+JmODdEmGQMZv5LEZfE42ACiS3C7mc1NkbC1jkigygi3jeQDgSMlf8NIvWMzPE8sPxc7MWi4SJKeIGSZcU4aNkxOL4c/PTeeLxcwwDjeNI+Ix2JkZWRzhcgBmz/xZFHltGbIiO9g4OTgwbS1tvijUf138m5L3dpZehH/uGUQf+MP2V36ZDQCwpmW12fqHbWkVAF3rAVC7/YfNYC8AirK+dQ59cR66fF5SxOIsZyur3NxcSwGfaykv6O/6nw5/Q198z1K+3e/lYXjzkziSdDFDXjduZnqmRMTIzuJw+Qzmn4f4Hwf+dR4WEfwkvogvlEVEy6ZMIEyWtVvIE4gFmUKGQPifmvgPw/6k2bmWidr4EdCWWAKlIRpAfh4AKCoRIAl7ZCvQ730LxkcD+c2L0ZmYnfvPgv59V7hM/sgWJH+OY0dEMrgSUc7smvxaAjQgAEVAA+pAG+gDE8AEtsARuAAP4AMCQSiIBHFgMeCCFJABRCAXFIC1oBiUgq1gJ6gGdaARNIM2cBh0gWPgNDgHLoHLYATcAVIwDp6AKfAKzEAQhIXIEBVSh3QgQ8gcsoVYkBvkAwVDEVAclAglQ0JIAhVA66BSqByqhuqhZuhb6Ch0GroADUO3oFFoEvoVegcjMAmmwVqwEWwFs2BPOAiOhBfByfAyOB8ugrfAlXADfBDuhE/Dl+ARWAo/gacRgBAROqKLMBEWwkZCkXgkCREhq5ASpAJpQNqQHqQfuYpIkafIWxQGRUUxUEyUC8ofFYXiopahVqE2o6pRB1CdqD7UVdQoagr1EU1Ga6LN0c7oAHQsOhmdiy5GV6Cb0B3os+gR9Dj6FQaDoWOMMY4Yf0wcJhWzArMZsxvTjjmFGcaMYaaxWKw61hzrig3FcrBibDG2CnsQexJ7BTuOfYMj4nRwtjhfXDxOiCvEVeBacCdwV3ATuBm8Et4Q74wPxfPwy/Fl+EZ8D34IP46fISgTjAmuhEhCKmEtoZLQRjhLuEt4QSQS9YhOxHCigLiGWEk8RDxPHCW+JVFIZiQ2KYEkIW0h7SedIt0ivSCTyUZkD3I8WUzeQm4mnyHfJ79RoCpYKgQo8BRWK9QodCpcUXimiFc0VPRUXKyYr1iheERxSPGpEl7JSImtxFFapVSjdFTphtK0MlXZRjlUOUN5s3KL8gXlRxQsxYjiQ+FRiij7KGcoY1SEqk9lU7nUddRG6lnqOA1DM6YF0FJppbRvaIO0KRWKip1KtEqeSo3KcRUpHaEb0QPo6fQy+mH6dfo7VS1VT1W+6ibVNtUrqq/V5qh5qPHVStTa1UbU3qkz1H3U09S3qXep39NAaZhphGvkauzROKvxdA5tjssc7pySOYfn3NaENc00IzRXaO7THNCc1tLW8tPK0qrSOqP1VJuu7aGdqr1D+4T2pA5Vx01HoLND56TOY4YKw5ORzqhk9DGmdDV1/XUluvW6g7ozesZ6UXqFeu169/QJ+iz9JP0d+r36UwY6BiEGBQatBrcN8YYswxTDXYb9hq+NjI1ijDYYdRk9MlYzDjDON241vmtCNnE3WWbSYHLNFGPKMk0z3W162Qw2szdLMasxGzKHzR3MBea7zYct0BZOFkKLBosbTBLTk5nDbGWOWtItgy0LLbssn1kZWMVbbbPqt/pobW+dbt1ofceGYhNoU2jTY/OrrZkt17bG9tpc8lzfuavnds99bmdux7fbY3fTnmofYr/Bvtf+g4Ojg8ihzWHS0cAx0bHW8QaLxgpjbWadd0I7eTmtdjrm9NbZwVnsfNj5FxemS5pLi8ujecbz+PMa54256rlyXOtdpW4Mt0S3vW5Sd113jnuD+wMPfQ+eR5PHhKepZ6rnQc9nXtZeIq8Or9dsZ/ZK9ilvxNvPu8R70IfiE+VT7XPfV8832bfVd8rP3m+F3yl/tH+Q/zb/GwFaAdyA5oCpQMfAlYF9QaSgBUHVQQ+CzYJFwT0hcEhgyPaQu/MN5wvnd4WC0IDQ7aH3wozDloV9H44JDwuvCX8YYRNRENG/gLpgyYKWBa8ivSLLIu9EmURJonqjFaMTopujX8d4x5THSGOtYlfGXorTiBPEdcdj46Pjm+KnF/os3LlwPME+oTjh+iLjRXmLLizWWJy++PgSxSWcJUcS0YkxiS2J7zmhnAbO9NKApbVLp7hs7i7uE54Hbwdvku/KL+dPJLkmlSc9SnZN3p48meKeUpHyVMAWVAuep/qn1qW+TgtN25/2KT0mvT0Dl5GYcVRIEaYJ+zK1M/Myh7PMs4qzpMucl+1cNiUKEjVlQ9mLsrvFNNnP1IDERLJeMprjllOT8yY3OvdInnKeMG9gudnyTcsn8n3zv16BWsFd0VugW7C2YHSl58r6VdCqpat6V+uvLlo9vsZvzYG1hLVpa38otC4sL3y5LmZdT5FW0ZqisfV+61uLFYpFxTc2uGyo24jaKNg4uGnupqpNH0t4JRdLrUsrSt9v5m6++JXNV5VffdqStGWwzKFsz1bMVuHW69vctx0oVy7PLx/bHrK9cwdjR8mOlzuX7LxQYVdRt4uwS7JLWhlc2V1lULW16n11SvVIjVdNe61m7aba17t5u6/s8djTVqdVV1r3bq9g7816v/rOBqOGin2YfTn7HjZGN/Z/zfq6uUmjqbTpw37hfumBiAN9zY7NzS2aLWWtcKukdfJgwsHL33h/093GbKtvp7eXHgKHJIcef5v47fXDQYd7j7COtH1n+F1tB7WjpBPqXN451ZXSJe2O6x4+Gni0t8elp+N7y+/3H9M9VnNc5XjZCcKJohOfTuafnD6Vderp6eTTY71Leu+ciT1zrS+8b/Bs0Nnz53zPnen37D953vX8sQvOF45eZF3suuRwqXPAfqDjB/sfOgYdBjuHHIe6Lztd7hmeN3ziivuV01e9r567FnDt0sj8keHrUddv3ki4Ib3Ju/noVvqt57dzbs/cWXMXfbfkntK9ivua9xt+NP2xXeogPT7qPTrwYMGDO2PcsSc/Zf/0frzoIflhxYTORPMj20fHJn0nLz9e+Hj8SdaTmafFPyv/XPvM5Nl3v3j8MjAVOzX+XPT806+bX6i/2P/S7mXvdNj0/VcZr2Zel7xRf3PgLett/7uYdxMzue+x7ys/mH7o+Rj08e6njE+ffgP3hPP7l7FYAQAAIABJREFUeJzsvX+QVNWd//3qUYkGejL6ABuHUqG0xO9G+3YIlMIs9hMqKrAUg6vjjkCoSorKt4gus7XJMob8QOLKMv7xVIZo5huLx1SUDBS4EYhhIFiacXYQv/ije7AspESGVDl8l/AozPBLWec+f9w+t8+9fW9Pz3Dv0Ofe86qiaG7/4L7POZ8f5+cFjUaj0Wg0Go1Go9FoNBqNRqPRaDQajUaj0Wg0Go1Go9FoNBqNRqPRaDQajQYAw0iZ4g+AaZoYRooH7lyNaZqYpnm5bzEwhB5Zm6zfMFKm1q/1R1W/Ri2uDPoHRWN+8K4f8+L+JwFIpw1HC89mc4l02uCWqxfYn0kkEkHfymVB63fqT6cN81TtYqqnzKb/aBcGmOm0QS7Xk7jlzgWX+W7DQ2gHEPoB+o92ye0hGpXugdYfT/3l+L88iTj4P6hs/x/4/ypns34GUNPXDsAtVy9IXO4CCBqt36l/sK7N83NV3SsAyOV6oiE8j9AvJz5eyO0gSmWg9Wv9Ai//B07t2WwuAdH1f1DZ/j+0BCDuBqD1O3v+XuUQpTIQ0xu5XE/CMFLmqdrFjvf99Oc2LyeTmaP1a/2R0g/Fgd+NsH/Vtcuo5v+rgvohMb+VSCRs8WAJ7T/aVfT56imzOVW7mM7OV+3GozJx1y/w0u/+u2vdVLYuXM9Hbed4Z8eiyJTByWQGw0iZJ5MZ+5owcj/9yVMbtH6tP1L6T9UuZij/B5YPjIp2Vf1/YJmHaPjjBzo5mcxwZXISYBmAKAzRG8xtXs7x/d/h1tu+DsBAzUrls2Ctv9CI3foBnnn6KQBuv2M6gEP/tPrt9u+oXgbC+Y8f6HS8V65+GdXKQuvX+oX+K5OTbNsv1//JqKpdNf8f2CJAa+gHuwGIyhevLQMY4PY7lhd9V1S+OxNSqRHEXT9YgV8g65d57+BbLFmXpXrKY7Azf7HuPvt9gxX2UGJ4dxoOog2I1wAP3LmaDy+8bNerl/7+2i8D8FHbOcfvTavHVKkctH6tX+hnoFAGBpjl+L93diyyr6mqXTX/H/h/IM8FQcEARAYM5A3AuSgEvAxgu3KBIM765Qbs1u/OgsXfXvz3wMeMH+hUSnsp5DlhL/2i3m9c+qnje3/ZdK1ybcALrT+++kv5P7EQWAR+Wb+q2lXz/6NSuHE2AIiHftM0PVeyiqExMSTmFfjdDR+sslApCRiJ/t1N3QA0Nh9zfEceRtb6tf4w7zsM3EHQz/9tXbgegG/922SgMG0i9Kvk/0pRyf4/sCmAIQ3Adb3/aJdtANPqLQMYn39PNAAh3jU0ksjleoK67cCIu/5S2mVk5+c1ByobPyxiWj3uBTIVr9+9HkJGrne34xefF45QdqDyf6X1a/2Vhtv/NTUM0op1327/Z+nvLgr84rPi2rR6lPF/flS6/w8sAQjLAAwjZd783T9x2+SJHOo9wZHn7jWpwAM04q7fjbvnI5C1d3b+xp7/6ux8lUxmjq19Wn3hOyrqb2oY5Ke7vwngKIPdTd12vQvN8mt3r0/V+tf646Vf9n+5XE+ilZTZ1DCYv/IaM6dPyb/2DvwCr+RHBf0yKvn/wE8CFARlAAC3TZ5Ic8akhYkcCeuGAybO+g3DMv613U7d4Gz08spf8dqt3TBSpmr6hQN8ouE1AMn5DV8/qFf/Wn+89UOhDCAfBHcX3hMBzsv/RUW/Kv4/lAQgaAM41HuCFqwMSAWG0i/mg4yHN1KTv+7eBiOjmn6A1m1VrGnYBFj6Rb27D0hx7xYwjFTR6l8V9csOsHVboc1r/fHWPxJU1A9yL75oGg/w9v9eqKZfpfgX6lCK1wEHQzkA8O4Frm2cxZot+5RaEFJKv3w0pKB6ymyyq/YULfyIin5rVGApEA/9AlEOWn889YM8KrbUcT3K/k8mjvpViH+hTQFA8SIWqwFY7wkHcEr6fMEBqLUH1A9Z/67lM5i/8QC7m7p5aOdj9mfcR0UePvQu2edXkl62Qfky8NTfYjWAh3ZaumX9WxeuZ1r9scjol9H6463fTRz8XynioF+F+BdqAiAzEgcwWvcWJoaRMrPPrwRgFzC/+QBbW6ztL3IikF21h8OH3qWx+RjZ54lMGXjpB+wyEDsBwFoNu2v5DEDr1/qjoR8KAWDm9Cnsnt7N3NY6+71SHYDRvcvwGGkH4LLcbEhUqv7QswzZAfS9/gbzN1oOYEvLTYDbAWxn1/IZ1N490772o5/9AoCO3iqlhn8Esv70sg2O97a03OS5FU4ugyjqP1W72PekQND6tf5o6xe+D5z+Dyw/ID4P0dIfd/9fifpHbQQAsMWfql1MY7NwAMeKPrMLHIVw4vR5YOzo3GSAiMwXLONv+jxJ65gB+29rQYilf7CujaruFeRyPYn5GzHZeMB2BFHTv6b3D7SOsTR3rZsKwOzVH2j9Wn+k9Psxt7VOSoCKFwj2vf5GJPyfm7j5fzeVqD+wpwF64eUAANb0/gGwHEBn56t0dr6KeG685QAOkF62gfSyDXT0VrHwvnvCvM1Q+eUrb9pZHMBL7c/ar2X9MrlcTyKX60lEXb8fWr/WHwX9cfd/Wn/l6w99BOCXr7wJr7yJyDVean+WPz/4A8BaAfzewYH866y9Jc69AjjsewwbOYO7YdJX7et++gUep0Apidav9cdVf9z9n9Zf2fpHZQrAzwE8PGYTM284l3/9ezrCHZC4LHT0VgFjueevV8FXnO9p/Vq/1h9t/RBv/wdafyXrDz0BKOUAuk4muXvJXgD6jV9T1bvC8b5hpMxnv38f3/vVHiUXgACW7jzvn77ACzOX8P7pCzBB69f6tf6o64+7/9P6K1t/6AlAKQdw5sxZAK64IkF17ocwbqznSWAqs3fCRee/uQgTrNdav9YPWn+U9cfd/2n9la0/9ASglAOQn/wURcQc5mBdG5/0bGH8QCfjxllDQWfOnNX6tX5A64+qfoi3/wOtv9L1hzrpIDKZd3Yssvc9fuPas8y6fhwAT8x9jSfmWuclT73qBKlkceJz/JOBMG9xVMiu2sMrP+kFnDq1fq1f64+u/rj7P62/8vWPykFAw/2O+whFlYeEtH6tf7jf0fq1fvm7Wr/WH/R9aTQajUaj0Wg0Go1Go9FoNBqNRqPRaDTlYpompmnywJ2r7deGkTLlP/lrjs9oNBr10favFqP6MKC4Ii8EyeV6EqZpkk4b3HL1Al7c/yQAiUS01nm8uP9J0mnDBOvhF+Kxl/1Hu+zrjMIi1NFGOLMH7/qxXbeSXgCy2Vwi6vWvKaDtX9u/x0cTlVD/kauAy427AaTThikMoP9ol/0UsFyuJ/HAnasvewMIGqFf1u2FuyxG7QZDRu7N+DlAofuWqxckolb/cUfbv7Z/gZf9g1N7NptLgE4AIoO7AYinPLmp6raOfYxK45e3rBhGyjxVu9jxvpcj6D/aRW7zcjKZOZEph7g7wLij7T+e9u/WD8WB343wAZdTe+AHAek5IAsRAMCqaDeDdW2cql1sl81o318YnExmMIyUKU64AuwgJ8qg/2gXXeumsnXhej5qO0fy1AY6O19V/qlfoh4TiURR3XvVf/WU2ZyqXRwJ7TLl2H/+j7Z/bf+RsX8o6D9Vu5ih7B8sH3C5tQeeeeghUPDKgAF7GDC3eTnH93+HW2/7OgADNSsjkwX7HW/5zNNPAXD7HdMBHPqn1W/3/D2VykNoHz/QyclkhiuTkwDLAYq2EPX6B/WGQMNA23/87B+c+q9MTrLbeLn2LzNa2kNbBCgPgVZL16unzGYwXxAf9rWb6fTLylW0F3IWdzKZsQtWNALLAAa4/Y7lRd8Vla/6gzCs4S8cp1c9cOdqPrzwsl027x18iyXrslRPeQx2Wtf6a78MwEdt5xy/N60eZcpDaBcOQNS7eF1u/bt/M8RbDhRx74lEomgItNr1WdkHpNOGMnVcCm3/4di/679I5HI9od3/pSLrZ0A60Q/Mcur/nR2L7Guj5fsC+w/0HJBz6EtkwKI8RAYM5A3Ae24oanOD4OwRiSxY/A0Fw79x6aeO7/1l07VMq9+uVFm4j+8UDrBU/bvLQaCSdnkExK/360XXuqmRtn+Btv+R2//f/zzLod4THHnuXuXKpZT9i7oWgV/WP1q+L9AEIO5DoO7tPlBoAKUMwM1/D3zM+IFOpcrDNE3PYVzRLkR7kHXvbuoGoLH5mOM78jCiSmXgR1wSIBWHQIMkDPt3jQpVbA84LPv/+59nac6YtHQm+OPP0kq0C3cnwM/+ty5cD8C3/m0yUEgahX5h/xKB139gUwBxHwLNG0DR/X544WVTHhIUyMbv7vnBtdy4NINhqDMELkt3D4fK9B/t8jV88Xl59CSUmw2BIR2g67pcDtPqrXIYn39PlJlKwR/UHAINirDs/+bv/onbJk8UPWCTCt25FYb9AxzqPUELln6VaGoYpBWrHNz1b+nvLgr84rPi2rR6CLv+A10DEOc54FLOX0bOfr0WwcjZHyxyz4NVbA/ATVPDID/d/U0AO/sHS7cw/M7OV23nL17LvX5Vej8QXgKkUhlAcdKWt3/737L9VzWXGALdsUjbP4uYVn8vv+l8lxYmciSkew+DIOwfgOfuNZc1zuKPW/Ypkwzncj2JVlJmU8Ng/sprzJw+Jf/aO/AL3LZ/2+SJ1ghISPU/KgUalyFQGffQl0B2/l4G4IWKc2CGUTCAQuP3DnoycvB3Zb/KaR+JAwT1yyDoIVAVNLvR9n9p9i9+w+89FRD3704CRTv3qn+3/rDtP7AfC3MOWLVekGj8a7uX2tdK9fpk3A1AxTkwgdf+VvcCMXmqSCDqXFXtQncQDlDFMhDtv3WbdcyI2/79Ar/4rHwtzvYvfmtt4yzWKNQDFozU/gXZ51fyo5/9AoCO3irl9AuGs89/tOs/sCmAMIdAVZkHk2ndVsWahk2AFQCE1qEMwL0VSNU5MMNImYN1bXzSs8WuT8spWu+LVdCnpO9UT5lNdtUee9pDRe1CN0DrthX5vwvtPA71H8QQqPiduNu/yrin8oT9y2fCyOVRsP/tZJ9faV8/cfo8MHY0bz1QvEbCBJe7/kM7ByCwOSAg7HmQoBH3LxaBiABQvgFYc5+5XE9CxTkwOfgLdi2fwfyNB9jd0s1DOx+zr4uysHqF3faCOBW1u3Vfl08ExHaf4SRAKtc/FJIAyHcCdhfeKzUEKr4r/1Yc7V/+vTVb9o3SnQePYaTMXctnAEj2b+mXt0LK9i8+n162AahibeM9vK14GcDwO0CCMOs/lARAGP8TDa8B/kOg8pyXn/GDmr0gcA5fOgNgsQGAZQTT6o+RfX4l6WUblOwJeAV/gNq7Z5K9eybpZRvY2rLevl5YCGW1i13LZ1BrfU6po0G9dIvX43HWv4X1t9APcPiQ+vUvU+j5FB3oAsTH/ssJgOC0f4E8BK4ahpEys8+vpO/1N+xrjc3HSto/WOXExgNe0z/K4VX/gG8SNNr1H9oIgNwDuJQhUJV7QSIoVHWvGDIAHj70Lo3NhexXBIHLcuMjxC/4u3FO/VivRTkBDoehAuXoluvfiXMaTOX6L4Wo37jZv3Dmfa+/YSWBzQeGtP++19+g9u6Z9mdUHAKXtc/feMC+fqp2MY3Ncp077V+l+h0Kv/oH7DYgdwDE6Mdo1n9oCQD4zwFBeUOgYd5b2DjmwF3veQVAwfyNB9iFFTDmTbbmUFVcAOQmvWwDu5bPEIGNps+TtI4ZsP8WzN94gF3LZ0RKuxfC4XV2vgrA7NUfUNW9IhL17+61Ca1xs3/533IQHMr+AbA/r94QuNzrLbJ118FwXeumAlb7jzL+SdDlrf9QEwAZ9xDoUEMgUer9AI6szh38OjtftQNALteTmL8RM5v/rIrZvx+/fOVNeOVNxEMoX2p/lj8/+AMg/4CY/OfmbzzAvMlqaB+q9y/mu4vqv3sFTZ8nyWTm2EkAoGz9ywFvS8tN9vWHdj5GVfeKyNu/11C1bxAcM2A/J0EOgF49YFWHwEvZuqD/aBfvHRzIv87a9u/m+uuSId5pOJSTBFVC/YeeAMjDILugrCEQwJ4HEXMgKvWCvIJCKYN47+BbDgPI5XoSlgNUK/vP5XoSBivM60oERDmg3TDpq/b1h8dsomucZeipZIKO3jNKaR+KKNa/X9Cf21oHYJ93HnX7N4yUKfQ3Nh+zRzyGCoLlBkBVKWXrYk77kUetnvDDkwfpCP7p9JcVFep/1EYAoDC8MdQQiBgCFajSCxoKP4OYecM+Hh7zezqosudAVV0AI5KAv+xYxG83/R7A3g9uGf1Y7vnrVfAV5/e6Thay/M8u/Bcq1Xd21R4OH+q1/y22ubmJYv2/s2MRhw+9awf9UkTR/kXwt5Oeuscco1l+dS7WPsy8wToETdS/Fyr2gEvZekdvFePGjXVdO1uxCd6lUOn1H2oC4DcMsqb3D7SOseYGvYZA5m/EVHkOzItSBnH3kr1AknHjrH+rvhc4l+tJWFtZCg36nr9e5fjM+6cv8MLMJbx/+gJMgDNnztrvvV2hzt4P9/PMX2kpvG5stv6OYv2LerbOPSicbS+G9cXQP0TT/g0jZb6zYxHpp+6jOr/RST7jv1SdiwA4rX4748aNpd/4NVW9K0bpzsNDJK2yvbttHQr2/o1rz/Klq/+GfWf8f/P4JwP+b1YwKtR/6CMAQ837eg2BlDoOUlVKGYQwBjkrNoyU+ez37+N7v9qjZGZcdM8e9biXi7ZDcNe5Ktq97q+x2bntrdzkR8X6FyM+1fkzD6Bw7gFE3/6n1W+niu2O3Q2idzdUEBScP38uEivgRUIkdjTICFsX5VTT127pNVImlIj+VPb0TylUqP9RmQIoNRdUzhCIasjD4IcPvQvc5GsQ9ueNlDn1qhNDZsOqoqIBj5SRJD8q179o7/K/oRC8o2r/jkQFivS7612uc7mu75w4ln3H/StdpR6wGA2T14TIiKkfUUZD+QWV/cbeCRed/67A+g89ARhq3tca/sRzCESVXpAXhWHw0p9xvC4jG9aoRzltV/X699MYF/v3uj+/ezaMlPn2p2MRdV3K+YM6PWD5Ht2jYF6fiTrv2B1AJ43Nx6iU+g89AShn6PuKKxJU534I48YqM/9ZDsPV4R76VCnzD5o4ao9i/cfZ/v0Yjj5Vy0LV+w4S99ogN2V3DEIk9ASg1DCI+8lfGieqZP5hEGftgiiUQSn7d08VaDRRQRW7Df0kQPfCEHvV5/EzPDHXelZA67Yq/OY/o9ALGgmqNKAwiLN2QRTKwOtQE9n+ZbT9azSjT+hOZiTZvbtnEAVnqNHEHbcv8BsB0Pav0Wg0Go1Go9FoNBqNRqPRaDQajUaj0Wg0Go1Go9FoNBqNRqPRaDQajUaj0Wg0Go1Go9EEi2mamKbJA3eutl8bRsqU/+SvOT4TFeKuX6OBoe1AfCZqdlCO/ef/REq3IO7+TzX9oZ0E+OL+J0mnDROsR0CKZ4T3H+2yrzMKBxFdLuKqXzTmB+/6MS/ufxJA1gtANptLpNMGt1y9wP5MIqF+UcRZux8fXnjZTKdfBgp20H+0CwPMdNogl+tJ3HLngst8l8GRSCQwTdNR/7L9g+UDavrazQ8vvAw8GcnKj6v/E6iiP/AbEE7Qq+HL5I0AiNZJX1p/Id75GYDQfcvVCxJRCoJx1u5G9PLF89+97CDqNhBHHxBn7aCe/sD+Y/nYTsNImcLwBX4OILd5OZnMHOUbQdz1C1QzgCCJs3ZwHukrHvR1ZXKS4zOlEgHVy8J9pLHsA0rZP6C8D4i7/1NVf1WQP3YymcEwUqYwfsB2dP1Hu+y/u9ZNZevC9XzUdo7kqQ10dr4aiSeCxVm/mN9KJBJ2AARLr9AuUz1lNqdqF2vtimt3czKZQW7/bvzs4J0diyJRFkK7uwxK2T8QibYQZ/8HauoPNOuQxbsf8fvM008BcPsd0wE4vv873Hrb1wH/5yarlhXGWb/QPn6gk5PJjN3zq+lrdwwDi6xX1j9Qs1LpXkCctbsZypHFxQ7A6QOirhvi7f9ATf2BLgK0hj9wPMHrgTtX8+GFl22n8N7Bt1iyLkv1lMdgp3Wtv/bLAHzUds7xe9PqMVVqBHHWL7QLAxCZr3htGcAAt9+xvOi7mcwcwP+pcJVOnLW78bvvcu3AbQOgph2I1+CsWy/d1N1n9xBl/Srphnj7P1BT/6gUrjwnInpC4m8oCL9x6aeO7/1l07VMq9+urDMUxEm/+xGuwgBEBgzkDcC5Khq8DEBrD/+uR49SdhAlG3AzlP2Dtw+IgnaIl//z4lL1u0jkcj2B3VtgIwCmaXquZhbDIu7/qP9oF7ubugGYVn8MgPH590RPSlS+q3cUaAEERVj6xW9QobrduI31P95ch2GkWLIuC1Ay+BUZwI5FSvUC4qxdMFw72LpwPVBsA2DZwY1LP3VcU41S9g94+gBh/yppD9P/y78l/URF+cMw/f/N3/0Tt02eyKHeExx57l6TADvugSUAsniv1cACWXhj87Gi3xFzqVBYURlmAQRFGPpV0C0o1wCquldQA9DXzu6Wm4DyHUClUo72mr526GunBjiFt+MH9bS7KVkO0o4AEfi9bACK/UAItxoqwgf4LQb08wHuOWRVtIfl/+XfrGR/GGb8u23yRJozJi1M5EjA9x3aQUBNDYP8dPc3rf9EMvzdTd228M7OV+05UPF6/EBnUaMPswDC4lL1h13xQVOOAdT0tTuSmsbme4t+R0XHP5R2t+4jz91LY3Px76iofSjcwd/L+ZXrB1TD8gHFWyGFD+jsfBUo1g3q13+Q/l+gkj8MUv+h3hO0YPmOoAmtkRlGymxqGARg5vQp9nW/jF/gFu+R+SlhHJeqX1XdUNDuNoCavnb+/udZy4g7E/zxZ2n7O7IxqKLTCy/tXrq9jB/U1u7GywaGav8C1cvBz/6hdBmorlsQlP+Xf08lfxikfsNImWsbZ7Fmy77ANYdagF5bgtwHJMgrpgVeSUBYBRAml6pfVd3g7/zdRuxGNZ1euLWXoxuioV2m1JbAkfgB1SjH/qFYu+q6BUH5f/Fbwhf6fabSUCH+hTYFAMXbYJoaBllrjQDaC6JOSZ+vnjKb7Ko9Si5+8iLO+nO5nkQrlu7WbYWs98hz93IEWNs4izWX6+ZCxkt7HHS78XJkUJ4d7P4fzwEzzEn/9P8OaQeyo60ku/HaBrimbhNru5c6FoTK2j9qO1e2/VeqbkFY/q8StXpxKfpH6x5DTQBkdi2fwfyNB9jdYpXAQzutApANYevC9UyrP0b2+ZWkl21Q/mQomZHqX7NlnwgayiUF3gawFIA1W9qRM3qALS030disnk4v/LR76YZoaS+FbAcP7XzMvi7sYOvC9TQ2t1P7P1cCYBgHhvQD8ugKz91bkWW4a/kMAMkHFPTL2ofj/1TQLbhU/6/qSKhguPoFP/rZLwBC0x56AmAYKVMI2gXMbz4AwNYWaxWwOA0JrBXRwlDEd8IugLAJQv/+/f9JwKc2jzpuA2hshv37/5N5k+Hff/7PAKSXbbiMdxgesnY/3Y3Nx5Rs3+XiZQfCBgDpVDRrxMSrLaxtnOX52/+7gheHybr7Xn8DKMwDb21Z7zgNrjHfO3RrV1G3ICj/ryoj0d/3+hvU3j3Tvn7i9HlgbCj3N2ojAGBlv2DNgzQ2i7mPY0Wf2QWjVgBhIlc+xE8/+BuAwNJmkX1+JX2vv8H8jdHoCZfSHmXdQyHswLkgynrtF+zASpxOnD7P2586beHm74a3SjpIZPuv6WvP64++bsGl+D9VO4Ay5eoHQPxNFWsb7+Ft14hhUISaABhGyhQZXXrZBpo+T9I6ZoA1vX+gdQwM1rXRtW4qALNXf0BV9wpyuZ7E/I2Yo1UAYeGlnTFYZdDXzmBdG0Bk9UPpBKimr52O3ipgrN3jEeUVBfy0A5HW7YWfHxB/y35A7Ibwxiq3okDw3L2m1AOumCBRrv/LZOYUTQk5UUu3IM7+H0au3/0bYd5j6CMAv3zlTXjlTcQQ9kvtz/LnB38AWIcivHdwIP86ax0QQ/EBEGHfY1gMpR2IrP7hJECZzBzWNs5i/kZ1VviWoqT2fMAD61CkKOkuRbl+QCSHwymLSi63cnQ/8/RTLFmXjZRuwaX4f5V3QQlGon80GZUpAHkI+4ZJX7WvPzxmEzNvOJd//Xs6FJ/n9qKUdmBI/blcT2INmCouBBxOAiRQSV8pytEuG3xUdJcirn4grroFWv/I9BtGynz2+/fxvV/tCc0/hJ4AiOHOe/56FXzF+V7XySR3L9kLQL/xa6p6VzjeH40CCJOhtAMl9ctcf10yrNsMlXISoHd2LGJa/XZldzv4MZR2Jqu9y2M4XIofUJm46haMVL/qvl9Q6fUfegJwz1+vsl+/f/oCL8xcwvunL8AEOHPmLABXXJGgOvdDGDcWw0hFxhGWox2iq384CVDUKEe7xVniQClbOH/+HNdcYz0S1WseVGXi7P9gZPoBRPBXnUqv/9ATgL0TLjr/zUWYYL12P/giapTSDtHXP5wEaNy4sUMshFKLUtrBafxR0u1HKVv44gsll7mURZz9H4xc//FPrKlB1ZOhS61/UQ5hEeqki6i8d3YsYkv+yW/fuPYss64fB8ATc1/jibmvATD1qhOkksV1HXYBhEUu15MIQr9AtXLI5XoSeydcRP7TOmaAvRMu2vqbGgZpahjkiy9Mpl51wr6uOqW0f+Pas3Y9NzUM8ug/fAFY7WLF3Fmmqos+/TCMlOnX/kX9w9DtX0WCtH8VuRT9Ki/8EwRR/2GXQ+gFPBKH5j5FTeWGcCn63b+hYjkEoV9ltH6tf7jf0fq1/jDuRaPRaDQajUaj0Wg0Go1Go9FoNBqNRqPRaDQajUaj0Wg0Go1Go9FoNBqNRqPRaDQaTbwxTRPTNHngztX2a8NImfKf/DXHZ6JC3PVrNDC0HYjPRM0OyrH//J9I6RbE3f+ppj+0o4Bf3P8k6bRhgvWIz+o7RcXZAAAgAElEQVQpswHrSWjiOhX4DOugiKt+0ZgfvOvHvLj/SQBZLwDZbC6RThvccvUC+zOJhPpFEWftfnx44WUznX4ZKNhB/9EuDDDTaYNcridxy50LLvNdBkcikcA0TUf9y/YPlg+o6Ws3P7zwMvBkJCs/rv5PoIr+wG9AOEGvhi+TNwIgWicfaf2FeOdnAEL3LVcvSEQpCMZZuxvRyz9VuxjA0w6ibgNx9AFx1g7q6Q/sP5aPqzWMlCkMX+DnAHKbl5PJzFG+EcRdv0A1AwiSOGsH57Gn4kEnVyYnOT5TKhFQvSzcx77KPqCU/QPK+4C4+z9V9Qf6MKCTyQyGkTKF8QO2o+s/2mX/3bVuKlsXruejtnMkT22gs/PVEZ2ZXGnEWb+Y30okEnYABEuv0C5TPWU2p2oXa+2Ka3dzMplBbv9u/OzgnR2LIlEWQru7DErZPxCJthBn/wdq6g8065DFux9x+MzTTwFw+x3TATi+/zvcetvXAZhWv93z91TLCuOsX2gfP9DJyWTG7vnV9LU7hoFF1ivrH6hZqXQvIM7a3QzlyOJiB+D0AVHXDfH2f6Cm/kAXAVrDHzieXPfAnav58MLLtlN47+BbLFmXpXrKY7DTutZf+2UAPmo75/i9afWYKjWCOOsX2oUBiMxXvLYMYIDb71he9N1MZg5QHDy0dvXwu+9y7cBtA6CmHYjX4KxbL93U3Wf3EGX9KumGePs/UFP/qBSuPCciekLibygIv3Hpp47v/WXTtUyr366sMxTESb/70cXCAEQGDOQNwLkqGrwMQGsP/65Hj1J2ECUbcDOU/YO3D4iCdoiX//PiUvWfv7/DvnbNS/MSuVxPYPcW2AiAaZqeq5nFsIj7P+o/2sXupm4AptUfA2B8/j3RkxKV7+odBVoAQRGG/gU3/Su12X+lFswja/s5/PikijcEt7H+x5vrMIwUS9ZlAUoGvyID2LFIqV5AnLULhmsHWxeuB4ptACw7uHHpp45rqlHK/gFPHyDsXyXtYfp/8Z155oAdB/rSdRUVB8LSf/7+Dm6/9gpumzyRQ70neO/+DpNccHEgFOcy1GpgIbyx+VjRd8VcKhRWVN783T/ZBXDkuXsrPiMMQn9ttptrNpy1dZ9fOZZKTgKGNIC8/r/d9Yj93pG1/YUPvuv83tn/bz3jBzorvq6hPO1FuvN6r+md5/iOPIeogvZycLcBKG0DUOwHwr/LYBE+wG83hJ9+9xyyytrh0v2/uD7PHDC3ccL+XAMT6UgkK7JsgtR/6+Mfmw9+/XqaMyYtnQlefPd4oDEg0F0AMk0Ng77iG5uP0dh8jM7OV+3r4rVwfHLl3zZ5Is0Zk9smTwzrdgPnUvWDWrrlACifeiWviP3bXY+wjRP2n5vXVBd+4Ov5P3nG/l+PKeP8htLuqTuv9fzkwvCeMP4oB//dTd0OGwDK9gOq0dQwCHgH/8bmY1x/12/sa7LuqGgPyv+rSJD6D/WeoKUzwaHeQgIUFKEVsmGkTGEAM6dPsa/7ZfwCd8WrOAIAl65/njlgqjQCICO0/3T3NwEcvX93Fu8YBQDHSMDhHZWv1Y2Xdl/dea3/+7dfshcDqtC2y8XLBrzav0iC5NEQ1cvBz/6htA9QXbcgKP8vUGkEAILVf+vjHxemwN8N1i+GWoBeW4LcByTIK6YFXknA2sZZrNmyTykDuVT98pyXKsFf4GUA/3Jfe+QTACjW7qvbNQ2gUtsuh1JbAoUdfGnMt32/r2r9C8qxfyj2AVFpB0H5f7CC4M1rqtnGCdt+Kt0fBqX/1vpCAhC0TYT2LAAo3gbT1DDIWmv6w14QdUr6fPWU2WRX7VFy8ZMXl6q/L12HSHwOK1YeuVxPohVLd+u2fNbbXEdDttv+TKk1ACo7/yLtXrp91gBECa9EHpx24MvX4VY+NuVpIYCb11TbPT8RFGQqqVfotQ1wTd0m1nYvdSwIlX3AR23nPP2fHQSk8pC1V5JuQZD+/5qX5nGEDqZxNeDqNFQol6Lf8UO98+w4EDShJgAyu5bPYP7GA+xusUrgoZ1WAciGsHXheqbVHyP7/ErSyzYofzKUzEj1r9myz6p81EuKPA1g/jOAlfk+5WrUW1puorH5WCR6QG7tDU/OZG330oLuXqcxW9rVq+PhItvBQzsfA3r57OPJzg99HStB8gj+R9b2FwV+x+iKOWBWYjDctXwGgOQDhP6CD/Dzf/Y6EVfwV0G34FL9/9rGWazaT6EMXB2GSme4+gU/+tkvAEIb/Q49ATCMlCkE7QLmNx8AYGuLtf1HnIYE1nYIYSjiO2EXQNgEoX///v8kxPWao4LbABqbYf/+/2TeZPj3n/8zAOllGy7jHYaHrN1Pd1QSHz+87EDYABTs4H80/c8hf8sv+Fcisu6+198ACvPAW1vWO06Da8z3DqNkB0H5f7BGy85TWDSrAiPR3/f6G9TePdO+fuL0eWBsKPc3aiMAYGW/YM2DNDaLuY9jRZ/ZBaNWAGEiVz7ETz/4G4DA0maRfX4lfa+/wfyN0egJl9IeZd1DIezAuSDKev1UYz6g3wWr9v+0aBTATQMTKz4JEMj2X9PXntdv6V7bOMv3e6v25194jIqoxKX4P9EBvHWyNTyu4hRhufoBEH9TxdrGe3g7hOF/CDkBMIyUKTK69LINNH2epHXMAGt6/0DrGBisa6Nr3VQAZq/+gKruFeRyPYn5GzFHqwDCwks7Y7DKoK+dwbo2gMjqh9IJUE1fOx29VcBYu8cjyisK+GkHIq3bCz8/IP6W/YDYDQFwDfOgt/A7fS/BNcCRfC9QjAQ0UNgm25euq5jAUK7/y2TmlJzfvYZ5hWmAfBJwZG0/DWsqU7cgDP+vUuAfqX73b4R5j6GPAPzylTfhlTcRQ9gvtT/Lnx/8AWCdhvTewYH86yw1+e/IhaDyU6KG0g5EVv9wEqBMZg5rG2cxf6Nl5Kr3gktqzwc8gKruFZHSXYpy/YBIDkuWRc7aVnr48VBvORDK0f3M00+xZF22tO6cdJbADuuvqOi3Xhf7P1V3f8mMRP9oMipTAPIQ9g2Tvmpff3jMJmbecC7/+vd0KD7P7UUp7cCQ+nO5nsQaMFVcCDicBEigkr5SlKNdNvio6C5FXP1AXHULtP6R6TeMlPns9+/je7/aE5p/CD0BEMOd9/z1KviK872uk0nuXrIXgH7j11T1rnC8PxoFECZDaQdK6pe5/rpkWLcZKuUkQO/sWMS0+u3K7nbwYyjtTFZ7l8dwuBQ/oDJx1S0YqX7Vfb+g0us/9ATgnr9eZb9+//QFXpi5hPdPX4AJcObMWQCuuCJBde6HMG4shpGKjCMsRztEV/9wEqCoUY52i7PEgVK2cP78Oa65xnokqtc8qMrE2f/ByPQDiOCvOpVe/6EnAHsnXHT+m4swwXrtfvBF1CilHaKvfzgJ0LhxY0M56OJyUUo7OI0/Srr9KGULX3yh5DKXsoiz/4OR6z/+iTU1qHoydKn1L8ohLEKddBGV986ORWxpuQmAb1x7llnXjwPgibmv8cTc1wCYetUJUh7nWIRdAGEhP9DhUvQLVCuHXK4nsXfCReQ/rWMG2Dvhoq2/qWGQpoZBvvjCZOpVJ+zrqlNK+zeuPWvXc1PDII/+wxeA1S5WzJ1lqrro0w/DSJl+7V/UPwzd/lUkSPtXkUvRr/LCP0EQ9R92OYRewCNxaO5T1FRuCJei3/0bKpZDEPpVRuvX+of7Ha1f6w/jXjQajUaj0Wg0Go1Go9FoNBqNRqPRaDQajUaj0Wg0Go1Go9FoNBqNRqPRqEzg2w1M09r18OBdP+bF/U8CkE4bjq0Q2WwukU4b3HL1AvsziUThVlxbJxK5XE/Qtxka5ejPk4iDfh/tEBP9oNu/1q/t34NY6IfKbv+hnQQoV/6p2sVUT5kNWA9CkQqkKAExjJR583f/xG2TJ3Ko9wRHnrvX9PpcpVNKP0BNX7v54YWXgSeL9vxHSb+sXdB/tIuavnZPXSrrF8YP8OGFl810+mVAt3+tX9u/jLb/ymn/oSUAcuVXS9erp8xmcMps+o928WFfu5lOv1x08MFtkyfSnDFpYSJHwrrBkCmlH7DLwKsxRE2/m+opszkFkat/OdM/VbsYQLd/rV/bvwtt/5XT/gNPAEQhnExmuJJCxutuCKIR5DYvJ5OZ43gAwqHeE7RgZUCqIIZtEolEwjBSpmgAfvoFnZ2vAjjKIEr6/Yhi/Z9MZrgyOclxPS7tX6DtX9u/tv8Cld7+AxlakOcsxAMOREHU9LU7sqH+o13kNi/n+P7vcOttXwdgoGYlmcwcxxHAaxtnKXUetGgA4wc6kRuCW3/XuqkARfoBuwyipB+cjT+K9S+0C2Ttw23/wpZU0y9ea/vX9q/tXx37D2wEwF0ANX3t9r9r+tp55umngAFuv2N50XczmTnAyM5NrhSsysNuCH76vRD6Qd0y8NIv94Kqp8ym7WHv+heoqN1t/OMHOouqWZSFn365/b+zYxHT6reHes9hoO1f27+2f/XsP7Dswl15InN54M7VfHjhZdMyAIsl67JFWSHAR23nABwFoEIGKON+cI9b/4rN1rPghVHISAuE7Gsq65fbhFz/t98xndmrPwAKmmVU0u/X7gVe7V+0ASjd9r1+r1LR9m+h7V/bv/zvSrf/USlceU5IDIOIv6Eg/salnzJ+oJN5k61HhHb0VlV8AxgK93yYvBrUvTJYlMOPm34PREM/FMpArnM3QjtEU/8zTz/lcP4Cue0DkWv/oO1f27+2/0q1/8CmAEzTdOxlFNiLI1zX+492sbupG4Bp9ccAGC+9f+L0eWBsULcXOl767eGhgY8Ba2hUrny/7G/e5GjoB2f9u41f1D8U2gBEU/+SdVnH9VJtH6KnX9u/tn9t/wUqxf4DSwD8DjKQ50fAafiNzcfwoqO3CpUqH0oe5ABQtDoUihuBIEr63fUPRL7+Be75QRhaO6ivX9u/tn/xWtt/Zdt/VVg/3NQwWLQiGKwCaGw+RmPzMXsLDOB4DdYqSJVpahikqWGQJ+a+VqRf/Ln+rt/YDSGK+kX9v/KTXofuONS/bPyi/mXtQKT1a/vX9q/tv/LtP5SDgHK5nkQrKfOJhtcAmDl9iv2enPnIq1/F613LZzB/44EwbmvUEPrFv3e3FIa6nJlftPWL+m9s9s4zo1r/hpEymxoGAWf7d2f9mcwce6W08fBGqF3sWAClKtr+tf1r+1fD/kM7CVA2gtZtBeHuAyL8BF9/XdLzuirIizcamyk6IQqsBUFV3Ss8v6+yfjEE2LrNf4BJXhQGFJWDyvrdAUBu/wK3fpu8PaisH7T9a/vX9i/+Xcn2H1oCAAUjEA2iqWGQtflkWAg/JX3+o7ZzSu6BduO3n7WpYZCZ07uZ21pXOBK0rg2w5kajoh/grc6dvHnwkP3vRx5dVeT8ZQbr2siu2hMZ/XIAkNuDuwzEavCtC9cD0NhNZND270Tbv7b/SrP/wBMAWax7L2jrtip7OOyhnZYByBnQ4UPrg76dUccwUuZbnTsBbAN45NFVgKW/ddsxdrcAdPPQzscc3z186N3RvNVQEPU9PbPQdgJCf01fO1tabgJgbmsdANlVe+zvRsX43QFAbg+yI6yeMjuvf4+9EMxtM6qh7V/bP2j7l/9dyfYfaAIgN36A6ZmFjn+/efAQjfnGsLXFMnZxHCI4V8Me/8T71KxKRuifnlkIWBUvDAEKDUDMBW1tWR85/eLAC2H0jzy6yqFf1L/lBItXQAsDUFU/FAxedoKCZ55+ikceXZV3hN22/lOu+T9V9Wv71/YP2v5BDfsP9CTAps+teYtbn/1p0fuHv/cE75++AMDeCRd9f0fOgFQ6BGI4+rcZDb7zf1HS/8ijq+wTwPzq/5mnn3KcDCaXier6ZUrpB+t0sKruFZGqfxlt/9r+tf1Xnv2HchSwKAiZ1jGFjEacCiUejAEwe/UHdgEEdU+jidY/PP1gPQlLRuUyGIn+361Oc/sd0wG1tYNu/1q/tn/xWiX7D2wKQL7xViNlfuPaswBM/Mo1/NO37uQ+YP7GA56NPwqUq1/mvYNvAdiNQGWGq1/M/YoyAKjqXqWk8cPI6l+m7eEBlhxdjAGmimWg7V/bv3it7V8d+w/tHABERvQpdLiE9x/t4r2DA65rWahV1wHK+OkXj8sEcSxmGrCMoP9olprLcrfBU65+dxuICuXo96J6ymx7G5DKaPvX9q/tXw37D93QDCNlDta18UnPFsB62IGcHT3Z+g+A9QCIqDz8QeDWDvHR76UdSuvf/PlSavraI1MGEO/2D/HWr+1f23+lt/9QzwFwM36gk8G6Ng4A1bkf8sFJuHvJXgD6jV9T1et9KEbUOPC3zwNWGWj9e/NXk9ScUb/3K+PnBONa/9r+LeJa/wJt/5VT/6M6AjB+oJMrrrD+yy++KGx1vOKKBNdc82UAzpw5G9kMMG76vbLfuOj36/3FRb8gzu0f4q1f23/l239oDwMC/wxIcDKZ4WQy4yiMOKH1R1t/dtUeXvlJr+/7Udev7b80Wn+09atg/6FPAWRX7eHwoV4AGpshXX2GL139N+w7foYn5loPS2jdVsXUq05Y18+EfUejjyiDOOqPc/2Lk81eyR96Ejf9EO/6F2j77wXiV/8q2H+oQw0jPdIwCkNAgpGUQVT06/q3GG45REW/rn9t/yP5XlT0C+Jq/xqNRqPRaDQajUaj0Wg0Go1Go9FoNBqNmzPmkWguD9ZoNEOi7V8TC3RD13gxzxzQ7SIGaPvXeBF7+7/18Y/jXQAxIvaNXVOEtv/4oO3/8hD4dgPTtOrxwbt+zIv7nwQgnTYclZvN5hLptMEtVy+wP5NIFG5Fbgx96bpELtcT9G2GRjn68ySG0n9kUT/X9M5TWr+PdihDP0Sz/v3a/62Pf2wefnxSIq76BVHXn0fbf0zrv5LsP7QEAArCxSNAwXoKVE3+iUe3XL0g4W4At9Z/bL6z/YL9Gw1MpCORVGZfZDn6AbsMstlcAgr655kD5jZO2L+hun5Zu0C0Aa/6V1m/V93D8Nq/yvpB27+2f23/oI79h3YSoFz51dL16imzGZwym/6jXXzY126m0y+Ty/Uk5pkDZkcimbh5ezVQcABHFvWHdYuhUko/YJeB1FASQw15njGPmOMSNythDH7GD1YZnAJH/Yv3jizqh+3FvyfaR5j3fKm4jR4oq/13Z1+CEsm46BmEdd9hoO1f27+2/8q3/8ATAFEIJ5MZrqSQ8bobgmgEuc3LyWTmmB2JpKcB3Ly9msMVXe0W4rSnRCKRMIyUKRqAn35BZ+erAGQyc8zc45MSvPux6WUAAJVs/H76/ZDr/8qvnLYdmzsACCrd+A0jZZ5MZrgyOclxvZz2X5eeU9LBqRT8tf1r+9f2X6DS7T+QH5aPOjyZzADYBVHT1+7IhvqPdpHbvJzj+7/Drbd9HYCBmpVkMnPsTHCeOWAeWdTPzdurK77iBaIBjB/oRG4Ibv1d66YCFOkH7DKQ54BU1w/Oxl9u/YvPH1nUz+EdlR0AhXaBrH247d8wUmZtttv+vgr1r+1f27+2fzXtP7ARAHcBiHkOsArhmaefAga4/Y7lRd/NZOYABUfSl67jqcZZrEnvC+r2QseqPOyG4KffC6EfrDLoS9extnEWa7ZY+lUYAvbSL/eCqqfMpu1h7/oXyPUv9B+u8HOx3cY/fqCzqJpFWfjpl9v/OzsWMS1dx/n7O7jmpXmh3nuQaPvX9q/tXz37D6xw3Q88ENncA3eu5sMLL5uWAVgsWZctygoBPmo7BxSeoiT/jgpzQFAoBz/9KzYngYJRyLgXCMm/owqyfrlNyPV/+x3Tmb36A6CgWaamr53abDd96bqK1+/X7gVe7V+0ASjd9r1+r1LR9m+h7V/bv/zvSrf/USlceU5IDIOIv6Eg/salnzJ+oJN5kwcB6OitqvgGMBTu+TB5Nah7ZbAohx83/Z6fbN9BXfp+5fVDoQzkOncjtIOlH6JR/2Dpf+bppxzOXyC3faBk+1dpEZiMtn9t/9r+K9P+A5sCME3TsZdTYC+OAL5057fhRC9gFcLuJmuuY1r9MQDGS987cfo8MDao2wsdL/328NDAx4A1NCpXvl/2N28yrPzmvaio3z1cKde/2/hF/UOhDYClPwr1DwX9S9ZlHddLtX3w1l/JwV/bv7Z/bf/q2X9gCYAs3mtREMBnb77AZxTENzYXKl2mo7cKlSof/PULrkxO4ktjvs1nn79gX3M3AoHK+g8/PinhV/+CKNf/rfUfm2LRknt+EIbWDmrrB23/2v61/YMa9l8V1g83NQzalT/2W48BVg9gd1M39fv/F43Nx+wtMIDjNcDaxllh3VqoiBWsTQ2DNDUM8sTc1+xVoZ99/gK7m7rtP9ff9Ru7IaiuX2zhuvXxj81cridx/v4Ou/5f+UmvQ3dj87HI1r+X8Yv6/9tdj9jagUjqF2j71/av7b/y7T+0IUXDSJlNDdZcxszpU+zrpTIfgF3LZzB/4wF7FahKc0DiFKcGJtKXrrOvb2m5yX4dZf0ycv23bis/z4yCflk7WO3/X+5rx6ttuPdLiwVgKusHbf/a/rX9CyrZ/gM/CEgsVMjlehKtWENBrdusRn/+/g4+q33B8Xl5xavM9dclPa9XMh2JZKLBY7VyYzNFJ0SBtSCoqnuF52+pqB+sHoDYvuI2/O7sS9Sl7wecJ2UBReWgqn6wVu6Ktg/59t9cR0N+ZTMU67fJ24Oq+rX9a/vX9q+O/QeeAMgLFUT2IuaEHrvyPtayFCgIPyV996O2c0XbIFSjI5FMeM0BgjUsOHN6N3Nb6wpHgta1AdYCmSjoF3OAb3Xu5M2Dh+zrjzy6iq/N3wY+J4QN1rWRXbVHef0COXOX9ze7M36xGnzrwvUANHajNNr+tf1r+1fH/gNPAOTG794L2rqtit0tlsKHdloGIGdAhw+tD/p2Rh3R+AHbAB55dBVg6W/ddozdLQDdPLTzMcd3Dx96dzRvNRREfU/PLEQ4AaG/pq/dHg6d22plwtlVe+zvRsX43QFAbg+PPLrKkf1b+vfYC8HcNqMa2v61/YO2f/nflWz/gSYAcuMHmJ5Z6Pj3mwcP0ZhvDFtbLGMXxyGCczXs8U+8T82qZIT+6ZmFgFXxwhCg0ADEPODWlvWR0y8OvBBG/8ijqxz6Rf1bTrB4BbQwAFX1Q8HgZScoeObpp3jk0VV5R9ht6z9Vu9gxHK6qfm3/2v5B2z+oYf+BngTY9Lk1b3Hrsz8tev/w957g/dPWQx72Trjo+ztyBqTSApDh6N9mNPjO/0VJ/yOPrrJPAPOr/2eefspxMphcJqrrlymlH6zTwaq6V0Sq/mW0/Wv71/ZfefYfylHAoiBkWscUMhpxKpR4MAbA7NUf2AUQ1D2NJlr/8PSD9SQsGZXLYCT6f7c6ze13TAfU1g66/Wv92v7Fa5XsP7ApAPnGW42U+Y1rzwIw8SvX8E/fupP7gPkbD3g2/ihQrn6Z9w6+BWA3ApUZrn4x9yvKAKCqe5WSxg8jq3+ZtocHWHJ0MQaYKpaBtn9t/+K1tn917D/wRYCQLwyREX0KHS7h/Ue7eO/ggOtaFmrVdYAyfvrF4zJBHIuZBiwj6D+apeay3G3wlKvf3QaiQjn6vaieMtveBqQy2v61/Wv7V8P+Qzc0w0iZg3VtfNKzBbAediBnR0+2/gNgPQAiKg9/ELi1Q3z0e2mH0vo3f76Umr72yJQBxLv9Q7z1a/vX9l/p7T+UEQA/xg90MljXxgGgOvdDPjgJdy/ZC0C/8Wuqer0PxYgaB/72ecAqA61/b/5qkpoz6vd+ZfycYFzrX9u/RVzrX6Dtv3Lqf1RHAMYPdHLFFdZ/+cUXha2OV1yR4JprvgzAmTNnI5sBxk2/V/YbF/1+vb+46BfEuf1DvPVr+698+w/tYUDgnwEJTiYznExmHIURJ7T+aOvPrtrDKz/p9X0/6vq1/ZdG64+2fhXsP/QpgOyqPRw+1AtAYzOkq8/wpav/hn3Hz/DE3NcA64SsqVedsK6fCfuORh9RBnHUH+f6FyebvZI/9CRu+iHe9S/Q9t8LxK/+VbD/UIcaRnqkYRSGgAQjKYOo6Nf1bzHccoiKfl3/2v5H8r2o6BfE1f41Gk3MME0T0zR54M7V9mvDSJnyn/w1x2c0Gs3oM6q7ADSaOCACWiJRSOTdvYCoZ/kv7n+SdNowoXDyHVj7v8V1RmER8mgj6v7Bu37Mi/ufBJD1ApDN5hLptMEtVy+wPyO3FY1mtNCtThM6cQl+7jO8Zd1+zz+/5eoFiSgFAREA02nDlAO/m/6jXfbDT6LUHuTRDL8ESOiOWt1r1EO3Ok3gyEEAcDwD2/UQlESUekGGkTLl077cz/52B0MRDLLZXALU1i8nP4aRMofSDpb+3OblZDJzIpMExD0B0qiFbngh4NULcBPFYcDhBAHZAUYhAApEEgBwZXKS4z2/IBiF08/k5OdkMmNrr+lrd4x+iKB/fP937EfhDtSsVD4J0AmQRkX0GoAQEb0AQRzmQU8mMxgG5slkpmTjqp4ym8F8QEinDeXPfxdYAQCrbgeKRwHcVE+ZzSlQ/gx8oVskP/KzzWv62vOPPR3g9juWF303k5kDqD9V5NX2RQLUf7TLOwE6tYHOzlfJZOYoXf8aNdENLkBK9QJK9f7Ed0bpNkNF7gGPH+gsGv73Iiq9YC/kdlBKPxCJMnCvg3jgztV8eOFlUzz3HGDJumzRaBDAR23nHL8l9lGrUibuti8j9Isn/8kjIEKnG1V0a9Ql8AYW51WwfsOggrgEQL9EKA4B0AvDSNkBcMXm4meF9x/t4ner0zzy6CrH9aiUhbsNyL1hKAT+G5d+6vjeXzZd6xUcE7lcT9i3PGLinAAJyokBeSK1BkhFQksAIJ6rYL16AboXHM8AKA9pl+oBDtSs5GsL1nJdqhGwyuO/Bz5m/ECnMmVgmqanDQt7EN6PezkAACAASURBVMmwHPh3N3UD0Nh8zPEdt/3c/N0/cdvkiRzqPcGR5+5VpkwEcUqAYOgYANFdA6RaBzi0NQDyKthq6bo89/thX7uZTr+snEGXQp4DtreDgVkIAFOB4gDw3sEBHnm03RE0VC8XrxOwutZ56//agrVcV9cGFAKgYag7L24YKbOpYZCf7v4m4wc6WbIuC8DvVheSABkR/AVXJidxKrlYmbUBfmceiGAu6D/a5Rv4xedF4BcjSLdNnkhzxqSFiRwJ5e4vnSETINd1uRym1VvlMD7/nigzEfxdCZBJhU7dinpPJBIJ8dorBkB01wAJVDkHI7AEwF35IuMVWa675ysWP+VXwUaqAZTS8t7BtzwDwD/+6I9cKY0U6ACoVgCUkbWD5dCFoa3YnITNHwCPwU7xjQ/s7wp7AatnOK1+VG45cGT98lTY7qZuO/DnF785XnuNehzqPUELVgCsVOKeAAnEQkh51NMvBohrnRGMAap0gAP7j+O+DcgPORMG7yHAUqg4LeAOgIBjCNgPd3lYAXC78vqvTE4qqRuKAz+gpHaBKAOAmdOn2Ne9gp6Ml17DSJlrG2exZss+JcrDq/4FQyVA4CwDw0iZKk2BuLfBimH+cmOATCXrdKPqNtDARgD0NiAnQottDK73/YJ/8UKg4O/tcjHUIkBw6lc1AOZyPYlWUuYTDa/ZQaCcZE8O/OJ3wrvLYPGa7mndVpX/uxD03Y5R9hPid1TS7YVc/+CfAMkBzyv42/9+7l5zWeMs/qhAAuTeBls8DVo6BryzY5F9bVq9WqN/Km4DDXQNgNf8t1gFKz7z3sG38qtgC0Og/bVfBjyDn1INQODVAxa4A8Hupm47CwZrIZC8hUhF/e4AKHpAXkHQrV9e9KSidoFcBnIA8MK9HUw13YaRMps+LyzubB0z4Pm5poZB1lqj33YyeEp6v3rKbLKr9jCtHuWeDqQToALu+8/HAPvfcgyoarZOBRWBX14I+Zcdi5SJAap2gANfBOi+6f94cx2GkbLngEttfylaBatQAyiFewhQxuoRFBzEeNQLAF6UGwDd+qOgXSDKQA4A3gz1vnrMm2wN///7z/8ZgL7X32D+xgPsbrHa/0M7LT8g+4OtC9czrf4Y2edX2td+9LNfAFT08L9OgIqRh8RLxYAtLTcBBd8vOj8nkxluXPqpUjFAxQ5wYAlAWKtgxZyK9NWK3wZT7hCg33dDvblRpPwAWCAKPaBSuOdzZQbr2uwAoHIZNH2epLXXCoL/jhX8AXYtn8H85gMAbG1ZD+Aa/TnGruUz6Hv9DWrvnmlfP3H6PDB2dG4+IOKUAPnR1DBIK4WpUDkGWL6/m2/922TAeXCSvA10Wn3xmgjpZyouFoTRAXb9F4FqDiwBCHMVrCrbYGRE8AP/IUD38B/oABiFAOjFruUzmL/xAKVWdFd1r+D//GHGZbm/S+X90xcc/76Hq9g74SLpZRuKPnuqdjGNzaLtO33A/I1WgoD4myrWNt7D21v2BXzH4aEToIL/EwtBQR4J9A78Ar8p0EqOBapuAw3tHIAgtwGptA1Gxv1YWDEEKAK/OxjqAKhuACwXeUvb2sZZgNW7Ez1GOwAqRC7Xk8BjDhysId65rXX2v0XbH8yf+SDOhZi9+gOqulcU2b7X3HolohOgYuRO0MlkBnYX3vMK/O7vel2v1Fgwkg7w9Xf9pij+jfY20FASgCBXwYIa+4CHQgTAGtq556+Wc3BXbFX3CnvVf1RHAqIYAIdisK6N+RtXsGv5DH75yrf4Y6+1OGxN/v21jbPYuWdv/vU9rNmyr+hI2UrH7z4bmzFrPNY4iOHP9w4O5P+dpSbE+wsTvwTI7fyhEPiilgD5UegEea9r8OoElmrzqsSCcjrAUBz/RvscjNBGAMoZAoehV8Gqtg3GjWGkzF3LZ1B790yyd8/kX+e12e8NFQwhGklAHALgUJxMZpi/sROosq/d89erAKvOxRDv21v2sbZxFtdfZy0q+96vULocvALaw2M22f+eeYM1//nwmN/TIZWN+Oyz37+P7/1qT8Xrl0f7trTcZA9xy8i93iglQOXgN4/v1QksxbJzj7PmZ/uKfrOSKNUBnttaB7XFI2KlfivM+Bfq44D9hsBh6FWwlVq5IyW9bAPzJg9y5Qzo6K2y5gmfu9ce0vENhhQyZ5XLJK4B0M24cZbOM2fOArB3wkXHtVyuJyHX+bPfv4/jnwywRsETEf3Y/PlS64S03A+5e4nV1vuNX1PVu+Iy39mlk8v1JBqbMZ9oOOrYBix6dlFNgMrF65CckWyFrPTy8OsAi+BfKfEv1ARARgyBl7sKNr1sg9JDXzLysLZY0PP+6Qs0fSXJt9/4HS/MXGJvHYp6MCwnAC7K9dhJYxQDoGDvhIue12Wdos6jgGGkzHHjxjKufwfn92/mzBeWtCuuSFCd+yGMGxuJqS/h/MfjvZgtyglQKcT5KCPpBKp2GiQ4O8B2/GuqrPgXegJgGClTbGvZBWWtggXsrTAqb4MRDNa18UnPFjp6O5FX875/+gIvzFxiLSCaYF1za4xyb9AvAEKhHKIUAAGmXnWCL139N+w7YyVDZ86cdVxzE4V6hkLwF3zxhVk0QghWmchJwPFPvPfUVzp+RxrHIQHywhEEY9QJrPT4N2ojAFDoCQ+1CnYXKL8Nxg8x7A1WANzLRTv4exG13mBcA6Dg7U/HApZQMQoiX4syqWSCzy78F29/OtZRr2Jo/BvXni1qByon/jJxS4BkKj0IjhaVGP9CTQBE1gfWHHjT50laxwywpvcPtI6xesZeq2Dnb8SMwjYYL+Rer+wQBKV6ACo3fkGcA6DXqnDwXvkbRfYdPwOM9dRaWEl/xnktQsQlASq1c6ESg2BYqBD/Qh8B+OUrb8IrbyIWf73U/ix/fvAHgLUS1msVbImTn5RHnu8WAVC+HmXiGgCzq/bw202v+b4vzoyPMuXUb5TbAMQjATKMlPnOjkX8dtPvad1WhdgBJQIgY/IHJfW1+wZAw0iZ8zcesM9CWNv4d0omQlD58W9UpgDk7O2GSV+1rz88ZlPJVbBRRB7ulo+8LDUMrjpxD4DWiV7R1qgpTZwSoPRT9/FJz6eMp7PiA+BoUMnxL/QEoKO3ChhrzX1/xfle18lkyVWwUdkGk121h8OHemlsdg53PzHXCoqt26oiPQwe5wCocrvVaIZLLteTMFhhXlfXBt3WLoiRBsAo+P9Kj3+hJwDyojf3qncxBB71VbDyI25l5J5v1DQLoqpLo9F4I5IAuLQAGAUqPf6FngC4t3rJq97lIfCoogOgRqOJG2Iuf6QBUPXev1gL4e78VVr8C/0kQFEQhw+9S2PzMeyVrsfPOIbA/ebAo7ANRqPRaOKG1zMS5AAob4P08v+q+36vkV85/smB/3LFv9Azq5Es4nDvj1UxA9RoNBpNAXcs8DoHQVyPou8fjn75epTKQKPRRBjTNDFNkwfuXG2/NoyUKf/JX3N8RqPRjD6jehKgRhMHREDze0Y4RD+rf3H/k6TThgnWoS/iuNf+o132dUZhBHK0EXX/4F0/5sX9TwLIegHIZnOJdNrglqsX2J+R24pGM1roVqcJnbgEP/eQnaxbPAFNBMKqbmvF8y1XL0hEKQiIAJhOG6Yc+N30H+2ynwIXpfYgj2b4JUBCd9TqXqMeutVpAkcOAlAIfmAFQBH8gESUekGGkTJPJjP24h73Y0/dwVAEg2w2lwC19cvJj9cjX70Sgf6jXeQ2LyeTmROZJCDuCZBGLXTDCwGvXoCbKA4DDicIyA4wCgFQIJIAgCuTkxzv+QXBmr525YOAnPycTGZs7TV97Y7RDxH0j+//jv0QmIGalconAToB0qiIXgMQIqIXIIjDPOjJZAbDwDyZzJRsXNVTZjOYDwjptBGZw5+sAJB/auNA8SiAm+opszkFGIo/4lnoFsmPSO7E62eefgoY4PY7lhd9N5OZA6g/VeTV9kUC1H+0yzsBOrWBzs5XyWTmKF3/GjXRDS5ASvUCSvX+xHdG6TZDRe4Bjx/oLBr+9yIqvWAv5HZQSj8QiTJwr4N44M7VfHjhZdNKACyWrMsWjQYBfNR2zvFbYh+1KmXibvsyQv/td0wHcIyA+J0UqopujboE3sDivArWbxhUEJcA6JcIxSEAemEYKTsArticLHq//2gXv1ud5pFHVzmuR6Us3G1A7g1DIfDfuPRTx/f+sulaptVvpzbbbV/rS9clcrmeUbrz4RPnBEhQTgzIE6k1QCoSWgIA8VwF69UL0L3geAZAeUi7VA9woGYlX1uwlutSjYBVHv898LFSj0k2TdPThoU9iGRYDvy7m6zA3tjsfB68bD+12W62ccJ+r4GJdCSSSpSJ4FITIBcVnQDB0DEAorsGSLUOcGhrAORVsNXSdXnu98O+djOdflkZJ1cO8hywvR0MzEIAsJ5/7Q4A7x0c4JFH2x1BQ/Vy8ToFUjz/2zMA1rUBhQBoGOrOixtGymxqGOSnu7/J+IFOlqzLAvC71YUkQEYEf8GVyUmcSi5WZm2A35kHIpgL+o92+QZ+8XmROOdyPYlaUOKUoCETINd1uRym1VvlMD7/nigzEfxv/u6fuG3yRA71nuDIc/eaVOjUraj3RCJhn+TnFQMgumuABKqcgxFYAuCufJHxiizX3fMVi5/yq2Aj1QBKaXnv4FueAeAff/RHrpRGCnQAVCsAysjawXLowtBWbE7C5g+Ax2Cn+MYH9neFvYDVM5xWPyq3HDiyfnkqbHdTtx3484vfHK9VGvWQCSsBMoyUedvkiTRnTFqYyJFQ7j44xEJIedTTLwaIa50RjAGqdIAD+4/jvg3IDzkTBu8hwFKoOC3gDoCAYwjYD3d5WAFwu/L6r0xOKqkbigM/oKR2gSgDgJnTp9jXvYKejJfeeeaAHVBVGP73qn/BUAkQOMvAMFKmawSgotuEexusGOYvNwbIVLJON6puAw30P9WrYAuIBuHeEz5U4PdaCKRaOfglAEMtAgSnfhW1C+QycC8G9UMO/KBW+y/3oV9uxyhvFxS4dRtGylzbOIs1W/YpUyZBJkCq6feaxpTXAZWKAe/sWGT/jkr2r2oHONA1AF7z32IVrPjMewffyq+CLQyB9td+GfAKfuoN/4J3ABS4g//upm67IYC1EEhOnlTUn8v1JFpJmU80vOYIgF6Jj1u/nAyqqF0gl4EcALxwO0HVdBtGymz6vLC4s3WM9yNMmxoGWZtf0C+SwVPS+9VTZpNdtYdp9WrM+8t4JUCt26ryfxeC/lAJkGGklPR5Mu77z8cA+99yDKhqtk4FFYFfXgj5lx2LlIkBqp6DEfgiQPdN/8eb6zCMlD0HXGr7S9EqWIUaQCncQ4AA9fv/V/7vb8N+671rXprHeNQLAF74BcB/ua9gGP/PnsX5HtExx/dG8z7DRJSBHABcW9ryr0r3ClVk3mSr9/vvP/9nAPpef4P5Gw+wu8XS/9BOyw/I/mDrwvVMqz9G9vmV9rUf/ewXABXd+9UJUDHykHipGLCl5Sag4PtF5+dkMsONSz9VKgao2AEO7MfD2gYkPxta3HOlb4OB0kOA5+/v4JqX5hV95/z9HRx+fFLFN/ThINddbbZbCnrF/xaoYOzl4tbv3tIm6x+sa8sHAHWGPqE4AEIhCGafX0nf62/Y1+dvPAAUHL979GfX8hkA1N49E7ASgBOnz/P2p2Mrtky8EgC/BEjofmjnY0W/s3XhehqbvROgjt6qitXvhfB/YhTEHQO2LlwPwLf+bTLgnDJ2TyO710RI/40ysaBSt4EGNgIQ5ipYVbbByIjeHziHAM/f38Fnb77AZ7WLi4b/rnlpHrc+/rEZtSQACsHeUZfpOkcSUAiAamT8w2HX8hkUD/45qepewf/5w4xRuZ+gef/0Bce/7+Eq9k64SHrZhqLPnqpdTGOzaPtOHyASBMTfVLG28R7e3rIv4DsOj6bPk7T2WgnQv4OdAO1aPoP5zZaurS1WAHQmQMfYtXwGfa+/YSdAACdOnwfGjs7NB4Twf6ITBPJIYLdn4Bf4TYFWcixQdRtoaOcABLkNSKVtMDLux8I2NQyy/r8L80Pu1b2D+X3wUZgH9KNUXaocAEeKWNwleox2AFSIXK4ngc8iwC0tNzG3tTDKIdq+aOviXIjZqz+gqnuF5wLAcO46WHQCVIzcCTqZzMDuwntegd/9Xa/rlRoLRtIBvv6u3xTFv9HeBhpKAiDP/4L/Klh524fXFhjBod4TtGAFSlXZtXyGZdz3wz1/tZyDu2KrulfA/R1AdJMAv7pUOQAOxWBdG/M3rmAX/0zDo7+wr/el61iDlQTs3LMXgLWN97Bmy76iI2UrHb/7bGzGrPFY4yCGP987OJD/d5aaEO8vTPwSILfzh0Lgi1oC5EehE+S9rsGrE1iqzasSC8rpAENx/PPqAIepObQRAL8h8OGugs3lehI8d6+5rHEWf6zghUB+GEbK3LV8BrV3zyR790ymvlR4T67YtY2zAFj1WSEYQjSSgMG6Nvryw/1H0nV2FiuG/6MQAIfiZDLD/I2dsLHQG77nr1cB1gI3McT79pZ9rG2cxfXXWXPK3/sVSpeDV0B7eMwm+98zb7DmPx8e83s6qML92We/fx/f+9Weitcvj/ZtabnJHuKWkXu9UUqAysFvHt+rE1iKZeceZ83P9hX9ZiVRqgM8t7UOaotHxEr9VpjxL9THAXsNgZe7CrZSK3ekpJdtsAL71+exd8JFa57wuXvtYLhGfPB+MeeXD4bSUagql8nJZAbySYDga5P+b77GVZEOgG7GjbN0njlzFoC9Ey46ruVyPQm5zp/9/n0c/2SANQqeiOjH5s+XWiek5X7I3UusxK/f+DVVvSsu851dOrlcT6KxGfOJhqOObcDyguYoJkDl4nVIzki2QlZ6efh1gEXwr5T4F2oCICOGwMvdBpRetkHpoS8ZeVj77/58N/95/+u8/+xCmr6S5Ntv/I4XZi6hdcyAvTvg7QgHw/6/uxewgt3X8vOk7gC4KNdjJ41RDICCvRMuel6XdYo6jwKGkTLHjRvLuP4dnN+/mTNfWNKuuCJBde6HMG5sJKa+hPMfj/ditignQKUQOwNG0glU7TAkcHaA7fjXVFnxL/QEwDBSptjWsgvKWgUL2FthVNgHPBSDdW180rOFjt5OYCzXvDSPnd/rYCew/hfAP24FrF0Abo1R7g36BUAoGE+UAiDA1KtO8KWr/4Z9Z6zRgDNnzjquuYlCPUMh+Au++MIsGiEEq0zkJOD4J9576isdvxP94pAAeeEIgjHqBFZ6/Bu1EQAo9ISHWgW7C5TfBuOHmPfl2YUlA6Agar3BuAZAwdufjgUsoWIaQL4WZVLJBJ9d+K+iPf1iaPwb154tagcqJ/4ycUuAZCo9CI4WlRj/Qk0ARNYH1hx40+dJWscMsKb3D7SOsXrGXqtg52/EjMI2GC/koC87BEGpHoDKjV8Q5wDotSocvFf+RpF9x88A3gf6FFbSn3FeixBxSYBK7VyoxCAYFirEv9BHAH75ypvwypuQX+DyUvuz/PnBHwDWSlivVbAlTn5SHnm+WwRA+XqUiWsAzK7aw283veb7vjgtLcqUU79RbgMQjwTIMFLmOzsW8dtNv6d1WxViB5QIgIzJH5TU1+4bAA0jZc7feMA+C2Ft498pmQhB5ce/UZkCkLO3GyZ91b7+8JhNJVfBRhF5uFs+8rLUMLjqxD0AWid6RVujm1vrPzYP74jeiZYjJU4JUPqp+/ik51PG01nxAXA0qOT4F3oC0NFbBYy15r6/4nyv62Sy5CrYqGyDya7aw+FDvTQ2O4e7n5hrBcXWbVWRHgaPZQDMH+mscru9FEYa/HXiYKFqOeRyPQmDFeZ1dW3Qbe2CGGkAjIL/r/T4F3oCYC96wzou84WZS6xjMycU5oCjvgrW44EOgLPnGzXN88wBsyORjG8AHOHzHKL6LAgoL6iJ96NSDkNp9ntfxeAvEEkAXFoAjAKVHv9CTwDcK933chEmWK/dT32KEmfMI+a4xM2xDYAdieSIdIvEIej7qQTKCWri/aiUg6zZK6j5lUkUgj8MHchVDvSlEHP5Iw2Aqvf+xVoId+ev0uJfqOOyouLe2bHIfgzmN649y6zrxwHWELgYBp961QlSHv5O1W0w4xI3j6jRnjGPKD/n5cc8c2BIbSLoRaUcZM1eQc2vTKIQ/GHoQB6VQK8pJpfrSeydcBH5T+uYAbtTmMv1JHK5nsQXX5ie/l9V3y/wGvmV49/4gU47+F+u+Be68Y1kEYd7f6yKGaAXYlTgct/HaDKU5jiWiUYTR9yxwOscBHE9ar4fhqdfvh6lMtBoNBqNRqPRaDQajUaj0Wg0Go1Go9FoNBqNRqPRaDQajUaj0Wg0Go1GM1L09oKAMU1rR0ciUShav20eGo1Go9FcLgI/CVAEwAfv+jEv7n8SgHTacATAbDaXSKcNbrl6gf0ZOWCqiAjyibwQOeifql0MQPWU2dZn88dk3nL1gkRU9AtE/UNxvQuiWP8Q37av0WjUJLSjgF/c/6Tt/E7VLraDX//RLtkpRsrznUxmMAxszTJCP1jPge4/2sWHfe0mPBmpMhD8/+2dcWwU153HP2uDLwmsY3LAtaC0WK0a1CY7rgPKGUTcIkGDG8W5S2gdSJFaoUo0Ef4jEQRyhaMoKFRXKSZtrUZW/iDBoCRNkzQYKCipYxmCTHpegxCcGmwqxVEJSozXEASJ5/6YfbNvZmfXi9lZ9q1/Hwl5d2dnme97M+/3fb/35k1NjWXrZTAR6l8xEc99hZggQTCHvF91qgFQAUAPfDrD/V1UDbYDpZMSt6yYrdZ3nhSd7dkWVA6qDEpFv8KyYoHBX6cU638in/uKoAyQ3wQp7aWYARMEk8jbVacvW+gPAJA5CMR3r6a+fnHJNIRBqX8I1g+lYQL8dX8+Wp+TAYLS1D9Rz30QEyQIJpHXhwE5KfBULxhwL/Lh/i73b9e2O3jlgWc503qJ6NAOOjvfGdczA4oR9YCLeLwvorSPxdCsFcbr99d91WA7un5V/34qqxeVpH6YWOe+ZcVsy4rZkUjEM/wz3N8VWPeq3ktFvyCYSF6dt94A+h9x+Lvf/hqAO++aB8DH7/+Ub839LhD81CQwv2egGjalfc3uaNp3hvu72LWxhsceX+f53DTt/rrXH2iRre4TVWs5cfxYRv16cCjmMpno577SPz3RiZ4Bqhps90yCVZkP/zlQapkQQTCBvE4CdFKgeJ5g9NA9G/n75bfdRvzE8WOs3NZLZfVT8Jbz2fCsWwA403rJ83u1jdimNgpBvZqubXcA6QHwO/dv4baFrYBjCL5IfIRlmaU9qO79nDh+zA2COj/esJdJWtpc6Qf4xs/+wtw5Mzk1cA5eXFq0ZRLGuR/w30Ti8b5Qjv96Ufr1DJCiarA9aYIS3HnX6rR96+sXA3K7rCAUmoJcYPq4qOoFqL+Qavy+9uhnnv3+8fI0ahvfMK4hsKyY3bx8lF/u/z7TE51uD2jXxhruvGtemgFYtPG0u6+eLg0YQijaABCEatCz1X02qgbb+eGvellfb7O9M8LeTTVGngvXc+7rBujDF5cWvX7/I0yVCVJZECBpglJzA/xloTDx2hcEk8hbBsC27cCZvO6kMN/nw/1d7G/uBqC28SwA05PbVC9CNQC+nkFRB0E9+IOjRWlfszsKu08DqR4gBAf/M62XqG3EHwBsDLh9TNWXe0eEb3um4B/QC+bUwDm2k8wAFClhnfsAc+fMdAwQM/kwlKPPL/6A/cej27CsGCu39QJkDfxpJujNB4MyIUV9/QuCSeTNAGRa+U6fFAXexq9p/dm031HjiJCaVW1iEFRMis7OOBNa4Q/8YG4A8BsgHX/g39/c7WZCwAkA+vh5PN4X4cWl9qqmBezdc7hoe4NhnvsmGCAI1wSZfP0LQjET2kJAehDQbwnb39ztNn6dne+443/qtT6BTGFSEIzH+yItxOyty9919eeS7vYHftMCQCb8da/jnAepQDid0hj3zeXcD8J/7ptigCBcE2TS9S8IJhGKAdCDIEDdvGp3m37Rq+Cvvw5q5EwLgrp+XXsQ/tngpgYARa51n2lf/b2Jt4flU7/J5LMDYNr1LwimEGqDE9SA+xdJCbpXPigQbGlawGZDgqBiPAGslLXnWvdq32VzRgHYN1BmlHbIz7mvfsPU+m9e7tTf9ZogU68BQSh2QhsCgPR7uZuXj7IlmQVW4+JD2vcrqxfRu+6A0bf/ZcLR/ijgXRdfoWu/IQeYZ66n7nt3rgVgw6bnOHfhc2BK4Q48T1yPfvWZMkAmBj6VCQFoeTUV9McyQZYVK7lrXxCKlVANgE7H6vk0tPWwf7vTCv7oLacR1CfIvfLAs9Q2nqV351pqVu0wNhCqRr9j9Xz3s2vRrtiw6TnAvACg935VGYxH/76BMrY0LeGDPYcLctz5xH8O5Kq/Y/V8Zt1bB5htgCA/JkgQhPAI3QBYVszt0XUADet7AHhl+7MAnlngqgEE0HuBYE4QtKyYrTfiily1D753xLOvaQFAr2+da6l7gJpVO8I90BAJKoNc9et1b7IB8nOtHQCFade/IJhEwTIA4PSCwEkDNq1Xqb+zad/pACODoB78a1btoPlKlJaKhPsXxtYOgPqLWQHAH/gG3zsCaLrIrl9Rs2pH0PoPRqCXwbXqb2jr0eq+NBhvB0DHlOtfEEwjVAOgAiLgCYibB/5MSwWMLmx1l8ddtPE0Zd1riMf7Ig1t2KYGwecPHYVDR1HPWfpT+wv89eEnPN8ZTS77G6Rd/55JAdCyYvayOaNs2PQc+wbKaL4S5Xuv/cbRXuG9vSuTfhUAVfB/4Rc/4Oe/P2BMzy9TGTT//pRrAKE06z8Xcu0AeE2QWde/IJhE6BmAbAFxuL+LE8cTyde9VCX3CZoJbRJ6j+X22V9J264m/wVpN52xtENm/aYE+rHIgNccYAAAC7dJREFUR/2baID8jLcD4P+Nwh+5IEwMCjIEkKlBfKTiZepuv5R8/Tr78vt04hvCvoEyYApLPpkMt3q3nY/WM32wnbunXQTg7f+5mWda/pMzrfB08yiQmgFtUgCwrJi95JPJ7OMqMIXmK1F+cmQXL9WtpKUi4fR4+/Zck37TGKsM3CcFlqj+TIynAyAIQmEI3QBkC4hd56Pcu/IgAMPWHygbWOPZblIQVCz5ZLL7+uSFy7xUt5KTFy7DjNR3er69E4DK+JNZ9ZuG0n6SYN2KXPV//Gkibd9iJ5cyKNX6z8R4OwAmXv+CYBKhG4BsAXFkxOkJlZdHqIw/CVOnGH8f8MEZV73vueoGgOmJTsrLI0yNPwmUlv5suhXXqt+0md+ZykBlQK5Vv4kGyM/1dAAEQQiX0A1AtsDgpkW1B8CYTKZVzEYXtvJpMgAoRkYujqnflACQLUhnGsMdS79JgR8yH+949YN5BiiIidYBEASTCHXQXV3If3vzQfZs/zoAd0+7yIKvTgVg633vsvU+Z830OyafIxZNv+5NCYLZ6F13gEP/NQBATeWIq3Ms/aUQAGD8+kuF8eiPx/sipVD3B2dc9fxrqUi4nYLm5aM0Lx/lyy/tkr7+BaFYCb2BuZ718NW+JjeE+XgegMmIftF/rfuU0vUvCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCIIgCMWAbdvYts1D92x0X1tWzNb/JT/zfEcQBEEQhMIR2lLAr73/DDU1lg3O878rqxcBzhPA1OcUYCGiG4EyNA//+9O89v4zALpmAHp745GaGotv3nS/+51IpCSLQxAEQShC8h5xVPCrqbFsPfD7Ge7vomqwHSi9lb70jEYmE6S0f/Om+yNiAARBEIRCk7eIoy/baVkxe2jWCs/2ICMw3N9FfPdq6usXl5QJEBMUTKZlYSUbIgiCUHjyOgRwPlqPZWGfj9a7P1w12M7QrBUM93dRWb3IDfofv/9TvjX3uzC0g87Od6ivX2z8U8BUgItEIh4TNNzfBaSboMrqRQyBMkHG68+G3xROpCEhQRCEYiSvDa5lxexMjzj93W9/DcCdd80DSBkAoLbxjcDfMy0gKv3TE52cj9YzKTobSJkgINgEAYmqtSWVCcmWEcqUDSrlbIht22lZDX9GpBR1C4JQvOQ1A+A09nie4PXQPRv5++W33YbuxPFjrNzWS2X1U/CW89nwrFsAONN6yfN7tY0Y1StW+pUJUgFNvXZMUII771qdtm99/WKgtIJCUEYIcLNBOpXVixhNmiMLs+o9G3pWSH8PeEwhgMUa99oJMgyCIAj5pCAtjN4DVD1g9RdSgf9rj37m2e8fL0+jtvEN44Kg/zGmygSpLAiQNEGpIOgvC4WJ+hVBGaGxMgGQygaYqltHzwqBVz+kl0EpaRcEobjJWyOTqceiGkCVDtcD//7mbgCa1p/17KMHDZVC1o85Hu/L12EXjIlmghR+M2RZMTvbcFCiai0njh/jscfXeX7HVP3gNULqOlBkGw4xWbMgCMVP3oYA9OCvB2zV8CmG+7syBn71fdVbUsH/Gz/7C3PnzOTUwDk+fHGpTZFOFhvTBPk+18uittEpi+nJbarcTA7+kD1wnzh+zDUBOj/esJdJWk/5i8RHWJa5wwL60BiJ9CyAHzU5tJSGQgRBKD5CWwioefkov9z/fec/0Xo9+5u73cCfnP3vea16/fpvzZ0zk/X1NtuZyYdhHXAeCMsE6dtMzoaoY1+5rRdIZkK2tVFZ/RTDLV3Jb7Wl9ZInRWczFF2BBf7bCI3Rr9ejBWm3yQYxNGuFmABBEEIjFAMQj/dFWojZW5e/C0DdvGp3mx7wVPDXXwc1dqcGzrEdJwNgErmYoCCCTBA4AdSUbIiOCvxuGty3XQ2D+AmYFIqJ+v3E430RC2w1KXTN7mjg93ZtrOGxx9s9pk/MgCAI+SK0DIAyAQAtr6aCnb/no8+UBydY6I1cPN4X4cWl9qqmBezdc9iYBjBXE5Rp30zbTMmGKCwrZutGSMcf+Pc3d7tzAcCZD+G/ndQ0/X6CFkPq2nYHkD4X4jv3b+G2ha2AU1amD4UIglBchGYAwDvxC5we8RYn8+1OfhrSvl9ZvYjedQeMu/0vE/kyQTqmZkMU/kyIjmOMUuU0HV/q3IrZJuvXzdD0RKc7FLJrI4FzIW6LNXne60Mhpl8fsi5COhM90yP6C68/VAOg07F6Pg1tPezf7jT6P3rLMQD6LOhXHniW2saz9O5cS82qHSXxiMB8m6BVl/6bzZsOe367mMl3JsQ0/Qp/JkSfFLpmdxR2nwZSa2PAaXdfPVNypvUStY0FOeRQkHURHPx6/Itlqfku6hwX/aI/DP2hGwDLitm9O9cC0AE0rO8B4JXtzwJ4Ur61jWfpWD0fALXPhk3PAbDZoPR/JsZjgvyav3qbM15sUllky4ToSwIrspkgE/UHMSk6O+M6CAp/4AfvXSGmTghVC0RB9nURRhe2ugtDRUqk9c9kgPzrY/gXxSoR+aK/yPQXLAMA0NDmBP+hWStoWq/S3mfTvtMBzLq3zv3s3IXPgSmFOcgQuB4TpEyAZcXsF37xA37++wPGBT9d/+B7R2ho62HP9q8D3TmbINP1K/O3dfm7bhYg0+RHHT3wgzejZOKESP9qmWM1QKV4S2SuBqgUtYPoLyb9oRoA1fAB1KzaQfOVKC0VCTYP/JmWCsfhqwlQizaepqx7DfF4X6ShDZukWYAytjQt4YM9h8M81IJxrSaolIZDIKX/vpaFVA2252yCCn+k+Sepha3L3/UMhQThf06Gfy4EmDshciKvizDRDZDoLy79oWcAnj90FA4dBcoA+FP7C/z14ScApwd04ngi+bqXquQ+QY2dqVyPCVImYNmcUQCje78QrD81DyCzCSoF/bPurUvpfzXhGQoJxtmuTIN+HWxpWgDATgMmRGa6fvWgrz8sKxsmrouQSb97d4vT/GXVb3IQFP3Frb8gQwB6Cv/22V9xP3+k4mXqbr+UfP06+5ImodQYrwlSmZBlc8weBsmmX80DyJYJMlW/ZcXsZXNGef7QUfa19dB8Jcr3XvsNPPwELRUJz6S3su41aft3rJ7P4HtH3Pcq8G92s2FL3Z5/MTaMuvnRcYaBUkF/dGErVd1rKLV1EbLr7/HUv9K/Znfm3zPNAIn+4tcfugHYN1AGTGHJJ5PhVu+2rvNR7l15EIBh6w+UDXgbQZPHff2MxwSpse//aFhmfBlk0//MukswdICnm1+nbKDM1Vkq+jNp1+nsfAdIGSBIDZeoDIgK/CaUg9/8+OlYPZ8FHclbYH23weZjXYQbPUFyvPpbH0lkfUYG1PDY4+vGNECiX/RrbzPqD90ALPlksvv65IXLvFS3kpMXLsMMGBm5CEB5eYTK+JMwdUrWe+BNJRcT9Pnnl4By0le7NZ+JrF9pb74S5SdHdvFS3UpaKhKUl0f4138m7f4/d7M4uShm2ZeOfv9DsJSJKPZrw5/yVMfdfMXbq29o66GKHsJYF+FGTpC8Xv27NtZkfEYGJG8ZTd4dkckAiX7Rn6v+UAtlrPF7/al/U6c6PaSRkYuemc6mZwAsK2brJgjg27fexMkLlzk44yrl5Y6sm2++xd2uykD0m6t/LN3qfHeMT7p+SE/5F3sZWFbMvnvaRT74zDtUo4Y+VPZjXv0DzucZlsrOhv4ETVDrIryR9r0f/qrXmSDZGWHvppqClN2N0P9F4qO01TJB9Iv+3PSHvhKgZcXsv735IP936n9pWn+Wu6dd5F9u+jcOfzzC1vucxWFaXi3jjsnnnM9HvL/x8aeJMA+xIByccdX7nqswI/Veb/z9iH5z9Y+lWxGkf0vTAmMCv87MW2+Gz3yZPy7Dw084mT9gCZPdslFtQK53RcABz+e1jW+4RknnRk2QLLR+mEZtI2llIPpFfy76C+KKrnUf/0InJjWAfkS/6B/vvqbpLtY7dgpVjqJf9Bfi/7lWsun/f5UBWhzkM47bAAAAAElFTkSuQmCC";
+const ASSET_BLAST  = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAwAAAACACAYAAAC82Q7LAAAKKmlDQ1BzUkdCAABIiZ2Wd1RT2RaHz703vVCSEIqU0GtoUgJIDb1IkS4qMQkQSsCQACI2RFRwRFGRpggyKOCAo0ORsSKKhQFRsesEGUTUcXAUG5ZJZK0Z37x5782b3x/3fmufvc/dZ+991roAkPyDBcJMWAmADKFYFOHnxYiNi2dgBwEM8AADbADgcLOzQhb4RgKZAnzYjGyZE/gXvboOIPn7KtM/jMEA/5+UuVkiMQBQmIzn8vjZXBkXyTg9V5wlt0/JmLY0Tc4wSs4iWYIyVpNz8ixbfPaZZQ858zKEPBnLc87iZfDk3CfjjTkSvoyRYBkX5wj4uTK+JmODdEmGQMZv5LEZfE42ACiS3C7mc1NkbC1jkigygi3jeQDgSMlf8NIvWMzPE8sPxc7MWi4SJKeIGSZcU4aNkxOL4c/PTeeLxcwwDjeNI+Ix2JkZWRzhcgBmz/xZFHltGbIiO9g4OTgwbS1tvijUf138m5L3dpZehH/uGUQf+MP2V36ZDQCwpmW12fqHbWkVAF3rAVC7/YfNYC8AirK+dQ59cR66fF5SxOIsZyur3NxcSwGfaykv6O/6nw5/Q198z1K+3e/lYXjzkziSdDFDXjduZnqmRMTIzuJw+Qzmn4f4Hwf+dR4WEfwkvogvlEVEy6ZMIEyWtVvIE4gFmUKGQPifmvgPw/6k2bmWidr4EdCWWAKlIRpAfh4AKCoRIAl7ZCvQ730LxkcD+c2L0ZmYnfvPgv59V7hM/sgWJH+OY0dEMrgSUc7smvxaAjQgAEVAA+pAG+gDE8AEtsARuAAP4AMCQSiIBHFgMeCCFJABRCAXFIC1oBiUgq1gJ6gGdaARNIM2cBh0gWPgNDgHLoHLYATcAVIwDp6AKfAKzEAQhIXIEBVSh3QgQ8gcsoVYkBvkAwVDEVAclAglQ0JIAhVA66BSqByqhuqhZuhb6Ch0GroADUO3oFFoEvoVegcjMAmmwVqwEWwFs2BPOAiOhBfByfAyOB8ugrfAlXADfBDuhE/Dl+ARWAo/gacRgBAROqKLMBEWwkZCkXgkCREhq5ASpAJpQNqQHqQfuYpIkafIWxQGRUUxUEyUC8ofFYXiopahVqE2o6pRB1CdqD7UVdQoagr1EU1Ga6LN0c7oAHQsOhmdiy5GV6Cb0B3os+gR9Dj6FQaDoWOMMY4Yf0wcJhWzArMZsxvTjjmFGcaMYaaxWKw61hzrig3FcrBibDG2CnsQexJ7BTuOfYMj4nRwtjhfXDxOiCvEVeBacCdwV3ATuBm8Et4Q74wPxfPwy/Fl+EZ8D34IP46fISgTjAmuhEhCKmEtoZLQRjhLuEt4QSQS9YhOxHCigLiGWEk8RDxPHCW+JVFIZiQ2KYEkIW0h7SedIt0ivSCTyUZkD3I8WUzeQm4mnyHfJ79RoCpYKgQo8BRWK9QodCpcUXimiFc0VPRUXKyYr1iheERxSPGpEl7JSImtxFFapVSjdFTphtK0MlXZRjlUOUN5s3KL8gXlRxQsxYjiQ+FRiij7KGcoY1SEqk9lU7nUddRG6lnqOA1DM6YF0FJppbRvaIO0KRWKip1KtEqeSo3KcRUpHaEb0QPo6fQy+mH6dfo7VS1VT1W+6ibVNtUrqq/V5qh5qPHVStTa1UbU3qkz1H3U09S3qXep39NAaZhphGvkauzROKvxdA5tjssc7pySOYfn3NaENc00IzRXaO7THNCc1tLW8tPK0qrSOqP1VJuu7aGdqr1D+4T2pA5Vx01HoLND56TOY4YKw5ORzqhk9DGmdDV1/XUluvW6g7ozesZ6UXqFeu169/QJ+iz9JP0d+r36UwY6BiEGBQatBrcN8YYswxTDXYb9hq+NjI1ijDYYdRk9MlYzDjDON241vmtCNnE3WWbSYHLNFGPKMk0z3W162Qw2szdLMasxGzKHzR3MBea7zYct0BZOFkKLBosbTBLTk5nDbGWOWtItgy0LLbssn1kZWMVbbbPqt/pobW+dbt1ofceGYhNoU2jTY/OrrZkt17bG9tpc8lzfuavnds99bmdux7fbY3fTnmofYr/Bvtf+g4Ojg8ihzWHS0cAx0bHW8QaLxgpjbWadd0I7eTmtdjrm9NbZwVnsfNj5FxemS5pLi8ujecbz+PMa54256rlyXOtdpW4Mt0S3vW5Sd113jnuD+wMPfQ+eR5PHhKepZ6rnQc9nXtZeIq8Or9dsZ/ZK9ilvxNvPu8R70IfiE+VT7XPfV8832bfVd8rP3m+F3yl/tH+Q/zb/GwFaAdyA5oCpQMfAlYF9QaSgBUHVQQ+CzYJFwT0hcEhgyPaQu/MN5wvnd4WC0IDQ7aH3wozDloV9H44JDwuvCX8YYRNRENG/gLpgyYKWBa8ivSLLIu9EmURJonqjFaMTopujX8d4x5THSGOtYlfGXorTiBPEdcdj46Pjm+KnF/os3LlwPME+oTjh+iLjRXmLLizWWJy++PgSxSWcJUcS0YkxiS2J7zmhnAbO9NKApbVLp7hs7i7uE54Hbwdvku/KL+dPJLkmlSc9SnZN3p48meKeUpHyVMAWVAuep/qn1qW+TgtN25/2KT0mvT0Dl5GYcVRIEaYJ+zK1M/Myh7PMs4qzpMucl+1cNiUKEjVlQ9mLsrvFNNnP1IDERLJeMprjllOT8yY3OvdInnKeMG9gudnyTcsn8n3zv16BWsFd0VugW7C2YHSl58r6VdCqpat6V+uvLlo9vsZvzYG1hLVpa38otC4sL3y5LmZdT5FW0ZqisfV+61uLFYpFxTc2uGyo24jaKNg4uGnupqpNH0t4JRdLrUsrSt9v5m6++JXNV5VffdqStGWwzKFsz1bMVuHW69vctx0oVy7PLx/bHrK9cwdjR8mOlzuX7LxQYVdRt4uwS7JLWhlc2V1lULW16n11SvVIjVdNe61m7aba17t5u6/s8djTVqdVV1r3bq9g7816v/rOBqOGin2YfTn7HjZGN/Z/zfq6uUmjqbTpw37hfumBiAN9zY7NzS2aLWWtcKukdfJgwsHL33h/093GbKtvp7eXHgKHJIcef5v47fXDQYd7j7COtH1n+F1tB7WjpBPqXN451ZXSJe2O6x4+Gni0t8elp+N7y+/3H9M9VnNc5XjZCcKJohOfTuafnD6Vderp6eTTY71Leu+ciT1zrS+8b/Bs0Nnz53zPnen37D953vX8sQvOF45eZF3suuRwqXPAfqDjB/sfOgYdBjuHHIe6Lztd7hmeN3ziivuV01e9r567FnDt0sj8keHrUddv3ki4Ib3Ju/noVvqt57dzbs/cWXMXfbfkntK9ivua9xt+NP2xXeogPT7qPTrwYMGDO2PcsSc/Zf/0frzoIflhxYTORPMj20fHJn0nLz9e+Hj8SdaTmafFPyv/XPvM5Nl3v3j8MjAVOzX+XPT806+bX6i/2P/S7mXvdNj0/VcZr2Zel7xRf3PgLett/7uYdxMzue+x7ys/mH7o+Rj08e6njE+ffgP3hPP7l7FYAQAACEpJREFUeJzt3UFu2zgUBmBp0GVzgi4L+C5Z5RS5R+7hU3SVuwToMidI95pFw0b12BlZlshH8vuAYtBpbFOSI/+Pj5KHAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAG99PbVHoMAADABoR7Th2eXle/J255LAAAGVwqAO6nt+mzf/vs+RQVdVgb1nM/ju0dHsoci1Kvu7V/Sg8AANZIQf15vBuvCe3zx1z7eutGyh5SGF8Tyl+evo1bv57iIK+XH9cfw5pfFwCYWRPMTx+zpCNw+uf0368dA7fLHbqFfACAAE7DeI7XOf3/CgCgJtoYQPOuDWfP451zI/8xXzrkPQLUzAkMaM5p4L82rN36ePYhePfr8PQ6rVm3D5znl4luLJ0FFjDqND++Wx/DPZ+bZWqdfa9tvGxP8UJE3pA060zgf1z40OP8Lz68Y0vHOddxyv16fIgcps+NTeEIROWERFNOQv/SwP9//hQEPsTjKB3ES78+dYhctAD9clKiCbPgv1Xov+Q4DEJfaZFCVaSxAMASPrSoWsbgf0ohUEDUWfeo46qd4qof1slDXn7ZqNZ76Mod/E8dBZQ8agiDNYwxMoUUQB5OslSn4Kz/JboBO6spWNc01mgUAAB5OMlSlSCz/pfoBuygxkBd45jZl/cEEImTEdUIHv4TRcCGag5NNY8dgLb9U3oAsEQl4X8YhuFx6ReO8bnaA3T60qrS44jM/unX4enVsYeCqv1wpR8Vhf85nYAb1B7+51rali3V+s2+AC3QASC0SsP/MOgErNZaINQJOE/4hw86IuTmxEtYFYf/OZ2AK7QcCFvetmvYD39z5yOgBB0AQmok/A+DTgCAGe6OHR4c+4gUAEAIrc8M974U6H56m+br/nveF3PP493Y8vt+GD6+5VcR0KeXH77hOaIuD8qv6efZk9DX8XuX+yOahmb/5ywF+kTr4X+up209p/ftv6T1/ZKKgNLjAH77UnoAuZyE/rPhcv4zioEyGg3/w/C+FKjlD3hgvdbPDcI/xNJ8ATAL9UtC5Z+fSY9TCMC+eiuMer/7Ta/bDRBJ0wXAe4hfO5v8mJ5DEZBHw7P/iS4AAFBckxcB/5p+TjeG/7nH2fMBG+q1IOr5guBetxsgkuY6ABsG/zndgJ11MPuf6ALQNe99gPKa7AAAAADnNVUA7DT7P/doKRBso/dOSG/LgHraVoDomikAMoT/RBGwsY6W/yS+HZiuzL8ArPRYyMuXf0FMzRQAAMTU+61Pl2qxQHL/f4ipiQIg4+x/ogsAcAXh/3O6JCS6JuTQRAEA1MVs8G8CH4kuCYmuCTkoACiqw/X/iesAgL8I/0Au1RcABZb/JJYBAQBQneoLAADqoOu1jP0E7E0BAMBu5mHWEpdl7CdgbwoAAHZlRrs/7mQDsSkAANhFCv5mtJdppVBK4V8R0KfDg+NeAwUAALsQ/PuUbmPpdpbr1F44vfxw3GtQfQHwdfw+DsNwLPDSx/fXBuACRcAyafb/fnqbWugECP/r6J6Q7N1Jqb4AAIDapULpebwbFU390j0h2buTogAAYHctzGpDDsI/OTRRABRYBmT5z0beZ7pKLOEq7WiWj17cT2/T83g3KgI+55wA5NJEAQDURRj8LQXj0uPYWzrePWwr/2U9O8TTTAGQsQtg9h/gSsJ/vyxpgXiaKQCGIUsRIPwDsCvdMWBvTRUA1KnD6wCs/6c7rdzecm+ulyCxdIo9fSk9gK19Hb+Pv6af6ZfmcaOnPabn3uj5oHu9rwvvedu5rPffCz5YOsWemuwAfB2/jxsuBzrOng+AFdzffrnW9pOZbIinuQ7A3I3dALP+Gc1a3lt1baKy/AfoiplsiKfpAmAYPgL8rBAYhssh80/HQPCH/fW63KHHbeZz3hNATs0XAMk80J8UA2d/hvw66AKY/QfOcm4AcuqmAJgT9CGO3roAPW0rADE1eREw9Wr4lqBm/+GdW1wClCWQEFJjS4GE/wV6mBnvYRtZLhVC3hNAbjoAQAitf/mR8H9ey8ccICoFACE1tBTI7D9wlu9GYBh8TwJlOPEQWuVLgYT/FVqcKW9xm7aQ9ov9A5CXDgChVdwJEP5Xam0pkHB7WY/hv6X39i3MekNZCgDCq7AIEP5v1EoR0Fu4hSUOT6/Ty9O3UREA5fhgohqVLAcS/jdUc4Cueexsb37HH3f/+SgCSo+D/A4Pr9PLD8e+NAeAqgQvAoT/HdQYpGsccxSt77vWt4//p/ghAkuAqMpsOVCkJUHHQfjfTW3LgQS89dJxrul4wzUsfyIKH1JUK0g3QPDPpIZgXcMYozndZ/Zhv3qZGe9lO7kswjIob0CqNpspzF0IHIeh7zW8JURdOx11XMSgqAGicUKiCRkLAcE/gEiBKtJYAGAJH1o05WTt8FbFwJ/rDQS9OErPupd+/Z7Y1wDbcjKlWWcuJFxaEPx1gbHQEVvucCiM5nd6C82I+z7quADOcbKiG0vvLOJDvE7z47v1MdzzubkseqhO4zv9b+lxtcQFswDAIvfT2zT/k/vx5BHp2EQaC2W4tSc1UVUDzbs2nJnFjc/sOwAAdMase7/MtgMA8Je1S7+2eB6A6LRLAWjGucC+ZGnQuaVELv4GAIBK6AAAAAB0Ys01Apce43oDAIDKXDuLb9a/bimwC+4AANAJ4R8AAKAThwcFIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA3OxfyjI3aY+bVDAAAAAASUVORK5CYII=";
+const imgKnight=new Image(); let imgKnightReady=false; imgKnight.onload=()=>{imgKnightReady=true;}; imgKnight.src=ASSET_KNIGHT;
+const imgMage  =new Image(); let imgMageReady  =false; imgMage.onload  =()=>{imgMageReady  =true;}; imgMage.src  =ASSET_MAGE;
+const imgBlast =new Image(); let imgBlastReady =false; imgBlast.onload =()=>{imgBlastReady =true;}; imgBlast.src =ASSET_BLAST;
+
+// Per-sheet frame layout (row index × frameH = source y; n = real frame count).
+const SHEETS = {
+  knight: { img:imgKnight, ready:()=>imgKnightReady, fw:96, fh:96,
+    dwF:1.15, foot:0.44,
+    anims:{ idle:{row:0,n:8,loop:1}, move:{row:1,n:8,loop:1}, attack:{row:4,n:22}, damage:{row:5,n:4}, death:{row:6,n:6} } },
+  mage:   { img:imgMage, ready:()=>imgMageReady, fw:64, fh:32,
+    dwF:1.35, foot:0.40,
+    anims:{ idle:{row:0,n:8,loop:1}, move:{row:1,n:8,loop:1}, attack:{row:6,n:8}, damage:{row:8,n:5}, death:{row:9,n:8} } },
+};
+const unitSheet = (u) => SHEETS[u.owner==='white' ? 'knight' : 'mage'];
+
+// Trigger a one-shot animation (attack / damage / death) on a unit.
+function playOnce(u, name) { u.anim=name; u.fi=0; u.ft=0; u.oneShot=true; }
+
+// Advance every unit's position tween + frame animation each render frame.
+function advanceAnims() {
+  GAME.pieces.forEach(u => {
+    const sh = unitSheet(u);
+    const tgt = tileCenter(u.row, u.col);
+    const dx = tgt.x-u.px, dy = tgt.y-u.py;
+    const dist = Math.abs(dx)+Math.abs(dy);
+    const moving = dist > 1.2;
+    if (moving) {
+      u.px += dx*MOVE_LERP; u.py += dy*MOVE_LERP;
+      // Update facing from horizontal direction of travel.
+      if (Math.abs(dx) > 1.0) u.facing = dx<0 ? -1 : 1;
+    } else { u.px = tgt.x; u.py = tgt.y; }
+
+    const A = sh.anims;
+    if (u.oneShot) {
+      const a=A[u.anim]||A.idle;
+      u.ft += ANIM_FPS;
+      if (u.ft >= ANIM_FRAME_MS){ u.ft=0; u.fi++; if (u.fi>=a.n){ u.oneShot=false; u.anim='idle'; u.fi=0; } }
+    }
+    if (!u.oneShot) {
+      const want = moving ? 'move' : 'idle';
+      if (u.anim!==want){ u.anim=want; u.fi=0; u.ft=0; }
+      const a=A[u.anim]||A.idle;
+      u.ft += ANIM_FPS; if (u.ft>=90){ u.ft=0; u.fi=(u.fi+1)%a.n; }
+    }
+  });
+  // Death animations play out, then vanish.
+  GAME.deaths = GAME.deaths.filter(d=>{
+    d.ft += ANIM_FPS; if (d.ft>=ANIM_FRAME_MS){ d.ft=0; d.fi++; }
+    return d.fi < d.sheet.anims.death.n;
+  });
+  // Spell blast FX (6 frames at 70ms each).
+  GAME.fx = GAME.fx.filter(f=>{
+    f.ft += ANIM_FPS; if (f.ft>=70){ f.ft=0; f.fi++; }
+    return f.fi < 6;
+  });
+}
+
+// Returns true if any unit is mid one-shot OR still moving toward its tile.
+function anyAnimating() {
+  return GAME.pieces.some(u => u.oneShot || Math.abs(tileCenter(u.row,u.col).x-u.px)+Math.abs(tileCenter(u.row,u.col).y-u.py) > 1.2)
+      || GAME.deaths.length > 0
+      || GAME.fx.length > 0;
+}
+
+// Resolves once all sprite animations have completed.
+function waitForAnims(extraMs=0) {
+  return new Promise(resolve => {
+    function check() {
+      if (!anyAnimating()) { if (extraMs>0) setTimeout(resolve, extraMs); else resolve(); }
+      else requestAnimationFrame(check);
+    }
+    requestAnimationFrame(check);
+  });
+}
+
+// Draw one animation frame of a sheet, centered at (x,y) feet-anchored, flipped by facing.
+function drawCharFrame(sheet, animName, fi, x, y, facing) {
+  if (!sheet.ready()) return false;
+  const a = sheet.anims[animName] || sheet.anims.idle;
+  const fr = Math.max(0, Math.min(fi|0, a.n-1));
+  const sx = fr*sheet.fw, sy = a.row*sheet.fh;
+  const w = CELL*sheet.dwF, h = w*(sheet.fh/sheet.fw);   // scale by width, keep aspect
+  const footY = y + CELL*sheet.foot;                     // feet sit near the tile bottom
+  ctx.save();
+  ctx.imageSmoothingEnabled=false;
+  ctx.translate(x, 0);
+  if (facing<0) ctx.scale(-1,1);
+  ctx.drawImage(sheet.img, sx, sy, sheet.fw, sheet.fh, -w/2, footY-h, w, h);
+  ctx.restore();
+  return true;
+}
+
+// ═══════════════════════════════════════════════════════
+// GAME STATE
+// ═══════════════════════════════════════════════════════
+const GAME = {
+  pieces:[],            // qubit units on the board
+  turn:'white', phase:'play',   // 'play' | 'gate' (action menu) | 'gameover'
+  selected:null,        // unit reference
+  reachable:[],         // cached move tiles for the selected unit
+  turnCount:0,
+  turnCap:60,           // battle ends here → most units (then HP) wins
+  mode:'vsBot', botColor:'black',
+  decoRate:2,
+  unitCount:6, boardPreset:0,
+  log:[], gateMenu:null, winner:null,
+  cnotMode:false, cnotControl:null,        // entangle-target mode
+  attackMode:false, attackSource:null,     // attack-target mode
+  particles:[],
+  deaths:[], fx:[],     // transient sprite animations (death, spell blasts)
+  difficulty:1,         // 0=easy, 1=medium, 2=hard
+  attractMode:false,
+  // Combat juice
+  shake:0,           // screen shake frames
+  floats:[],         // floating damage/crit text objects
+  // Turn timer
+  blitzMode:false, timerSec:30, timerLeft:30, _timerInterval:null,
+  // Stats for leaderboard
+  critCount:0, entanglCount:0,
+  // Entanglement beam flash
+  beamFlash:{},
+  // Bot explanation
+  botLastReason:'',
+  // Campaign
+  campaignMission:null, campaignDone:[],
+  // Guardian guard-stance
+  // (per-unit 'guarding' property on unit objects)
+  // Crowd vote
+  voteMode:false,
+};
+
+let _attractTimer = null;
+
+const ALL_GATE_IDS = ['H','X','Y','Z','S','T','Rx','Ry','CNOT','MEASURE'];
+
+function resetGame(mode) {
+  const p = applyPreset(GAME.boardPreset);
+  GAME.unitCount = p.units;
+  Object.assign(GAME, {
+    turn:'white', phase:'play',
+    selected:null, reachable:[], turnCount:0,
+    mode:mode||'vsBot', log:[], gateMenu:null, winner:null,
+    cnotMode:false, cnotControl:null, attackMode:false, attackSource:null,
+    particles:[], deaths:[], fx:[], attractMode: mode === 'attract',
+    shake:0, floats:[], beamFlash:{},
+    critCount:0, entanglCount:0, botLastReason:'',
+    campaignMission: (mode==='attract'||mode==='vsBot'||mode==='vs2P') ? null : GAME.campaignMission,
+  });
+  stopTurnTimer();
+  GAME.pieces = initBoard();
+  initTerrain();
+  ALL_GATE_IDS.forEach(g => {
+    const el = document.getElementById(`cnt-${g}`);
+    if (el) el.textContent = '0';
+  });
+  document.getElementById('attract-badge').style.display =
+    mode === 'attract' ? 'block' : 'none';
+  logEv(`Battle start — ${p.label}. Charge your qubits toward |1⟩, close in, and strike. WHITE moves first.`,'system');
+  updateHUD();
+}
+
+// ═══════════════════════════════════════════════════════
+// BOARD HELPERS — units, movement (BFS), adjacency, counts
+// ═══════════════════════════════════════════════════════
+const inBounds = (r,c) => r>=0&&r<GRID&&c>=0&&c<GRID;
+const unitAt   = (r,c) => GAME.pieces.find(p=>p.row===r&&p.col===c);
+const adjacent = (a,b) => Math.abs(a.row-b.row)+Math.abs(a.col-b.col)===1;
+const aliveCount = (owner) => GAME.pieces.filter(p=>p.owner===owner).length;
+const totalHp    = (owner) => GAME.pieces.filter(p=>p.owner===owner).reduce((s,p)=>s+p.hp,0);
+function refreshSuperpos(u){ const {theta}=stateToBloch(u.state); u.inSuperpos = Math.abs(Math.cos(theta))<0.6; }
+
+// Tiles a unit can reach within MOVE_RANGE steps (4-dir BFS, blocked by units).
+function reachableTiles(unit) {
+  const key=(r,c)=>r*GRID+c, seen={[key(unit.row,unit.col)]:0};
+  let frontier=[[unit.row,unit.col]];
+  const tiles=[];
+  const _range = (unit.moveRange !== undefined) ? unit.moveRange : MOVE_RANGE;
+  for (let d=0; d<_range; d++) {
+    const next=[];
+    frontier.forEach(([r,c])=>{
+      [[1,0],[-1,0],[0,1],[0,-1]].forEach(([dr,dc])=>{
+        const nr=r+dr, nc=c+dc;
+        if (!inBounds(nr,nc) || seen[key(nr,nc)]!==undefined || unitAt(nr,nc) || TERRAIN[nr*GRID+nc]==="tree") return;
+        seen[key(nr,nc)]=d+1;
+        tiles.push({row:nr,col:nc});
+        next.push([nr,nc]);
+      });
+    });
+    frontier=next;
+  }
+  return tiles;
+}
+
+// Enemy units adjacent to a given square (defaults to the unit's own square).
+function adjacentEnemies(unit, atRow, atCol) {
+  const r = (atRow===undefined?unit.row:atRow), c = (atCol===undefined?unit.col:atCol);
+  return GAME.pieces.filter(p => p.owner!==unit.owner && Math.abs(p.row-r)+Math.abs(p.col-c)===1);
+}
+
+// ═══════════════════════════════════════════════════════
+// PARTICLES
+// ═══════════════════════════════════════════════════════
+// QB-8 — honour prefers-reduced-motion: skip particle bursts (and screen shake,
+// gated at the call sites) for users who ask for a calm UI.
+const REDUCE_MOTION = (typeof window!=='undefined' && window.matchMedia)
+  ? window.matchMedia('(prefers-reduced-motion: reduce)').matches : false;
+
+function spawn(cx, cy, color, n=8) {
+  if (REDUCE_MOTION) return;
+  for (let i=0; i<n; i++) {
+    const a=Math.random()*2*π, spd=1+Math.random()*3;
+    GAME.particles.push({
+      x:cx,y:cy,vx:Math.cos(a)*spd,vy:Math.sin(a)*spd,
+      life:1,decay:0.026+Math.random()*0.03,r:2+Math.random()*2.5,color,
+    });
+  }
+}
+function tickParticles() {
+  GAME.particles = GAME.particles.filter(p=>{
+    p.x+=p.vx; p.y+=p.vy; p.vy+=0.07; p.life-=p.decay;
+    return p.life>0;
+  });
+}
+
+// ═══════════════════════════════════════════════════════
+// TURN LOGIC
+// ═══════════════════════════════════════════════════════
+function selectPiece(unit) {
+  if (!unit || unit.owner!==GAME.turn) return;
+  GAME.selected  = unit;
+  GAME.reachable = reachableTiles(unit);
+  GAME.gateMenu  = null;
+  sfxSelect();
+  updateSelInfo(unit);
+  // Pre-move Sage (critique rec #3): advise WHILE the player deliberates, before
+  // they commit — using their selection-to-confirm window as compute time, so
+  // the AI can actually influence the decision instead of only narrating it.
+  maybePreMoveSage(unit);
+}
+
+// Fires an advisory when a human selects one of their own units. Throttled,
+// no-op without an API key (degrades to the local Sage tips). Skips bot/attract.
+let _preMoveSageFor = null;
+function maybePreMoveSage(unit) {
+  const isHumanTurn = !((GAME.mode==='vsBot' && GAME.turn===GAME.botColor) || GAME.mode==='attract');
+  if (!isHumanTurn || GAME.phase==='gameover') return;
+  // No LLM proxy configured → the heuristic Sage is now selection-aware
+  // (analyzePosition leads with advice for GAME.selected), so render it.
+  if (!_sageEnabled()) { renderSage(); return; }
+  const key = `${unit.id}@${GAME.turnCount}`;
+  if (_preMoveSageFor === key) return;              // already advised this unit this turn
+  _preMoveSageFor = key;
+  const foes = adjacentEnemies(unit).map(e=>`${coord(e.row,e.col)}(${Math.round(charge(e)*100)}%)`).join(', ') || 'none adjacent';
+  const trigger = `PRE-MOVE DELIBERATION: the player has SELECTED their unit ${coord(unit.row,unit.col)} `
+    + `(charge ${Math.round(charge(unit)*100)}%, ${unit.inSuperpos?'in superposition':'eigenstate'}, `
+    + `coherence ${Math.round(unit.coherence)}%) and is deciding what to do before committing. `
+    + `Adjacent enemies: ${foes}. Reachable tiles: ${GAME.reachable.length}. `
+    + `Recommend the single best action (which gate, attack, measure, move, or hold) and WHY, in 1–2 sentences, before they move.`;
+  setTimeout(() => { if (GAME.selected===unit) callSageAI(trigger).then(ok => { if (!ok) renderSage(); }); }, 120);
+}
+
+const coord = (r,c) => `${String.fromCharCode(97+c)}${GRID-r}`;
+
+// Keep a unit's open-system Bloch vector in sync after any *coherent* operation
+// (gate / measurement / discharge) — a coherent state is pure, so |r|=1.
+function syncBloch(u){ if (u && u.state) u.bloch = QPhysics.blochFromPure(u.state); }
+
+// Decoherence each turn — now the EXACT solution of the Lindblad master equation
+// (QPhysics), not an ad-hoc linear drain. Excited charge relaxes toward |0⟩ as
+// e^(−t/T1) (amplitude damping) and the Bloch vector contracts inward as the
+// state mixes; the displayed "coherence" resource bleeds exponentially at the
+// T2 rate. Plot charge-vs-turns and it is exponential (R² ≈ 1) — verify with
+// runDecoherenceDiagnostic(). So charge really does bleed if you don't strike.
+function applyDecoherence() {
+  const { T1, T2 } = QPhysics.timesFromRate(GAME.decoRate);
+  const cohTau = 12 / Math.max(0.25, GAME.decoRate);   // coherence-bar time constant (turns)
+  GAME.pieces.forEach(u => {
+    if (!u.bloch) u.bloch = QPhysics.blochFromPure(u.state);
+    u.bloch = QPhysics.lindbladStep(u.bloch, { T1, T2, dt:1 });
+    // Project the relaxed (possibly mixed) state back onto a pure spinor so the
+    // rest of the engine — combat charge, Bloch arrow, superposition readout —
+    // sees it. Charge = (1−z)/2 is preserved exactly by the projection.
+    u.state = QPhysics.pureFromBloch(u.bloch);
+    u.coherence = Math.max(0, u.coherence * Math.exp(-1/cohTau) - Math.random()*0.4);
+
+    if (u.coherence < 6) {
+      u.state = blochToState(0,0); u.bloch = { x:0, y:0, z:1 }; u.coherence = 22;
+      logEv(`RELAX [T1]: ${coord(u.row,u.col)} fully decohered → collapsed to |0⟩, charge gone.`,'decohere');
+      spawn(u.col*CELL+CELL/2, u.row*CELL+CELL/2,'#ffa83c',8);
+      sfxDecohere();
+    }
+    refreshSuperpos(u);
+  });
+}
+
+// QB-6 — a LOCAL gate on one half of a Bell pair updates the shared 2-qubit
+// amplitude state but must NOT alter the partner's local statistics (the
+// no-communication theorem). We update the shared state only; the partner's
+// per-unit state and marginal are untouched.
+function propagateEntanglement(cell, gateName) {
+  const bell = cell.bell;
+  if (!bell || !GATES[gateName]) return;
+  const U = QPhysics.gateMatrix(gateName);
+  if (!U) return;
+  bell.amps = QPhysics.Bell.applyLocal(bell.amps, bell.q[cell.id], U);
+}
+
+const _EIGEN = b => b ? {alpha:{r:0,i:0},beta:{r:1,i:0}}
+                      : {alpha:{r:1,i:0},beta:{r:0,i:0}};
+
+// Collapse an entangled unit AND its partner with correlated outcomes drawn
+// from the shared Bell state, then break the link (measurement destroys it).
+// Returns the measured unit's collapsed bit, or null if it wasn't entangled.
+function collapseEntangledPair(unit) {
+  const bell = unit.bell;
+  if (!bell) return null;
+  const partner = GAME.pieces.find(p => p.bell === bell && p !== unit);
+  const res = QPhysics.Bell.measure(bell.amps, bell.q[unit.id]);
+  unit.state = _EIGEN(res.outcome); syncBloch(unit); refreshSuperpos(unit);
+  if (partner) {
+    partner.state = _EIGEN(res.partnerOutcome); syncBloch(partner); refreshSuperpos(partner);
+    logEv(`CORRELATED COLLAPSE: ${coord(unit.row,unit.col)}→|${res.outcome}⟩ forces `+
+      `${coord(partner.row,partner.col)}→|${res.partnerOutcome}⟩ via the Bell pair.`,'quantum');
+    partner.bell = null; partner.entangledWith = null;
+  }
+  unit.bell = null; unit.entangledWith = null;
+  return res.outcome;
+}
+
+function applyGate(unit, gateName) {
+  const gate = GATES[gateName]; if (!gate) return;
+  unit.state     = normalizeState(gate(unit.state));
+  syncBloch(unit);
+  // Quantum well boosts coherence instead of draining it.
+  const onWell = TERRAIN[unit.row*GRID+unit.col]==='well';
+  unit.coherence = onWell ? Math.min(unit.maxCoh, unit.coherence+4) : Math.max(0, unit.coherence-5);
+  if (onWell) GAME.floats.push({text:'WELL+', x:unit.px, y:unit.py-CELL*0.5, vy:-0.9, life:0.9, color:'#3fe08a', size:7});
+  refreshSuperpos(unit);
+  logEv(`CHARGE [${gateName}] on ${coord(unit.row,unit.col)} — ${GATE_INFO[gateName]?.short||gateName}. `+
+    `Charge now ${(charge(unit)*100)|0}%.`,'gate');
+  spawn(unit.col*CELL+CELL/2, unit.row*CELL+CELL/2,'#3fe08a',9);
+  sfxGate(gateName);
+  propagateEntanglement(unit, gateName);
+  const el=document.getElementById(`cnt-${gateName}`);
+  if (el) el.textContent = parseInt(el.textContent||0)+1;
+}
+
+function applyMeasure(unit) {
+  // QB-6 — if entangled, measuring this unit collapses BOTH halves with
+  // correlated outcomes drawn from the shared Bell state.
+  const collapsed = unit.bell ? collapseEntangledPair(unit)
+                              : measureState(unit.state).collapsed;
+  if (!unit.bell) { unit.state = _EIGEN(collapsed); syncBloch(unit); }
+  unit.inSuperpos=false;
+  unit.coherence=Math.min(unit.maxCoh, unit.coherence+12);
+  logEv(`MEASURE: ${coord(unit.row,unit.col)} collapses to |${collapsed}⟩ and stabilizes (coherence +12).`,'measure');
+  spawn(unit.col*CELL+CELL/2, unit.row*CELL+CELL/2,'#f5b73c',14);
+  sfxGate('MEASURE');
+  const el=document.getElementById('cnt-MEASURE');
+  if (el) el.textContent = parseInt(el.textContent||0)+1;
+}
+
+function applyCNOT(ctrl, tgt) {
+  ctrl.entangledWith=tgt.id; tgt.entangledWith=ctrl.id;
+  // Shared 4-amplitude Bell state |Φ+⟩ — the single source of truth for the
+  // pair's correlations (QB-6). q maps each unit id to its qubit index (0/1).
+  const bell = { amps: QPhysics.Bell.phiPlus(), q: {} };
+  bell.q[ctrl.id] = 0; bell.q[tgt.id] = 1;
+  ctrl.bell = bell; tgt.bell = bell;
+  GAME.entanglCount++;
+  logEv(`ENTANGLE: ${coord(ctrl.row,ctrl.col)} ⊗ ${coord(tgt.row,tgt.col)} — Bell link formed. `+
+    `A hit on one bleeds onto the other.`,'gate');
+  spawn(ctrl.col*CELL+CELL/2, ctrl.row*CELL+CELL/2,'#c05070',10);
+  spawn(tgt.col*CELL+CELL/2,  tgt.row*CELL+CELL/2, '#c05070',10);
+  sfxGate('CNOT');
+  const el=document.getElementById('cnt-CNOT');
+  if (el) el.textContent = parseInt(el.textContent||0)+1;
+  const _cnotTrig = `CNOT: Bell pair formed between ${coord(ctrl.row,ctrl.col)} and ${coord(tgt.row,tgt.col)} — strikes on one now bleed damage to the other`;
+  setTimeout(() => callSageAI(_cnotTrig).then(ok => { if (!ok) renderSage(); }), 300);
+}
+
+// ═══════════════════════════════════════════════════════
+// COMBAT — Charge & Measure
+// ═══════════════════════════════════════════════════════
+function destroyUnit(u) {
+  // Leave a death animation playing where the unit fell.
+  GAME.deaths.push({ sheet:unitSheet(u), x:u.px, y:u.py, facing:u.facing, fi:0, ft:0 });
+  spawn(u.px, u.py, FACTION[u.owner].col, 28);
+  spawn(u.px, u.py, '#ffffff', 10);
+  spawn(u.px, u.py, '#ffa83c', 14);
+  GAME.shake = Math.max(GAME.shake, 18);
+  GAME.pieces = GAME.pieces.filter(p=>p!==u);
+  GAME.pieces.forEach(p=>{ if(p.entangledWith===u.id){ p.entangledWith=null; p.bell=null; } });
+  if (GAME.selected===u) GAME.selected=null;
+}
+
+function damageUnit(u, dmg) {
+  u.hp -= dmg;
+  spawn(u.px, u.py, '#ff5a72', 10+dmg*4);
+  sfxCapture();
+  GAME.floats.push({text:'-'+dmg, x:u.px+(Math.random()-0.5)*18, y:u.py-CELL*0.35, vy:-1.5, life:1.0, color:'#ff5a72', size:10});
+  if (u.hp<=0) {
+    logEv(`DESTROYED: ${u.owner.toUpperCase()} unit at ${coord(u.row,u.col)} collapses out of play.`,'capture');
+    destroyUnit(u);
+  } else {
+    playOnce(u, 'damage');
+  }
+}
+
+// Attacking measures the attacker's qubit (Born rule): it discharges to |0⟩.
+// If it fired, the target is measured too — an excited target is caught exposed
+// and takes a critical hit. Entangled targets bleed 1 onto their Bell partner.
+function attack(attacker, target) {
+  const pAtt  = charge(attacker);
+  const fired = Math.random() < pAtt;
+  // Face the target and swing/cast (the attack animation plays regardless).
+  const fdx = target.col - attacker.col;
+  if (fdx) attacker.facing = fdx<0 ? -1 : 1;
+  playOnce(attacker, 'attack');
+  // The strike expends the unit's excitation — it returns to |0⟩, discharged.
+  attacker.state = blochToState(0,0); syncBloch(attacker); refreshSuperpos(attacker);
+
+  if (!fired) {
+    logEv(`MISFIRE: ${coord(attacker.row,attacker.col)} measured |0⟩ (P(hit) was ${(pAtt*100)|0}%) — no discharge.`,'info');
+    spawn(target.px, target.py,'#6b76a8',6);
+    GAME.floats.push({text:'MISS', x:target.px, y:target.py-CELL*0.4, vy:-1.0, life:0.7, color:'#6b76a8', size:7});
+    beep(196,'square',0.07,0.12);
+    const _mfTrig = `MISFIRE: ${coord(attacker.row,attacker.col)} rolled |0⟩ and missed ${coord(target.row,target.col)} — P(hit) was ${(pAtt*100)|0}%`;
+    setTimeout(() => callSageAI(_mfTrig).then(ok => { if (!ok) renderSage(); }), 400);
+    return;
+  }
+  // Mages hurl a spell blast at the target.
+  if (attacker.owner==='black') GAME.fx.push({ x:target.px, y:target.py, fi:0, ft:0 });
+  // QB-5 — a GUARDing unit is measured in the X-basis (apply H, then a Z-basis
+  // measurement): whether it is caught excited (a CRITICAL) depends on the
+  // relative phase φ it set up. |+⟩ is crit-immune, |−⟩ is fully exposed.
+  // Non-guarding units take the ordinary Z-basis measurement.
+  const tm = target.guarding ? measureState(GATES.H(target.state))
+                             : measureState(target.state);
+  target.state = tm.state; refreshSuperpos(target);
+  const crit = tm.collapsed===1;
+  // QB-6 — measuring an entangled target collapses its partner with a
+  // correlated outcome (|Φ+⟩ ⇒ same bit), then the entanglement is destroyed.
+  if (target.bell) {
+    const bp = GAME.pieces.find(p => p.bell === target.bell && p !== target);
+    if (bp) {
+      bp.state = _EIGEN(tm.collapsed); syncBloch(bp); refreshSuperpos(bp);
+      logEv(`CORRELATED COLLAPSE: ${coord(bp.row,bp.col)} → |${tm.collapsed}⟩ via the Bell pair.`,'quantum');
+    }
+  }
+  const dmg  = crit?2:1;
+  if (crit) {
+    GAME.shake = Math.max(GAME.shake, 16);
+    GAME.critCount++;
+    sfxCrit();
+    GAME.floats.push({text:'CRITICAL!', x:target.px+(Math.random()-0.5)*12, y:target.py-CELL*0.7, vy:-0.8, life:1.6, color:'#ffa83c', size:9});
+    spawn(target.px, target.py, '#ffa83c', 16);
+  } else {
+    GAME.shake = Math.max(GAME.shake, 8);
+  }
+  logEv(`STRIKE: ${coord(attacker.row,attacker.col)} → ${coord(target.row,target.col)} for ${dmg}`+
+    `${crit?' (CRITICAL — target caught in |1⟩!)':''}.`,'capture');
+  spawn(attacker.px, attacker.py, FACTION[attacker.owner].col, 8);
+  const partner = target.entangledWith && GAME.pieces.find(p=>p.id===target.entangledWith);
+  // Flash the entanglement beam when a hit propagates.
+  if (partner) {
+    const bKey = [target.id, partner.id].sort().join('|');
+    GAME.beamFlash[bKey] = 30;
+  }
+  damageUnit(target, dmg);
+  if (partner && GAME.pieces.includes(partner)) {
+    logEv(`ENTANGLED SPLASH: ${coord(partner.row,partner.col)} shares 1 damage via Bell link.`,'quantum');
+    damageUnit(partner, 1);
+  }
+  // Measurement destroyed the entanglement — break the link on both halves.
+  if (target.bell) { if (partner) { partner.bell=null; partner.entangledWith=null; } target.bell=null; target.entangledWith=null; }
+  const _splash = partner ? ` (Bell link splashed 1 dmg to ${coord(partner.row,partner.col)})` : '';
+  const _atTrig = crit
+    ? `CRITICAL HIT: ${coord(attacker.row,attacker.col)} measured ${coord(target.row,target.col)} in |1⟩ — 2 dmg${_splash}`
+    : `Strike: ${coord(attacker.row,attacker.col)} → ${coord(target.row,target.col)} — 1 dmg${_splash}`;
+  setTimeout(() => callSageAI(_atTrig).then(ok => { if (!ok) renderSage(); }), 400);
+}
+
+// ═══════════════════════════════════════════════════════
+// WIN CONDITION — elimination (turn cap → most units, then HP)
+// ═══════════════════════════════════════════════════════
+function checkWinner(force) {
+  const w=aliveCount('white'), b=aliveCount('black');
+  if (w===0 && b===0) return 'draw';
+  if (b===0) return 'white';
+  if (w===0) return 'black';
+  if (force) {
+    if (w!==b) return w>b?'white':'black';
+    const hw=totalHp('white'), hb=totalHp('black');
+    return hw>hb?'white':hb>hw?'black':'draw';
+  }
+  return null;
+}
+
+async function endTurn() {
+  // Stop any running blitz timer; clear guard stances for current side.
+  stopTurnTimer();
+  GAME.pieces.filter(p=>p.owner===GAME.turn).forEach(p=>{ p.guarding=false; });
+  // Wait for all sprites to finish their current action before processing the turn.
+  await waitForAnims(120);
+
+  applyDecoherence();
+
+  GAME.winner = checkWinner(false);
+  if (GAME.winner) {
+    logEv(`🏆 ${GAME.winner==='draw'?'DRAW — mutual annihilation':FACTION[GAME.winner].name+' WINS — enemy qubits eliminated'}.`,'measure');
+    GAME.phase='gameover'; sfxWin(); updateHUD();
+    checkLeaderboard();
+    // Campaign win check
+    if (GAME.campaignMission !== null) {
+      const m = CAMPAIGN_MISSIONS[GAME.campaignMission];
+      if (m && GAME.winner !== 'draw') {
+        GAME.campaignDone = GAME.campaignDone || [];
+        if (!GAME.campaignDone.includes(GAME.campaignMission)) GAME.campaignDone.push(GAME.campaignMission);
+        setTimeout(() => { startTypewriter('Mission complete! ' + m.winText); }, 600);
+      }
+    }
+    return;
+  }
+
+  GAME.turn      = GAME.turn==='white'?'black':'white';
+  GAME.phase     = 'play';
+  GAME.selected  = null; GAME.reachable = [];
+  GAME.gateMenu  = null; GAME.cnotMode = false; GAME.attackMode = false; GAME.attackSource = null;
+  GAME.turnCount++;
+
+  if (GAME.turnCount >= GAME.turnCap) {
+    GAME.winner = checkWinner(true);
+    logEv(`⌛ TURN LIMIT — ${GAME.winner==='draw'?'a tie':FACTION[GAME.winner].name+' wins on units / HP'}.`,'measure');
+    GAME.phase='gameover'; sfxWin(); updateHUD(); return;
+  }
+
+  updateHUD();
+  updateSelInfo(null);
+  startTurnTimer();
+
+  const isBotTurn = (GAME.mode==='vsBot' && GAME.turn===GAME.botColor) || GAME.mode==='attract';
+  if (isBotTurn) setTimeout(doBotMove, GAME.mode==='attract'?1200:TURN_DELAY);
+  else setTimeout(() => callSageAI(`${GAME.turn==='white'?'KNIGHTS':'MAGES'} turn begins — strategic overview`).then(ok => { if (!ok) renderSage(); }), 500);
+}
+
+// ═══════════════════════════════════════════════════════
+// BOT AI
+// ═══════════════════════════════════════════════════════
+async function doBotMove() {
+  if (GAME.winner) return;
+  const me = GAME.mode==='attract' ? GAME.turn : GAME.botColor;
+  if (GAME.turn !== me) return;
+  const mine = GAME.pieces.filter(p=>p.owner===me);
+  const foes = GAME.pieces.filter(p=>p.owner!==me);
+  if (!mine.length || !foes.length) { endTurn(); return; }
+
+  const rnd = [6, 3, 1][GAME.difficulty];
+  let best=null, bestScore=-Infinity;
+
+  mine.forEach(u=>{
+    const spots = [{row:u.row,col:u.col}, ...reachableTiles(u)];
+    const pAtt  = charge(u);
+    spots.forEach(s=>{
+      let nearest=99, adj=null;
+      foes.forEach(f=>{
+        const d=Math.abs(f.row-s.row)+Math.abs(f.col-s.col);
+        if (d<nearest) nearest=d;
+        if (d===1 && (!adj || f.hp<adj.hp)) adj=f;
+      });
+      let score = -nearest;
+      if (adj) {
+        score += 6 + pAtt*9;
+        if (adj.hp<=1 && pAtt>0.5) score += 6;
+        if (pAtt < 0.2) score -= 3;
+      }
+      score += Math.random()*rnd;
+      if (score>bestScore) { bestScore=score; best={u, s}; }
+    });
+  });
+
+  if (!best) { endTurn(); return; }
+  const {u, s} = best;
+  GAME.selected = u;
+
+  // Move: just update the row/col — advanceAnims will tween px/py automatically.
+  if (s.row!==u.row || s.col!==u.col) {
+    u.row=s.row; u.col=s.col;
+    spawn(u.col*CELL+CELL/2, u.row*CELL+CELL/2, FACTION[me].col, 6);
+    sfxMove();
+    // Wait for the walk tween to finish before striking.
+    await waitForAnims(180);
+  }
+
+  updateSelInfo(u);
+
+  // ── Action selection — uses the full action set, scaled by difficulty so
+  //    players see (and get punished by) MEASURE, CNOT, GUARD and phase. ──
+  const diff   = GAME.difficulty;                 // 0 easy · 1 medium · 2 hard
+  const myChg  = charge(u);
+  const adjFoes = adjacentEnemies(u);
+  const target = adjFoes.sort((a,b)=>a.hp-b.hp)[0];
+  // An adjacent enemy that is itself charged can crit u next turn.
+  const threat = adjFoes.some(f => charge(f) > 0.5);
+  const advanced = [0, 0.45, 0.8][diff];          // chance to reach for a smart play
+
+  // 1) Take a strong shot if we have one.
+  if (target && myChg > 0.6) {
+    GAME.botLastReason = `Bot strikes ${coord(target.row,target.col)} — charge ${(myChg*100)|0}%, Born rule: P(hit) = |β|².`;
+    attack(u, target);
+
+  // 2) Guardian under threat → brace in the X-basis. Hard bots set up |+⟩ with H
+  //    first (next turn) but a bare guard already halves the crit risk.
+  } else if (u.role==='guardian' && threat && diff>=1 && Math.random()<advanced) {
+    u.guarding = true; refreshSuperpos(u);
+    u.coherence = Math.min(u.maxCoh, u.coherence+8);
+    GAME.botLastReason = `Bot GUARDS ${coord(u.row,u.col)} — bracing in the X-basis (${(QPhysics.guardCritProb(u.state)*100)|0}% crit risk) against the adjacent threat.`;
+    sfxGate('Z');
+
+  // 3) MEASURE-discharge a dangerously exposed unit: in superposition, charged,
+  //    and threatened — collapse now to (maybe) drop to a safe |0⟩.
+  } else if (diff>=1 && threat && u.inSuperpos && myChg>0.4 && !target && Math.random()<advanced) {
+    GAME.botLastReason = `Bot MEASURES ${coord(u.row,u.col)} — discharging a unit about to be crit (collapse to an eigenstate).`;
+    applyMeasure(u);
+
+  // 4) CNOT-link an adjacent enemy into a Bell pair so the bot's next strike
+  //    splashes — hard bots only, and only when not about to be self-splashed.
+  } else if (diff>=2 && !u.entangledWith && target && myChg < 0.6 && !threat && Math.random()<0.4) {
+    GAME.botLastReason = `Bot uses CNOT on ${coord(target.row,target.col)} — forming a Bell pair so a later strike bleeds onto its partner.`;
+    applyCNOT(u, target);
+
+  // 5) Can't finish a kill — charge up. X for a sure |1⟩, or gamble on H
+  //    (superposition) when the bot wants to act fast.
+  } else if (myChg < 0.6) {
+    const gate = (diff>=1 && !target && Math.random()<advanced) ? 'H' : 'X';
+    GAME.botLastReason = gate==='H'
+      ? `Bot applies H to ${coord(u.row,u.col)} — entering |+⟩ superposition (~50% charge). A fast gamble.`
+      : `Bot charges ${coord(u.row,u.col)} with X — flipping to |1⟩ for a guaranteed strike next turn.`;
+    applyGate(u, gate);
+
+  // 6) Charged and adjacent — take the shot.
+  } else if (target) {
+    GAME.botLastReason = `Bot strikes ${coord(target.row,target.col)} — measuring the enemy at ${(myChg*100)|0}% charge.`;
+    attack(u, target);
+
+  } else {
+    GAME.botLastReason = `Bot charges ${coord(u.row,u.col)} with X — no enemy in reach yet, building toward |1⟩.`;
+    applyGate(u, 'X');
+  }
+
+  // Let the action animation finish before ending the turn.
+  await waitForAnims(200);
+  GAME.selected=null; GAME.gateMenu=null;
+  endTurn();
+}
+
+// ═══════════════════════════════════════════════════════
+// RENDERING
+// ═══════════════════════════════════════════════════════
+const canvas = document.getElementById('game-canvas');
+const ctx    = canvas.getContext('2d');
+// Keep canvas dimensions in sync with BOARD constant at runtime.
+canvas.width = BOARD; canvas.height = BOARD;
+const sageCanvas = document.getElementById('sage-portrait');
+const sageCtx    = sageCanvas ? sageCanvas.getContext('2d') : null;
+let   _t     = 0;
+
+// ── The Sage — Elite Mage portrait in the retro dialogue bar ──
+let _sageFi=0, _sageFt=0;
+function drawSageNPC() {
+  if (!sageCtx) return;
+  const W=sageCanvas.width, H=sageCanvas.height;  // 100×86
+  const t=_t;
+  sageCtx.clearRect(0,0,W,H);
+
+  // Deep arcane background glow
+  const ga=sageCtx.createRadialGradient(W/2,H*0.7,2,W/2,H*0.7,W*0.55);
+  ga.addColorStop(0,`rgba(139,125,255,${0.22+0.09*Math.sin(t*0.08)})`);
+  ga.addColorStop(1,'rgba(139,125,255,0)');
+  sageCtx.fillStyle=ga; sageCtx.fillRect(0,0,W,H);
+
+  if (imgMageReady) {
+    _sageFt+=16; if (_sageFt>=90){ _sageFt=0; _sageFi=(_sageFi+1)%SHEETS.mage.anims.idle.n; }
+    const fw=64, fh=32, sx=_sageFi*fw, sy=0;
+    const scale=1.48, w=fw*scale, h=fh*scale;  // ~94.7×47.4 — fills 100×86 nicely
+    const bob=Math.sin(t*0.06)*1.5;
+    sageCtx.save();
+    sageCtx.imageSmoothingEnabled=false;
+    sageCtx.translate(W/2, 0); sageCtx.scale(-1,1);   // face right (toward board)
+    sageCtx.drawImage(imgMage, sx,sy, fw,fh, -w/2, H-h-3+bob, w, h);
+    sageCtx.restore();
+  } else {
+    // Fallback orb when image not yet loaded
+    const gr=sageCtx.createRadialGradient(W/2,H*0.6,2,W/2,H*0.6,22);
+    gr.addColorStop(0,'#b9b4ff'); gr.addColorStop(1,'#3b34c0');
+    sageCtx.fillStyle=gr;
+    sageCtx.beginPath(); sageCtx.arc(W/2,H*0.6,22,0,2*Math.PI); sageCtx.fill();
+    sageCtx.fillStyle='rgba(255,255,255,0.85)';
+    sageCtx.font="14px serif"; sageCtx.textAlign='center';
+    sageCtx.fillText('🔮',W/2,H*0.6+5);
+  }
+}
+
+// ── Active biome helpers ───────────────────────────────
+// Returns the biome image currently active (grass or snow) for both board + bg.
+function isSnowBiome() { return document.body.classList.contains('biome-snow'); }
+function activeBiomeImg()  { return isSnowBiome() ? (imgSnowReady  ? imgSnow  : null) : (imgGrassReady ? imgGrass : null); }
+function alternateBiomeImg(){ return isSnowBiome() ? (imgGrassReady ? imgGrass : null) : (imgSnowReady  ? imgSnow  : null); }
+
+// ── Board ──────────────────────────────────────────────
+function drawBoard() {
+  ctx.imageSmoothingEnabled=false;
+  const hy=(GRID-1)*CELL, vc=BOARD/2;
+
+  // ── Quantum field ground — deep navy with a soft central glow (matches the
+  // UI chrome). Replaces the RPG biome so the board reads as a quantum lattice. ──
+  const bg=ctx.createLinearGradient(0,0,0,BOARD);
+  bg.addColorStop(0,'#0a0f24'); bg.addColorStop(0.5,'#0b1430'); bg.addColorStop(1,'#0a0f24');
+  ctx.fillStyle=bg; ctx.fillRect(0,0,BOARD,BOARD);
+  const fieldPulse=0.5+0.5*Math.sin(_t*0.02);
+  const glow=ctx.createRadialGradient(vc,vc,BOARD*0.04,vc,vc,BOARD*0.62);
+  glow.addColorStop(0,`rgba(47,224,208,${0.05+0.02*fieldPulse})`);
+  glow.addColorStop(0.6,'rgba(139,125,255,0.045)');
+  glow.addColorStop(1,'rgba(0,0,0,0)');
+  ctx.fillStyle=glow; ctx.fillRect(0,0,BOARD,BOARD);
+
+  // ── Faction camps: energized home-row strips (knights teal / mages magenta). ──
+  const camp=(y,rgb)=>{ const g=ctx.createLinearGradient(0,y,0,y+CELL);
+    g.addColorStop(0,`rgba(${rgb},0.18)`); g.addColorStop(1,`rgba(${rgb},0.03)`);
+    ctx.fillStyle=g; ctx.fillRect(0,y,BOARD,CELL); };
+  camp(0,'255,77,157');            // top — MAGES
+  camp(hy,'47,224,208');           // bottom — KNIGHTS
+
+  // ── Quantum lattice: grid lines + glowing nodes at every intersection. ──
+  ctx.strokeStyle='rgba(124,140,230,0.15)'; ctx.lineWidth=1;
+  for (let i=0;i<=GRID;i++){
+    ctx.beginPath(); ctx.moveTo(0,i*CELL+0.5); ctx.lineTo(BOARD,i*CELL+0.5); ctx.stroke();
+    ctx.beginPath(); ctx.moveTo(i*CELL+0.5,0); ctx.lineTo(i*CELL+0.5,BOARD); ctx.stroke();
+  }
+  const nodePulse=0.5+0.5*Math.sin(_t*0.045);
+  ctx.fillStyle=`rgba(124,140,230,${0.16+0.10*nodePulse})`;
+  for (let r=0;r<=GRID;r++) for (let c=0;c<=GRID;c++){
+    ctx.beginPath(); ctx.arc(c*CELL,r*CELL,1.1,0,2*π); ctx.fill();
+  }
+
+  // ── Terrain cells: barriers (impassable "vacuum gaps") + quantum wells. ──
+  const wellPulse=0.5+0.5*Math.sin(_t*0.07);
+  Object.entries(TERRAIN).forEach(([k,type])=>{
+    const idx=parseInt(k), tr=Math.floor(idx/GRID), tc=idx%GRID, x=tc*CELL, y=tr*CELL;
+    if (type==='tree') {                 // impassable barrier — a dark, hatched gap
+      ctx.fillStyle='rgba(6,9,20,0.82)'; ctx.fillRect(x+2,y+2,CELL-4,CELL-4);
+      ctx.strokeStyle='rgba(124,140,230,0.28)'; ctx.lineWidth=1;
+      ctx.strokeRect(x+3.5,y+3.5,CELL-7,CELL-7);
+      ctx.save(); ctx.beginPath(); ctx.rect(x+2,y+2,CELL-4,CELL-4); ctx.clip();
+      ctx.strokeStyle='rgba(124,140,230,0.14)';
+      for (let i=-CELL;i<CELL;i+=7){ ctx.beginPath(); ctx.moveTo(x+i,y); ctx.lineTo(x+i+CELL,y+CELL); ctx.stroke(); }
+      ctx.restore();
+    } else if (type==='well') {          // coherence booster — glowing teal cell
+      ctx.fillStyle=`rgba(63,224,138,${0.10*wellPulse})`; ctx.fillRect(x,y,CELL,CELL);
+      ctx.strokeStyle=`rgba(63,224,138,${0.42*wellPulse})`; ctx.lineWidth=1.5;
+      ctx.shadowColor='#3fe08a'; ctx.shadowBlur=8*wellPulse;
+      ctx.strokeRect(x+3,y+3,CELL-6,CELL-6); ctx.shadowBlur=0;
+      ctx.fillStyle=`rgba(63,224,138,${0.7*wellPulse})`;
+      ctx.font="9px 'Press Start 2P',monospace"; ctx.textAlign='center'; ctx.textBaseline='middle';
+      ctx.fillText('⚛',x+CELL/2,y+CELL/2); ctx.textAlign='left'; ctx.textBaseline='alphabetic';
+    }
+  });
+
+  // ── Rank/file coordinates (crisp, low-key). ──
+  ctx.font="8px 'Press Start 2P',monospace"; ctx.fillStyle='rgba(174,184,230,0.5)';
+  for (let r=0;r<GRID;r++){ ctx.textAlign='left'; ctx.textBaseline='top'; ctx.fillText(GRID-r, 4, r*CELL+4); }
+  for (let c=0;c<GRID;c++){ ctx.textAlign='right'; ctx.textBaseline='bottom'; ctx.fillText('abcdefgh'[c], c*CELL+CELL-4, BOARD-4); }
+  ctx.textAlign='left'; ctx.textBaseline='alphabetic';
+
+  // ── Soft edge vignette. ──
+  const vg=ctx.createRadialGradient(vc,vc,BOARD*0.40,vc,vc,BOARD*0.78);
+  vg.addColorStop(0,'rgba(0,0,0,0)'); vg.addColorStop(1,'rgba(2,4,12,0.42)');
+  ctx.fillStyle=vg; ctx.fillRect(0,0,BOARD,BOARD);
+}
+
+// ── Highlights ─────────────────────────────────────────
+function drawHighlights() {
+  const u = GAME.selected;
+
+  // Reachable move tiles + strike targets (only while choosing a move).
+  if (u && !GAME.gateMenu && !GAME.attackMode && !GAME.cnotMode) {
+    const pulse=0.55+0.45*Math.sin(_t*0.09);
+    GAME.reachable.forEach(t=>{
+      const x=t.col*CELL, y=t.row*CELL;
+      ctx.fillStyle=`rgba(63,224,138,${0.10*pulse})`; ctx.fillRect(x,y,CELL,CELL);
+      ctx.fillStyle='#3fe08a'; ctx.shadowColor='#3fe08a'; ctx.shadowBlur=5*pulse;
+      ctx.beginPath(); ctx.arc(x+CELL/2,y+CELL/2,5*pulse,0,2*π); ctx.fill();
+      ctx.shadowBlur=0;
+    });
+    adjacentEnemies(u).forEach(e=>{
+      const x=e.col*CELL, y=e.row*CELL;
+      ctx.strokeStyle='#ff5a72'; ctx.lineWidth=2;
+      ctx.shadowColor='#ff5a72'; ctx.shadowBlur=8;
+      ctx.strokeRect(x+3,y+3,CELL-6,CELL-6); ctx.shadowBlur=0;
+    });
+  }
+
+  // Selected-unit ring.
+  if (u) {
+    ctx.fillStyle='rgba(139,125,255,0.14)';
+    ctx.fillRect(u.col*CELL,u.row*CELL,CELL,CELL);
+    ctx.strokeStyle='#8b7dff'; ctx.lineWidth=2.5;
+    ctx.shadowColor='#8b7dff'; ctx.shadowBlur=14;
+    ctx.strokeRect(u.col*CELL+2,u.row*CELL+2,CELL-4,CELL-4);
+    ctx.shadowBlur=0;
+  }
+
+  // Attack-target mode: pulse adjacent enemies.
+  if (GAME.attackMode && GAME.attackSource) {
+    const pulse=0.6+0.4*Math.sin(_t*0.18);
+    adjacentEnemies(GAME.attackSource).forEach(e=>{
+      const x=e.col*CELL, y=e.row*CELL;
+      ctx.strokeStyle=`rgba(255,90,114,${pulse})`; ctx.lineWidth=3;
+      ctx.shadowColor='#ff5a72'; ctx.shadowBlur=12*pulse;
+      ctx.strokeRect(x+3,y+3,CELL-6,CELL-6); ctx.shadowBlur=0;
+    });
+  }
+
+  // Entangle mode: pulse adjacent units (friend or foe).
+  if (GAME.cnotMode && GAME.cnotControl) {
+    const pulse=0.6+0.4*Math.sin(_t*0.13);
+    GAME.pieces.forEach(p2=>{
+      if (p2===GAME.cnotControl || !adjacent(p2,GAME.cnotControl)) return;
+      const x=p2.col*CELL, y=p2.row*CELL;
+      ctx.strokeStyle=`rgba(255,77,157,${pulse})`;
+      ctx.lineWidth=2; ctx.setLineDash([5,5]);
+      ctx.strokeRect(x+4,y+4,CELL-8,CELL-8); ctx.setLineDash([]);
+    });
+  }
+}
+
+// ── Entanglement beams ─────────────────────────────────
+function drawEntanglementBeams() {
+  const drawn=new Set();
+  GAME.pieces.forEach(p=>{
+    if (!p.entangledWith) return;
+    const key=[p.id,p.entangledWith].sort().join('|');
+    if (drawn.has(key)) return;
+    drawn.add(key);
+    const partner=GAME.pieces.find(q=>q.id===p.entangledWith);
+    if (!partner) return;
+    const x1=p.col*CELL+CELL/2, y1=p.row*CELL+CELL/2;
+    const x2=partner.col*CELL+CELL/2, y2=partner.row*CELL+CELL/2;
+    const pulse=0.55+0.45*Math.sin(_t*0.09);
+    // Flash when a linked hit just occurred.
+    const flash = GAME.beamFlash[key] || 0;
+    const isFlashing = flash > 0;
+    if (isFlashing) GAME.beamFlash[key] = Math.max(0, flash - 1);
+    // Alternate hot-pink / cyan every 40 ticks.
+    const altA = (_t%80<40);
+    const baseR = isFlashing ? '255,60,60' : (altA ? '255,77,157' : '47,224,208');
+    const baseAlpha = isFlashing ? 0.95 : (0.78*pulse);
+    ctx.save();
+    // Outer glow
+    ctx.strokeStyle=`rgba(${baseR},${baseAlpha})`;
+    ctx.lineWidth=isFlashing ? 4.5 : 3;
+    ctx.shadowColor=isFlashing ? '#ff3c3c' : (altA ? '#ff4d9d' : '#2fe0d0');
+    ctx.shadowBlur=isFlashing ? 22 : 14*pulse;
+    ctx.setLineDash([7,5]);
+    ctx.lineDashOffset=-(_t*0.9);
+    ctx.beginPath(); ctx.moveTo(x1,y1); ctx.lineTo(x2,y2); ctx.stroke();
+    // Inner bright core
+    ctx.strokeStyle=`rgba(255,255,255,${isFlashing?0.9:0.28*pulse})`;
+    ctx.lineWidth=1.2; ctx.shadowBlur=0; ctx.setLineDash([]);
+    ctx.beginPath(); ctx.moveTo(x1,y1); ctx.lineTo(x2,y2); ctx.stroke();
+    ctx.restore();
+    ctx.setLineDash([]);
+  });
+}
+
+// ── Pieces ─────────────────────────────────────────────
+function drawPiece(u) {
+  const cx = (u.px!==undefined ? u.px : u.col*CELL+CELL/2);
+  const cy = (u.py!==undefined ? u.py : u.row*CELL+CELL/2);
+  const fac=FACTION[u.owner];
+  const ch=charge(u);                       // P(|1⟩) — combat charge
+
+  // Ground aura under the character (hot red as it charges toward |1⟩).
+  const auraPulse=0.7+0.3*Math.sin(_t*0.06+u.col*0.7+u.row*1.1);
+  const auraRGB = ch>0.6 ? '255,90,114' : fac.rgb;
+  const gy=cy+CELL*0.34;
+  const ga=ctx.createRadialGradient(cx,gy,3,cx,gy,CELL*0.5);
+  ga.addColorStop(0,`rgba(${auraRGB},${(0.20+0.26*ch)*auraPulse})`);
+  ga.addColorStop(1,`rgba(${auraRGB},0)`);
+  ctx.fillStyle=ga; ctx.beginPath(); ctx.ellipse(cx,gy,CELL*0.44,CELL*0.18,0,0,2*π); ctx.fill();
+
+  // Entanglement ring at the feet.
+  if (u.entangledWith) {
+    const pulse=0.45+0.55*Math.sin(_t*0.055);
+    ctx.strokeStyle=`rgba(255,77,157,${0.6*pulse})`;
+    ctx.lineWidth=1.5; ctx.setLineDash([4,4]);
+    ctx.shadowColor='#ff4d9d'; ctx.shadowBlur=8*pulse;
+    ctx.beginPath(); ctx.ellipse(cx,gy,CELL*0.34,CELL*0.15,0,0,2*π); ctx.stroke();
+    ctx.setLineDash([]); ctx.shadowBlur=0;
+  }
+
+  // The animated knight/mage (fallback to the procedural sprite if not loaded).
+  if (!drawCharFrame(unitSheet(u), u.anim, u.fi, cx, cy, u.facing)) {
+    const m=fac.rgb.split(',').map(Number);
+    drawSprite(cx, cy-2, CELL, 'unit', `rgb(${m[0]},${m[1]},${m[2]})`,
+      `rgb(${Math.min(255,m[0]+62)},${Math.min(255,m[1]+60)},${Math.min(255,m[2]+56)})`,
+      `rgb(${Math.max(0,m[0]-72)},${Math.max(0,m[1]-72)},${Math.max(0,m[2]-64)})`);
+  }
+  ctx.shadowBlur=0;
+
+  // QB-8 — colorblind-safe side marker: a faction initial (Knights = K,
+  // Mages = M) with a dark outline, so White/Black are not distinguished by
+  // colour alone. Position (top-left badge) is itself a redundant cue.
+  {
+    const letter = u.owner === 'white' ? 'K' : 'M';
+    const bx = cx - CELL*0.30, by = cy - CELL*0.34;
+    ctx.save();
+    ctx.font = `bold ${Math.max(9, Math.round(CELL*0.17))}px 'Press Start 2P', monospace`;
+    ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+    ctx.lineWidth = 3; ctx.strokeStyle = 'rgba(0,0,0,0.88)';
+    ctx.strokeText(letter, bx, by);
+    ctx.fillStyle = fac.col;
+    ctx.fillText(letter, bx, by);
+    ctx.restore();
+  }
+
+  // HP pips above the head.
+  const headY = cy - CELL*0.60;
+  const pipW=Math.max(6, Math.round(CELL*0.10)), gap=3;
+  const totW=u.maxHp*pipW+(u.maxHp-1)*gap, px0=cx-totW/2;
+  for (let i=0;i<u.maxHp;i++){
+    ctx.fillStyle = i<u.hp ? '#3fe08a' : 'rgba(255,255,255,0.16)';
+    if (i<u.hp){ctx.shadowColor='#3fe08a';ctx.shadowBlur=4;}
+    ctx.fillRect(px0+i*(pipW+gap), headY, pipW, 4);
+    ctx.shadowBlur=0;
+  }
+
+  // Charge bar just below the HP pips.
+  const bW=Math.round(CELL*0.55),bH=4,bX=cx-bW/2,bY=headY+7;
+  ctx.fillStyle='rgba(0,0,0,0.5)'; ctx.fillRect(bX-1,bY-1,bW+2,bH+2);
+  const cc = ch>0.66?'#ff5a72': ch>0.33?'#f5b73c':'#3fe08a';
+  ctx.fillStyle=cc; if (ch>0.05){ctx.shadowColor=cc;ctx.shadowBlur=4;}
+  ctx.fillRect(bX,bY,Math.round(bW*ch),bH); ctx.shadowBlur=0;
+
+  // ── Mini Bloch glyph (live qubit orientation indicator) ──
+  const {theta:bTh,phi:bPh}=stateToBloch(u.state);
+  const gR=Math.max(6,Math.round(CELL*0.090));
+  const gCx=bX+bW+gR+4, gCy=bY+bH/2;
+  ctx.strokeStyle='rgba(140,150,200,0.35)'; ctx.lineWidth=0.8;
+  ctx.beginPath(); ctx.arc(gCx,gCy,gR,0,2*π); ctx.stroke();
+  const gvx=Math.sin(bTh)*Math.cos(bPh)*0.75;
+  const gvz=Math.cos(bTh);
+  const gSx=gCx+gR*gvx, gSy=gCy-gR*gvz;
+  const gCol = ch>0.5?'#ff5a72': ch>0.15?'#f5b73c':'#3fe08a';
+  ctx.strokeStyle=gCol; ctx.lineWidth=1.5;
+  ctx.shadowColor=gCol; ctx.shadowBlur=4;
+  ctx.beginPath(); ctx.moveTo(gCx,gCy); ctx.lineTo(gSx,gSy); ctx.stroke();
+  ctx.fillStyle=gCol;
+  ctx.beginPath(); ctx.arc(gSx,gSy,1.8,0,2*π); ctx.fill();
+  ctx.shadowBlur=0;
+
+  // ── Guardian badge ──
+  if (u.role==='guardian') {
+    ctx.font=`bold ${Math.max(6,Math.round(CELL*0.085))}px 'Press Start 2P',monospace`;
+    ctx.textAlign='center';
+    ctx.fillStyle=fac.col; ctx.shadowColor=fac.col; ctx.shadowBlur=6;
+    ctx.fillText('G', cx, headY-3);
+    ctx.shadowBlur=0; ctx.textAlign='left';
+  }
+
+  // ── Guard-stance shield ring ──
+  if (u.guarding) {
+    const gsPulse=0.65+0.35*Math.sin(_t*0.12);
+    ctx.strokeStyle=`rgba(139,125,255,${gsPulse})`; ctx.lineWidth=3;
+    ctx.shadowColor='#8b7dff'; ctx.shadowBlur=18*gsPulse;
+    ctx.beginPath(); ctx.arc(cx,cy,CELL*0.48,0,2*π); ctx.stroke();
+    ctx.shadowBlur=0;
+  }
+}
+
+// Transient death animations + spell blasts (drawn above the units).
+function drawDeaths() {
+  GAME.deaths.forEach(d=> drawCharFrame(d.sheet, 'death', d.fi, d.x, d.y, d.facing));
+}
+function drawFx() {
+  if (!imgBlastReady) return;
+  ctx.imageSmoothingEnabled=false;
+  GAME.fx.forEach(f=>{
+    const fr=Math.min(f.fi,5), w=CELL*1.4, h=CELL*1.4;
+    ctx.drawImage(imgBlast, fr*128,0,128,128, f.x-w/2, f.y-h/2, w, h);
+  });
+}
+
+// ── Particles ──────────────────────────────────────────
+function drawParticles() {
+  GAME.particles.forEach(p=>{
+    ctx.globalAlpha=p.life;
+    ctx.fillStyle=p.color;
+    ctx.beginPath(); ctx.arc(p.x,p.y,p.r*p.life,0,2*π); ctx.fill();
+  });
+  ctx.globalAlpha=1;
+}
+
+// ── Gate menu ──────────────────────────────────────────
+// ── Gate color palette (used by menu + detail panel) ──
+const GATE_COLORS = {
+  ATTACK:'#ff5a72', H:'#2fe0d0', X:'#ff4d9d', Y:'#ffa83c',
+  Z:'#8b7dff',    S:'#3fe08a', T:'#f5b73c', Rx:'#2fe0d0',
+  Ry:'#3fe08a',   CNOT:'#c97bff', MEASURE:'#f5b73c', SKIP:'#6b76a8',
+};
+
+// ── Canvas text-wrap helper ──
+function wrapText(context, text, x, y, maxWidth, lineHeight) {
+  const words = text.split(' ');
+  let line = '';
+  for (let n = 0; n < words.length; n++) {
+    const testLine = line + words[n] + ' ';
+    if (context.measureText(testLine).width > maxWidth && n > 0) {
+      context.fillText(line, x, y);
+      line = words[n] + ' ';
+      y += lineHeight;
+    } else { line = testLine; }
+  }
+  context.fillText(line, x, y);
+}
+
+// ── Typewriter effect for sage dialogue bar ──
+let _sageTypeTimer = null;
+let _sageTyping    = null;
+
+function startTypewriter(text) {
+  if (_sageTypeTimer) clearTimeout(_sageTypeTimer);
+  _sageTyping = { text, idx: 0 };
+  const el = document.getElementById('sage-bar-text');
+  const more = document.getElementById('sage-bar-more');
+  if (el) el.textContent = '';
+  if (more) more.classList.remove('show');
+  typeNext();
+}
+
+function typeNext() {
+  if (!_sageTyping) return;
+  const el = document.getElementById('sage-bar-text');
+  if (!el) { _sageTyping = null; return; }
+  const { text, idx } = _sageTyping;
+  if (idx >= text.length) {
+    const more = document.getElementById('sage-bar-more');
+    if (more) more.classList.add('show');
+    _sageTyping = null; return;
+  }
+  el.textContent = text.slice(0, idx + 1);
+  _sageTyping.idx++;
+  _sageTypeTimer = setTimeout(typeNext, 20);
+}
+
+const MENU_W=192, MENU_IH=33;
+const SAGE_BAR_H=82;  // sage dialogue bar overlays bottom of canvas
+
+function menuPos(piece) {
+  const MH = GAME.gateMenu ? GAME.gateMenu.options.length*MENU_IH+48 : 0;
+  let mx=piece.col*CELL+CELL+6, my=piece.row*CELL;
+  if (mx+MENU_W>BOARD) mx=piece.col*CELL-MENU_W-6;
+  const maxY = BOARD - SAGE_BAR_H;
+  if (my+MH>maxY) my=maxY-MH;
+  if (my<0) my=0;
+  return {mx,my,MH};
+}
+
+function drawGateMenu() {
+  if (!GAME.gateMenu) return;
+  const {piece, options} = GAME.gateMenu;
+  const {mx, my, MH} = menuPos(piece);
+  const hovered = GAME._menuHover;
+
+  ctx.save();
+  ctx.textAlign = 'left';
+
+  // ── Main menu card ─────────────────────────────────────
+  // Dark bg
+  ctx.fillStyle = 'rgba(4,6,20,0.97)';
+  roundRect(mx, my, MENU_W, MH, 4); ctx.fill();
+
+  // Outer pixel border
+  ctx.strokeStyle = '#5a4cd6';
+  ctx.lineWidth = 2;
+  roundRect(mx, my, MENU_W, MH, 4); ctx.stroke();
+
+  // Inner highlight border
+  ctx.strokeStyle = 'rgba(139,125,255,0.28)';
+  ctx.lineWidth = 1;
+  roundRect(mx+3, my+3, MENU_W-6, MH-6, 3); ctx.stroke();
+
+  // Header bar
+  ctx.fillStyle = '#5a4cd6';
+  roundRect(mx, my, MENU_W, 22, 4); ctx.fill();
+  ctx.fillRect(mx, my+11, MENU_W, 11);
+
+  ctx.fillStyle = '#ffffff';
+  ctx.font = "bold 7px 'Press Start 2P',monospace";
+  ctx.textAlign = 'center';
+  ctx.fillText('⚡ CONTROL PULSES', mx + MENU_W/2, my+15);
+  ctx.textAlign = 'left';
+
+  // ── Option rows ────────────────────────────────────────
+  options.forEach((opt, i) => {
+    const oy  = my + 26 + i * MENU_IH;
+    const isHov   = (hovered === i);
+    const gateCol = GATE_COLORS[opt.action] || '#eaf0ff';
+
+    // Hover highlight
+    if (isHov) {
+      ctx.fillStyle = 'rgba(90,76,214,0.28)';
+      ctx.fillRect(mx+2, oy+1, MENU_W-4, MENU_IH-2);
+      // Left colored accent stripe
+      ctx.fillStyle = gateCol;
+      ctx.fillRect(mx+2, oy+1, 3, MENU_IH-2);
+    }
+
+    // Cursor chevron
+    ctx.fillStyle = isHov ? '#ffffff' : 'rgba(0,0,0,0)';
+    ctx.font = "7px 'Press Start 2P',monospace";
+    ctx.fillText('▶', mx+8, oy + Math.round(MENU_IH*0.58));
+
+    // Gate label
+    ctx.fillStyle = isHov ? '#ffffff' : gateCol;
+    ctx.font = "bold 7px 'Press Start 2P',monospace";
+    ctx.fillText(opt.label, mx+20, oy + Math.round(MENU_IH*0.48));
+
+    // Short description
+    ctx.fillStyle = isHov ? 'rgba(220,224,255,0.72)' : 'rgba(174,184,230,0.58)';
+    ctx.font = "5.5px 'Press Start 2P',monospace";
+    ctx.fillText(opt.short || '', mx+20, oy + Math.round(MENU_IH*0.82));
+  });
+
+  // ── Side detail card on hover ──────────────────────────
+  if (hovered >= 0 && hovered < options.length) {
+    const opt     = options[hovered];
+    const fullCtrl = GATE_INFO[opt.action]?.ctrl || '';
+    if (fullCtrl) {
+      const DW = 188;
+      const DH = 92;
+      // Prefer right side; fall back to left if near edge
+      const detX = (mx + MENU_W + 10 + DW < BOARD) ? mx + MENU_W + 10 : mx - DW - 10;
+      const detY = my;
+      const gateCol = GATE_COLORS[opt.action] || '#8b7dff';
+
+      // Card bg
+      ctx.fillStyle = 'rgba(4,6,20,0.97)';
+      roundRect(detX, detY, DW, DH, 4); ctx.fill();
+
+      // Colored outer border
+      ctx.strokeStyle = gateCol;
+      ctx.lineWidth = 2;
+      roundRect(detX, detY, DW, DH, 4); ctx.stroke();
+
+      // Inner border
+      ctx.strokeStyle = 'rgba(255,255,255,0.08)';
+      ctx.lineWidth = 1;
+      roundRect(detX+3, detY+3, DW-6, DH-6, 3); ctx.stroke();
+
+      // Colored header
+      ctx.fillStyle = gateCol;
+      roundRect(detX, detY, DW, 22, 4); ctx.fill();
+      ctx.fillRect(detX, detY+11, DW, 11);
+
+      ctx.fillStyle = '#ffffff';
+      ctx.font = "bold 7px 'Press Start 2P',monospace";
+      ctx.textAlign = 'center';
+      const lbl = GATE_INFO[opt.action]?.label || opt.action;
+      ctx.fillText(lbl, detX + DW/2, detY+15);
+      ctx.textAlign = 'left';
+
+      // Quantum description (wrapped)
+      ctx.fillStyle = '#c8d0f0';
+      ctx.font = "5.5px 'Press Start 2P',monospace";
+      wrapText(ctx, fullCtrl, detX+8, detY+32, DW-16, 12);
+    }
+  }
+
+  ctx.restore();
+}
+
+// Rounded-rect path helper for canvas UI
+function roundRect(x,y,w,h,r){
+  r=Math.min(r,w/2,h/2);
+  ctx.beginPath();
+  ctx.moveTo(x+r,y);
+  ctx.arcTo(x+w,y,x+w,y+h,r);
+  ctx.arcTo(x+w,y+h,x,y+h,r);
+  ctx.arcTo(x,y+h,x,y,r);
+  ctx.arcTo(x,y,x+w,y,r);
+  ctx.closePath();
+}
+
+// ── Turn banner ────────────────────────────────────────
+function drawTurnBanner() {
+  const isW=GAME.turn==='white';
+  const col=isW?'47,224,208':'255,77,157';
+  const g=ctx.createLinearGradient(0,0,BOARD,0);
+  g.addColorStop(0,'transparent');
+  g.addColorStop(0.5,`rgba(${col},0.18)`);
+  g.addColorStop(1,'transparent');
+  ctx.fillStyle=g; ctx.fillRect(0,0,BOARD,18);
+  ctx.textAlign='center';
+  ctx.fillStyle=`rgb(${col})`;
+  ctx.font="bold 6px 'Press Start 2P',monospace";
+    ctx.fillText(
+    `${FACTION[GAME.turn].name} TO MOVE  |  KNIGHTS ${aliveCount('white')} – ${aliveCount('black')} MAGES  |  TURN ${GAME.turnCount+1}/${GAME.turnCap}`,
+    BOARD/2,12
+  );
+  ctx.textAlign='left';
+}
+
+// ── Overlays ───────────────────────────────────────────
+function drawOverlay() {
+  if (GAME.phase==='gameover' && GAME.winner) {
+    const og=ctx.createLinearGradient(0,0,0,BOARD);
+    og.addColorStop(0,'rgba(7,11,24,0.88)'); og.addColorStop(1,'rgba(5,8,20,0.94)');
+    ctx.fillStyle=og;
+    ctx.fillRect(0,0,BOARD,BOARD);
+    ctx.textAlign='center';
+
+    if (GAME.winner==='draw') {
+      ctx.font="bold 18px 'Press Start 2P',monospace";
+      ctx.fillStyle='#8b7dff'; ctx.shadowColor='#8b7dff'; ctx.shadowBlur=22;
+      ctx.fillText('DRAW', BOARD/2, BOARD*0.444);
+      ctx.shadowBlur=0;
+      ctx.font="9px 'Press Start 2P',monospace"; ctx.fillStyle='#cfd6ee';
+      ctx.fillText('Mutual annihilation.', BOARD/2, BOARD*0.5);
+    } else {
+      const col=FACTION[GAME.winner].col;
+      ctx.font="bold 20px 'Press Start 2P',monospace";
+      ctx.fillStyle=col; ctx.shadowColor=col; ctx.shadowBlur=26;
+      ctx.fillText(`${FACTION[GAME.winner].name} WINS`, BOARD/2, BOARD*0.444);
+      ctx.shadowBlur=0;
+      ctx.font="9px 'Press Start 2P',monospace"; ctx.fillStyle='#cfd6ee';
+      ctx.fillText(`Units left  KNIGHTS ${aliveCount('white')} – ${aliveCount('black')} MAGES`, BOARD/2, BOARD*0.5);
+    }
+    ctx.fillStyle='#9aa3c4';
+    ctx.font="7px 'Press Start 2P',monospace";
+    ctx.fillText('Click to menu · R to copy replay', BOARD/2, BOARD*0.544);
+    // Session stats
+    ctx.font="6px 'Press Start 2P',monospace"; ctx.fillStyle='#6b76a8';
+    ctx.fillText(`Turns: ${GAME.turnCount+1}  |  Criticals: ${GAME.critCount}  |  Entanglements: ${GAME.entanglCount}`, BOARD/2, BOARD*0.584);
+    ctx.textAlign='left';
+  }
+
+  if (GAME.attackMode) {
+    ctx.fillStyle='rgba(255,90,114,0.07)'; ctx.fillRect(0,0,BOARD,BOARD);
+    ctx.textAlign='center';
+    ctx.font="bold 7px 'Press Start 2P',monospace";
+    ctx.fillStyle='#ff5a72'; ctx.shadowColor='#ff5a72'; ctx.shadowBlur=8;
+    ctx.fillText('ATTACK — CLICK AN ADJACENT ENEMY  [ESC to cancel]',BOARD/2, BOARD*0.98);
+    ctx.shadowBlur=0; ctx.textAlign='left';
+  } else if (GAME.cnotMode) {
+    ctx.fillStyle='rgba(255,77,157,0.06)'; ctx.fillRect(0,0,BOARD,BOARD);
+    ctx.textAlign='center';
+    ctx.font="bold 7px 'Press Start 2P',monospace";
+    ctx.fillStyle='#ff4d9d'; ctx.shadowColor='#ff4d9d'; ctx.shadowBlur=8;
+    ctx.fillText('ENTANGLE — CLICK AN ADJACENT UNIT  [ESC to cancel]',BOARD/2, BOARD*0.98);
+    ctx.shadowBlur=0; ctx.textAlign='left';
+  }
+}
+
+// ═══════════════════════════════════════════════════════
+// BLOCH SPHERE
+// ═══════════════════════════════════════════════════════
+function drawBloch() {
+  const bc=document.getElementById('bloch-canvas');
+  const bx=bc.getContext('2d');
+  const [W,H,R,cx,cy]=[100,100,44,50,50];
+  bx.clearRect(0,0,W,H);
+
+  const bg=bx.createRadialGradient(cx-12,cy-12,2,cx,cy,R);
+  bg.addColorStop(0,'#2a3358'); bg.addColorStop(1,'#0a0f22');
+  bx.fillStyle=bg; bx.beginPath(); bx.arc(cx,cy,R,0,2*π); bx.fill();
+
+  bx.strokeStyle='rgba(140,150,200,0.55)'; bx.lineWidth=1;
+  bx.beginPath(); bx.arc(cx,cy,R,0,2*π); bx.stroke();
+  bx.strokeStyle='rgba(140,150,200,0.30)'; bx.lineWidth=0.7;
+  bx.beginPath(); bx.ellipse(cx,cy,R,R*0.27,0,0,2*π); bx.stroke();
+  bx.beginPath(); bx.ellipse(cx,cy,R*0.27,R,0,0,2*π); bx.stroke();
+  bx.strokeStyle='rgba(140,150,200,0.22)'; bx.lineWidth=0.6;
+  bx.beginPath(); bx.moveTo(cx,cy-R+2); bx.lineTo(cx,cy+R-2); bx.stroke();
+  bx.beginPath(); bx.moveTo(cx-R+2,cy); bx.lineTo(cx+R-2,cy); bx.stroke();
+
+  bx.fillStyle='rgba(207,214,238,0.85)'; bx.font="7px 'Press Start 2P',monospace";
+  bx.fillText('|0⟩',cx+3,cy-R+10); bx.fillText('|1⟩',cx+3,cy+R-2);
+  // |1⟩ pole glows red — that's full charge (strongest strike).
+  bx.fillStyle='#ff5a72'; bx.shadowColor='#ff5a72'; bx.shadowBlur=7;
+  bx.beginPath(); bx.arc(cx,cy+R,3,0,2*π); bx.fill(); bx.shadowBlur=0;
+
+  const piece=GAME.selected; if (!piece) return;
+  // Read the open-system Bloch vector: a coherent state sits on the sphere
+  // surface (|r|=1); a decohered (mixed) state contracts inward (|r|<1) — the
+  // visible signature of Lindblad relaxation.
+  const b=piece.bloch || QPhysics.blochFromPure(piece.state);
+  const vx=b.x, vy=b.y, vz=b.z;
+  const sx=cx+R*(vx*0.7+vy*0.3);
+  const sy=cy-R*vz;
+
+  const vecCol = FACTION[piece.owner] ? FACTION[piece.owner].col : '#cfd6ee';
+  bx.strokeStyle=vecCol; bx.lineWidth=2;
+  bx.shadowColor=vecCol; bx.shadowBlur=10;
+  bx.beginPath(); bx.moveTo(cx,cy); bx.lineTo(sx,sy); bx.stroke();
+  bx.fillStyle=vecCol;
+  bx.beginPath(); bx.arc(sx,sy,3.5,0,2*π); bx.fill();
+  bx.shadowBlur=0;
+  bx.fillStyle='rgba(255,255,255,0.4)';
+  bx.beginPath(); bx.arc(cx,cy,2,0,2*π); bx.fill();
+}
+
+// ═══════════════════════════════════════════════════════
+// HUD
+// ═══════════════════════════════════════════════════════
+function updateHUD() {
+  const w=aliveCount('white'), b=aliveCount('black');
+  const hpW=totalHp('white'), hpB=totalHp('black');
+  const maxTot=(GAME.unitCount||6)*MAX_HP;
+  document.getElementById('p1-coh').textContent=`${hpW} HP`;
+  document.getElementById('p2-coh').textContent=`${hpB} HP`;
+  const wf=document.getElementById('p1-cbar'), bf=document.getElementById('p2-cbar');
+  if (wf){wf.style.width=Math.round(hpW/maxTot*100)+'%'; wf.style.background='var(--teal)';}
+  if (bf){bf.style.width=Math.round(hpB/maxTot*100)+'%'; bf.style.background='var(--rose)';}
+  document.getElementById('p1-ent').textContent=GAME.pieces.filter(p=>p.owner==='white'&&p.entangledWith).length;
+  document.getElementById('p2-ent').textContent=GAME.pieces.filter(p=>p.owner==='black'&&p.entangledWith).length;
+  document.getElementById('p1-cnt').textContent=w;
+  document.getElementById('p2-cnt').textContent=b;
+  document.getElementById('turn-info').textContent=FACTION[GAME.turn].name+' to move';
+  document.getElementById('phase-info').textContent=`units ${w} – ${b}`;
+  document.getElementById('turn-cnt').textContent=`${GAME.turnCount+1}/${GAME.turnCap}`;
+  // QB-8 — mirror turn/winner state into the aria-live region for screen readers.
+  const status = document.getElementById('a11y-status');
+  if (status) {
+    status.textContent = GAME.winner
+      ? (GAME.winner==='draw' ? 'Game over: draw.' : `Game over: ${FACTION[GAME.winner].name} wins.`)
+      : `${FACTION[GAME.turn].name} to move. Units ${w} to ${b}, turn ${GAME.turnCount+1} of ${GAME.turnCap}.`;
+  }
+  if (typeof renderSage==='function') renderSage();
+}
+
+function updateSelInfo(unit) {
+  if (!unit) {
+    document.getElementById('sel-name').textContent='—';
+    document.getElementById('sel-eq').textContent='|ψ⟩ = —';
+    document.getElementById('sel-theta').textContent='—';
+    document.getElementById('sel-phi').textContent='—';
+    document.getElementById('sel-coh').textContent='—';
+    document.getElementById('sel-hint').textContent='';
+    drawBloch(); return;
+  }
+  const ch=charge(unit);
+  document.getElementById('sel-name').textContent=`${coord(unit.row,unit.col)} · ${FACTION[unit.owner].name}`;
+  document.getElementById('sel-eq').textContent=fmtState(unit.state);
+  document.getElementById('sel-theta').textContent=`${unit.hp}/${unit.maxHp}`;
+  document.getElementById('sel-phi').textContent=`${(ch*100)|0}%`;
+  document.getElementById('sel-coh').textContent=unit.coherence.toFixed(0)+'%';
+  document.getElementById('sel-hint').textContent=
+    `Charge = strike chance (P(|1⟩)). Use X to charge toward |1⟩, H for a 50% gamble, MEASURE to discharge & stabilize. After attacking, the unit drops to |0⟩.`;
+  // QB-8 — announce the selection and, on the very first selection, show a
+  // one-time "click again for actions" onboarding hint.
+  const st = document.getElementById('a11y-status');
+  if (st) st.textContent = `Selected ${coord(unit.row,unit.col)}, ${FACTION[unit.owner].name}. `+
+    `Charge ${(ch*100)|0} percent, ${unit.hp} of ${unit.maxHp} HP. Click again to open actions.`;
+  try {
+    if (!localStorage.getItem('qb_hint_actions')) {
+      localStorage.setItem('qb_hint_actions','1');
+      logEv('TIP: click the selected unit again to open its action menu (charge, attack, measure, entangle).','system');
+      if (!REDUCE_MOTION)
+        GAME.floats.push({text:'click again for actions', x:unit.px, y:unit.py-CELL*0.6, vy:-0.5, life:2.6, color:'#f5b73c', size:7});
+    }
+  } catch(e){}
+  drawBloch();
+  if (typeof renderSage==='function') renderSage();
+}
+
+// ═══════════════════════════════════════════════════════
+// LOG
+// ═══════════════════════════════════════════════════════
+function logEv(msg, type) {
+  const log=document.getElementById('log');
+  const span=document.createElement('span');
+  span.className=`ev-${type}`;
+  span.textContent=`[T${GAME.turnCount+1}] ${msg}`;
+  log.appendChild(span);
+  log.scrollTop=log.scrollHeight;
+  while (log.children.length>90) log.removeChild(log.firstChild);
+}
+
+// ═══════════════════════════════════════════════════════
+// GATE MENU LOGIC
+// ═══════════════════════════════════════════════════════
+GAME._menuHover = -1;
+
+function openGateMenu(unit) {
+  const opts=[];
+  if (adjacentEnemies(unit).length)
+    opts.push({label:'[A] ATTACK', short:`strike — P(hit) ${(charge(unit)*100)|0}%`, action:'ATTACK'});
+  CELL_GATES.forEach(g=>opts.push({
+    label:`[${g}] ${GATE_INFO[g]?.label||g}`, short:GATE_INFO[g]?.short||'', action:g,
+  }));
+  opts.push({label:'[C] Entangle (CNOT)', short:GATE_INFO.CNOT.short,   action:'CNOT'});
+  opts.push({label:'[M] Measure',          short:GATE_INFO.MEASURE.short, action:'MEASURE'});
+  // Guardians get a GUARD ability: brace in the X-basis — relative phase (Z/S/T)
+  // decides the crit. Reach |+⟩ to be crit-immune; |−⟩ leaves you fully exposed.
+  if (unit.role==='guardian')
+    opts.push({label:'[G] GUARD',          short:'brace in X-basis — phase decides the crit', action:'GUARD'});
+  opts.push({label:'[·] End turn',          short:'',                     action:'SKIP'});
+  GAME.gateMenu={ piece:unit, options:opts };
+  GAME._menuHover=-1;
+  GAME.phase='gate';
+
+  // Crowd vote: if voteMode is on for this turn, auto-launch vote overlay.
+  if (GAME.voteMode && GAME.turn !== GAME.botColor) {
+    setTimeout(() => startCrowdVote(opts), 200);
+  }
+}
+
+function handleGateClick(mx,my) {
+  const {piece,options}=GAME.gateMenu;
+  const {mx:gx,my:gy}=menuPos(piece);
+  options.forEach((opt,i)=>{
+    const oy=gy+24+i*MENU_IH;
+    if (mx>=gx+4&&mx<=gx+MENU_W-4&&my>=oy+2&&my<=oy+MENU_IH-2) {
+      GAME.gateMenu=null;
+      switch (opt.action) {
+        case 'SKIP':    endTurn(); break;
+        case 'MEASURE': applyMeasure(piece); endTurn(); break;
+        case 'ATTACK':
+          GAME.attackMode=true; GAME.attackSource=piece;
+          logEv('Attack: click an adjacent enemy to strike. [ESC] to cancel.','quantum'); break;
+        case 'CNOT':
+          GAME.cnotMode=true; GAME.cnotControl=piece;
+          logEv('Entangle mode: click an adjacent unit to form a Bell link. [ESC] to cancel.','quantum'); break;
+        case 'GUARD':
+          piece.guarding=true; refreshSuperpos(piece);
+          piece.coherence=Math.min(piece.maxCoh, piece.coherence+8);
+          logEv(`GUARD: ${coord(piece.row,piece.col)} braces in the X-basis — a strike measures it as |±⟩; phase decides the crit (${(QPhysics.guardCritProb(piece.state)*100)|0}% crit risk).`,'quantum');
+          spawn(piece.px,piece.py,'#8b7dff',12); sfxGate('Z'); endTurn(); break;
+        default:
+          applyGate(piece, opt.action); endTurn();
+      }
+      if (GAME.pieces.includes(piece)) updateSelInfo(piece);
+    }
+  });
+}
+
+function getMenuHoverIndex(mx,my) {
+  if (!GAME.gateMenu) return -1;
+  const {piece,options}=GAME.gateMenu;
+  const {mx:gx,my:gy}=menuPos(piece);
+  for (let i=0;i<options.length;i++) {
+    const oy=gy+24+i*MENU_IH;
+    if (mx>=gx+4&&mx<=gx+MENU_W-4&&my>=oy+2&&my<=oy+MENU_IH-2) return i;
+  }
+  return -1;
+}
+
+// Keyboard shortcut gate lookup
+const KB_GATES = {h:'H',x:'X',y:'Y',z:'Z',s:'S',t:'T',m:'MEASURE',g:'GUARD'};
+
+// ═══════════════════════════════════════════════════════
+// INPUT — CLICK
+// ═══════════════════════════════════════════════════════
+canvas.addEventListener('click', async e => {
+  ac(); // init audio on first interaction
+  cancelAttractSchedule();
+  // Sage now floats beside the board and stays open, refreshing live.
+
+  const rect=canvas.getBoundingClientRect();
+  const scaleX=canvas.width/rect.width, scaleY=canvas.height/rect.height;
+  const mx=(e.clientX-rect.left)*scaleX;
+  const my=(e.clientY-rect.top)*scaleY;
+  const col=Math.floor(mx/CELL), row=Math.floor(my/CELL);
+
+  // Attract mode: any click stops demo
+  if (GAME.attractMode) {
+    stopAttractMode(); return;
+  }
+
+  // Game over → menu
+  if (GAME.phase==='gameover') { openMenu(); return; }
+
+  // Attack-target mode: click an adjacent enemy.
+  if (GAME.attackMode) {
+    const tgt=unitAt(row,col), src=GAME.attackSource;
+    GAME.attackMode=false; GAME.attackSource=null;
+    if (tgt && src && tgt.owner!==src.owner && adjacent(tgt,src)) {
+      attack(src, tgt);
+      GAME.selected=null; GAME.reachable=[]; GAME.gateMenu=null;
+      endTurn();
+    } else { logEv('Attack cancelled.','system'); }
+    return;
+  }
+
+  // Entangle mode: click an adjacent unit (friend or foe).
+  if (GAME.cnotMode) {
+    const tgt=unitAt(row,col), src=GAME.cnotControl;
+    GAME.cnotMode=false; GAME.cnotControl=null;
+    if (tgt && tgt!==src && adjacent(tgt,src)) {
+      applyCNOT(src, tgt);
+      GAME.selected=null; GAME.reachable=[]; GAME.gateMenu=null;
+      endTurn();
+    } else { logEv('Entangle cancelled.','system'); }
+    return;
+  }
+
+  // Action menu open → resolve the menu click.
+  if (GAME.gateMenu) { handleGateClick(mx,my); return; }
+
+  // Block during the bot's turn.
+  if (GAME.mode==='vsBot' && GAME.turn===GAME.botColor) return;
+  if (!inBounds(row,col)) return;
+
+  const clicked = unitAt(row,col);
+
+  if (GAME.selected) {
+    const sel = GAME.selected;
+    // Click an adjacent enemy → quick attack.
+    if (clicked && clicked.owner!==sel.owner && adjacent(clicked,sel)) {
+      attack(sel, clicked);
+      GAME.selected=null; GAME.reachable=[]; GAME.gateMenu=null;
+      endTurn(); return;
+    }
+    // Click the selected unit → open its action menu (stay put).
+    if (clicked===sel) { openGateMenu(sel); return; }
+    // Click a reachable empty tile → update row/col (canvas tween handles animation).
+    if (!clicked && GAME.reachable.some(t=>t.row===row&&t.col===col)) {
+      sel.row = row; sel.col = col;
+      spawn(col*CELL+CELL/2, row*CELL+CELL/2, FACTION[sel.owner].col, 6);
+      sfxMove();
+      GAME.reachable=[]; updateSelInfo(sel);
+      // Brief wait for walk tween to begin before opening the action menu.
+      setTimeout(() => openGateMenu(sel), 80);
+      return;
+    }
+    // Click another of your units → reselect.
+    if (clicked && clicked.owner===GAME.turn) { selectPiece(clicked); return; }
+    // Otherwise deselect.
+    GAME.selected=null; GAME.reachable=[]; updateSelInfo(null);
+    return;
+  }
+
+  // Nothing selected → pick one of your units.
+  if (clicked && clicked.owner===GAME.turn) selectPiece(clicked);
+});
+
+// Hover for menu highlight
+canvas.addEventListener('mousemove', e => {
+  if (!GAME.gateMenu) { GAME._menuHover=-1; return; }
+  const rect=canvas.getBoundingClientRect();
+  const mx=(e.clientX-rect.left)*(canvas.width/rect.width);
+  const my=(e.clientY-rect.top)*(canvas.height/rect.height);
+  GAME._menuHover=getMenuHoverIndex(mx,my);
+});
+
+// ═══════════════════════════════════════════════════════
+// INPUT — KEYBOARD
+// ═══════════════════════════════════════════════════════
+document.addEventListener('keydown', e => {
+  const key=e.key.toLowerCase();
+
+  // ? toggles Sage advisor
+  if (e.key==='?') { toggleAdvisor(); return; }
+  // V toggles Crowd Vote mode without opening the Settings menu
+  if (e.key.toLowerCase()==='v' && GAME.phase!=='gameover') {
+    GAME.voteMode = !GAME.voteMode;
+    const btn = document.getElementById('vote-btn');
+    if (btn) btn.textContent = GAME.voteMode ? 'ON ✓' : 'OFF';
+    _updateVoteBadge();
+    logEv(`Crowd Vote mode ${GAME.voteMode?'ENABLED — audience presses 1–4 next turn':'disabled'}.`,'system');
+    return;
+  }
+  // R copies replay
+
+  // ESC: cancel everything
+  if (e.key==='Escape') {
+    if (GAME.attackMode) {
+      GAME.attackMode=false; GAME.attackSource=null;
+      logEv('Attack cancelled.','system');
+    } else if (GAME.cnotMode) {
+      GAME.cnotMode=false; GAME.cnotControl=null;
+      logEv('Entangle cancelled.','system');
+    } else if (GAME.gateMenu) {
+      GAME.gateMenu=null; GAME.phase='play';
+    } else {
+      GAME.selected=null; GAME.reachable=[];
+      updateSelInfo(null);
+    }
+    closeModal();
+    return;
+  }
+
+  // Only keyboard gates in gate phase
+  if (GAME.phase!=='gate' || !GAME.gateMenu) return;
+  const piece=GAME.gateMenu.piece;
+
+  // Gate keys — any single-qubit pulse applies to the selected cell.
+  if (KB_GATES[key]) {
+    const gateName=KB_GATES[key];
+    GAME.gateMenu=null;
+    if (gateName==='MEASURE') { applyMeasure(piece); endTurn(); }
+    else if (gateName==='GUARD' && piece.role==='guardian') {
+      piece.guarding=true; refreshSuperpos(piece);
+      piece.coherence=Math.min(piece.maxCoh,piece.coherence+8);
+      logEv(`GUARD: ${coord(piece.row,piece.col)} braces in the X-basis — phase decides the crit (${(QPhysics.guardCritProb(piece.state)*100)|0}% crit risk).`,'quantum');
+      spawn(piece.px,piece.py,'#8b7dff',12); sfxGate('Z'); endTurn();
+    } else { applyGate(piece, gateName); endTurn(); }
+    return;
+  }
+
+  // Rx / Ry rotations (Shift+R = Rx)
+  if (key==='r') {
+    GAME.gateMenu=null;
+    applyGate(piece, e.shiftKey?'Rx':'Ry');
+    endTurn();
+    return;
+  }
+
+  // Space/Enter = skip
+  if (e.key===' ' || e.key==='Enter') {
+    e.preventDefault();
+    GAME.gateMenu=null; endTurn(); return;
+  }
+
+  // A = attack an adjacent enemy
+  if (key==='a') {
+    if (adjacentEnemies(piece).length) {
+      GAME.gateMenu=null;
+      GAME.attackMode=true; GAME.attackSource=piece;
+      logEv('Attack: click an adjacent enemy to strike. [ESC] to cancel.','quantum');
+    }
+    return;
+  }
+
+  // C = entangle (CNOT)
+  if (key==='c') {
+    GAME.gateMenu=null;
+    GAME.cnotMode=true; GAME.cnotControl=piece;
+    logEv('Entangle mode: click an adjacent unit to form a Bell link. [ESC] to cancel.','quantum');
+    return;
+  }
+
+  // Number keys: select gate by index
+  const idx=parseInt(e.key)-1;
+  if (!isNaN(idx) && idx>=0 && idx<GAME.gateMenu.options.length) {
+    const opt=GAME.gateMenu.options[idx];
+    GAME.gateMenu=null;
+    switch(opt.action) {
+      case 'SKIP':    endTurn(); break;
+      case 'MEASURE': applyMeasure(piece); endTurn(); break;
+      case 'CNOT':
+        GAME.cnotMode=true; GAME.cnotControl=piece;
+        logEv('Entangle mode: click an adjacent cell.','quantum'); break;
+      default: applyGate(piece,opt.action); endTurn();
+    }
+    if (GAME.pieces.includes(piece)) updateSelInfo(piece);
+  }
+});
+
+// ═══════════════════════════════════════════════════════
+// MAIN GAME LOOP
+// ═══════════════════════════════════════════════════════
+function loop() {
+  _t++;
+  tickParticles();
+  tickFloats();
+  advanceAnims();
+  ctx.clearRect(0,0,BOARD,BOARD);
+
+  // Screen shake: translate canvas by random jitter, decaying each frame.
+  // Suppressed entirely under prefers-reduced-motion (QB-8).
+  let _doShake = GAME.shake > 0 && !REDUCE_MOTION;
+  if (REDUCE_MOTION) GAME.shake = 0;
+  if (_doShake) {
+    ctx.save();
+    ctx.translate((Math.random()-0.5)*GAME.shake*0.7, (Math.random()-0.5)*GAME.shake*0.5);
+    GAME.shake = Math.max(0, GAME.shake - 1.4);
+  }
+
+  drawBoard();
+  drawHighlights();
+  drawEntanglementBeams();
+  // Painter's order: units lower on the board draw in front.
+  GAME.pieces.slice().sort((a,b)=>a.py-b.py).forEach(drawPiece);
+  drawDeaths();
+  drawFx();
+  drawParticles();
+  drawFloats();
+  drawGateMenu();
+  drawTurnBanner();
+  drawOverlay();
+
+  if (_doShake) ctx.restore();
+
+  if (GAME.selected) drawBloch();
+  drawSageNPC();
+  requestAnimationFrame(loop);
+}
+
+
+// ═══════════════════════════════════════════════════════
+// FLOATING NUMBERS — damage / crit / miss text
+// ═══════════════════════════════════════════════════════
+function tickFloats() {
+  GAME.floats = GAME.floats.filter(f => {
+    f.x += (f.vx||0); f.y += f.vy; f.life -= 0.022; return f.life > 0;
+  });
+}
+function drawFloats() {
+  ctx.save();
+  GAME.floats.forEach(f => {
+    ctx.globalAlpha = Math.min(1, f.life * 1.4);
+    ctx.font = `bold ${f.size||11}px 'Press Start 2P',monospace`;
+    ctx.textAlign = 'center';
+    ctx.fillStyle = f.color || '#ff5a72';
+    ctx.shadowColor = f.color || '#ff5a72'; ctx.shadowBlur = 10;
+    ctx.fillText(f.text, f.x, f.y);
+    ctx.shadowBlur = 0;
+  });
+  ctx.globalAlpha = 1;
+  ctx.textAlign = 'left';
+  ctx.restore();
+}
+
+// ═══════════════════════════════════════════════════════
+// BLITZ TURN TIMER
+// ═══════════════════════════════════════════════════════
+function startTurnTimer() {
+  if (!GAME.blitzMode || GAME.phase === 'gameover') return;
+  if (GAME.mode === 'vsBot' && GAME.turn === GAME.botColor) return; // don't time the bot
+  GAME.timerLeft = GAME.timerSec;
+  const bar  = document.getElementById('timer-bar');
+  const fill = document.getElementById('timer-fill');
+  const chip = document.getElementById('timer-chip');
+  if (bar)  bar.classList.add('active');
+  if (chip) chip.classList.add('active');
+  _updateTimerDOM();
+  GAME._timerInterval = setInterval(() => {
+    if (GAME.phase === 'gameover') { stopTurnTimer(); return; }
+    GAME.timerLeft--;
+    _updateTimerDOM();
+    if (GAME.timerLeft <= 8) beep(880,'square',0.03,0.04);
+    if (GAME.timerLeft <= 0) {
+      stopTurnTimer();
+      logEv("⏱ TIME'S UP! Charge bleeds hard — decoherence spike.",'decohere');
+      // Penalty: a decoherence spike — three turns' worth of Lindblad evolution
+      // applied at once (charge bleeds toward |0⟩), plus a coherence hit.
+      const { T1, T2 } = QPhysics.timesFromRate(GAME.decoRate);
+      GAME.pieces.filter(p=>p.owner===GAME.turn).forEach(u=>{
+        if (!u.bloch) u.bloch = QPhysics.blochFromPure(u.state);
+        u.bloch = QPhysics.lindbladStep(u.bloch, { T1, T2, dt:3 });
+        u.state = QPhysics.pureFromBloch(u.bloch);
+        u.coherence = Math.max(0, u.coherence-18);
+        refreshSuperpos(u);
+      });
+      if (GAME.gateMenu) GAME.gateMenu=null;
+      endTurn();
+    }
+  }, 1000);
+}
+function stopTurnTimer() {
+  if (GAME._timerInterval) { clearInterval(GAME._timerInterval); GAME._timerInterval=null; }
+  const bar  = document.getElementById('timer-bar');
+  const fill = document.getElementById('timer-fill');
+  const chip = document.getElementById('timer-chip');
+  if (bar)  bar.classList.remove('active');
+  if (fill) { fill.style.transform='scaleX(1)'; fill.classList.remove('urgent'); }
+  if (chip) { chip.classList.remove('active','urgent'); }
+}
+function _updateTimerDOM() {
+  const fill = document.getElementById('timer-fill');
+  const chip = document.getElementById('timer-chip');
+  const pct  = Math.max(0, GAME.timerLeft / GAME.timerSec);
+  if (fill) { fill.style.transform=`scaleX(${pct})`; fill.classList.toggle('urgent', GAME.timerLeft<=8); }
+  if (chip) { chip.textContent=GAME.timerLeft+'s'; chip.classList.toggle('urgent', GAME.timerLeft<=8); }
+}
+
+// ═══════════════════════════════════════════════════════
+// LEADERBOARD (localStorage)
+// ═══════════════════════════════════════════════════════
+function loadLeaderboard() {
+  try { return JSON.parse(localStorage.getItem('qublitz_lb')||'{}'); } catch(e){ return {}; }
+}
+function saveLeaderboard(lb) {
+  try { localStorage.setItem('qublitz_lb', JSON.stringify(lb)); } catch(e){}
+}
+function checkLeaderboard() {
+  const lb = loadLeaderboard();
+  const tc = GAME.turnCount+1;
+  let updated = false;
+  if (GAME.winner && GAME.winner!=='draw') {
+    if (!lb.fastestWin || tc < lb.fastestWin) { lb.fastestWin=tc; updated=true; }
+  }
+  if (!lb.mostCrits  || GAME.critCount    > lb.mostCrits)   { lb.mostCrits=GAME.critCount;    updated=true; }
+  if (!lb.mostEntangl|| GAME.entanglCount > lb.mostEntangl) { lb.mostEntangl=GAME.entanglCount; updated=true; }
+  if (updated) { saveLeaderboard(lb); logEv('🏅 New hall-of-fame record!','quantum'); }
+}
+function leaderboardHTML() {
+  const lb = loadLeaderboard();
+  if (!lb.fastestWin && !lb.mostCrits && !lb.mostEntangl) return '';
+  return `<h3>🏆 HALL OF FAME</h3>
+<div class="lb-wrap">
+  ${lb.fastestWin  ? `<div class="lb-row"><span class="lb-icon">⚡</span>Fastest win<span class="lb-val">${lb.fastestWin} turns</span></div>` : ''}
+  ${lb.mostCrits   ? `<div class="lb-row"><span class="lb-icon">💥</span>Most criticals<span class="lb-val">${lb.mostCrits}</span></div>`    : ''}
+  ${lb.mostEntangl ? `<div class="lb-row"><span class="lb-icon">🔗</span>Most entanglements<span class="lb-val">${lb.mostEntangl}</span></div>` : ''}
+</div>`;
+}
+
+// ═══════════════════════════════════════════════════════
+// CAMPAIGN — 3 training missions
+// ═══════════════════════════════════════════════════════
+const CAMPAIGN_MISSIONS = [
+  {
+    title:'MISSION 1 — THE BORN RULE',
+    intro:'One enemy Mage is fully charged at |1⟩ — it will strike unless you beat it. The Born rule: charge = hit chance (P(|1⟩) = |β|²). Charge your Knight with X and strike first.',
+    winText:'Born rule mastered! P(hit) = |β|² — your charge is your strike probability.',
+    setup(game) {
+      // 1v1, mage pre-charged
+      game.pieces = game.pieces.filter((_,i)=>i<2);
+      const mage = game.pieces.find(p=>p.owner==='black');
+      if (mage){ mage.state=blochToState(Math.PI,0); refreshSuperpos(mage); }
+    },
+  },
+  {
+    title:'MISSION 2 — DECOHERENCE RACE',
+    intro:'T1 decoherence bleeds your charge each turn. Your Knights start pre-charged — but you only have 8 turns before they decay to |0⟩. Strike NOW before the quantum clock runs out.',
+    winText:'T1 decoherence conquered! Real qubits lose coherence in microseconds — speed is everything.',
+    setup(game) {
+      game.turnCap=8;
+      game.pieces.filter(p=>p.owner==='white').forEach(u=>{
+        u.state=blochToState(Math.PI*0.8,0); refreshSuperpos(u);
+      });
+    },
+  },
+  {
+    title:'MISSION 3 — BELL PAIR TRAP',
+    intro:'Two enemy Mages share a Bell pair |Φ+⟩. Measuring one collapses BOTH to the same correlated outcome — but neither half can signal the other (local moves on one never change the other\'s odds). Exploit the shared collapse to break the pair.',
+    winText:'Entanglement understood! A Bell measurement reveals a pre-shared correlation — not spooky control. You cannot send a message through it; you can only read the matching outcome.',
+    setup(game) {
+      const mages = game.pieces.filter(p=>p.owner==='black').slice(0,2);
+      if (mages.length===2){
+        mages[0].entangledWith=mages[1].id; mages[1].entangledWith=mages[0].id;
+        const bell = { amps: QPhysics.Bell.phiPlus(), q: {} };
+        bell.q[mages[0].id]=0; bell.q[mages[1].id]=1;
+        mages[0].bell=bell; mages[1].bell=bell;
+      }
+    },
+  },
+];
+
+function startMission(n) {
+  closeModal();
+  resetGame('vsBot');
+  GAME.campaignMission = n;
+  CAMPAIGN_MISSIONS[n].setup(GAME);
+  updateHUD();
+  setTimeout(()=>{ startTypewriter(CAMPAIGN_MISSIONS[n].intro); },400);
+  logEv(CAMPAIGN_MISSIONS[n].title + ' BEGIN','quantum');
+}
+
+function openCampaign() {
+  const done = GAME.campaignDone || [];
+  document.getElementById('modal-content').innerHTML=`
+<h2>◈ TRAINING PROGRAMS ◈</h2>
+<p style="text-align:center;color:var(--dim);font-size:11px;margin-bottom:16px">3 quantum scenarios — each teaches one real physics concept.</p>
+${CAMPAIGN_MISSIONS.map((m,i)=>`
+<div class="mission-card">
+  <h4>${m.title}${done.includes(i)?'  ✓':''}</h4>
+  <p>${m.intro}</p>
+  <button class="btn" onclick="startMission(${i})">▶ START</button>
+  ${done.includes(i)?`<div class="mission-done">✓ Completed: ${m.winText}</div>`:''}
+</div>`).join('')}
+<button class="btn" onclick="closeModal();openMenu()" style="margin-top:12px">← BACK TO MENU</button>`;
+  document.getElementById('modal-overlay').classList.add('show');
+}
+
+// ═══════════════════════════════════════════════════════
+// CROWD / AUDIENCE VOTE MODE
+// ═══════════════════════════════════════════════════════
+let _voteInterval = null;
+
+// Execute the winning action fully — no dangling attackMode/cnotMode state.
+function _executeVoteWinner(action, piece) {
+  GAME.gateMenu = null;
+  if (action === 'ATTACK') {
+    const foes = adjacentEnemies(piece);
+    if (!foes.length) { endTurn(); return; }
+    // Auto-target the weakest adjacent enemy — no manual click required.
+    const target = foes.sort((a,b)=>a.hp-b.hp)[0];
+    logEv(`CROWD VOTED: ATTACK → auto-targeting ${coord(target.row,target.col)}.`,'quantum');
+    attack(piece, target);
+    endTurn();
+  } else if (action === 'CNOT') {
+    // Auto-entangle the first adjacent enemy, or nearest ally if no enemies adjacent.
+    const candidates = GAME.pieces.filter(p=>p!==piece && adjacent(p,piece));
+    const target = candidates.find(p=>p.owner!==piece.owner) || candidates[0];
+    if (target) {
+      logEv(`CROWD VOTED: CNOT → auto-entangling ${coord(target.row,target.col)}.`,'quantum');
+      applyCNOT(piece, target);
+      endTurn();
+    } else { endTurn(); }
+  } else if (action === 'MEASURE') {
+    applyMeasure(piece); endTurn();
+  } else if (action === 'GUARD' && piece.role === 'guardian') {
+    piece.guarding=true; refreshSuperpos(piece);
+    logEv('GUARD activated by crowd vote — braces in the X-basis.','quantum'); sfxGate('Z'); endTurn();
+  } else {
+    applyGate(piece, action); endTurn();
+  }
+}
+
+function _resolveVote(counts, voteOpts, piece, kv) {
+  clearInterval(_voteInterval); _voteInterval = null;
+  document.removeEventListener('keydown', kv);
+  document.getElementById('vote-overlay').classList.remove('show');
+  const winner = Object.entries(counts).sort((a,b)=>b[1]-a[1])[0];
+  if (!winner || !piece) return;
+  logEv(`CROWD VOTED: [${winner[0]}] with ${winner[1]} vote${winner[1]===1?'':'s'}.`,'quantum');
+  _executeVoteWinner(winner[0], piece);
+}
+
+function startCrowdVote(options) {
+  const overlay = document.getElementById('vote-overlay');
+  if (!overlay) return;
+  const voteOpts = options.filter(o=>o.action!=='SKIP').slice(0,4);
+  if (!voteOpts.length) return;
+  const counts = {};
+  voteOpts.forEach(o=>counts[o.action]=0);
+  window._voteCounts = counts;
+
+  const grid    = document.getElementById('vote-grid');
+  const timerEl = document.getElementById('vote-timer');
+  const status  = document.getElementById('vote-status');
+  if (!grid || !timerEl || !status) return;
+
+  // Capture piece reference now — before gateMenu is cleared.
+  const piece = GAME.gateMenu ? GAME.gateMenu.piece : GAME.selected;
+
+  let sec = 12; // Snappier than 15 for demo pacing.
+
+  grid.innerHTML = voteOpts.map((o,i)=>`
+    <div class="vote-btn" id="vb-${i}" onclick="castVote('${o.action}',${i})">
+      <span style="color:var(--gold);font-family:var(--pixel);font-size:13px">[${i+1}]</span>
+      <br>${o.label.replace(/^\[\w+\]\s*/,'')}
+      <span class="vote-count" id="vc-${i}">0</span>
+    </div>`).join('');
+  overlay.classList.add('show');
+  timerEl.textContent = sec; timerEl.classList.remove('urgent');
+  status.textContent = '';
+
+  // Opening fanfare so audience looks up.
+  beep(523,'triangle',0.06,0.08);
+  setTimeout(()=>beep(659,'triangle',0.06,0.08),90);
+  setTimeout(()=>beep(784,'triangle',0.08,0.12),180);
+
+  // Keyboard handler: 1-4 = vote, Escape/Enter/Space = force-resolve immediately.
+  const kv = e => {
+    const n = parseInt(e.key)-1;
+    if (n>=0 && n<voteOpts.length) { _doVote(voteOpts[n].action, n, counts); return; }
+    if (e.key==='Escape' || e.key==='Enter' || e.key===' ') {
+      e.preventDefault();
+      status.textContent = 'Resolved early.';
+      _resolveVote(counts, voteOpts, piece, kv);
+    }
+  };
+  document.addEventListener('keydown', kv);
+
+  _voteInterval = setInterval(()=>{
+    sec--;
+    timerEl.textContent = sec;
+    if (sec<=4) timerEl.classList.add('urgent');
+    if (sec<=4) beep(880,'square',0.03,0.04);
+    if (sec<=0) _resolveVote(counts, voteOpts, piece, kv);
+  }, 1000);
+}
+
+function _doVote(action, idx, counts){
+  counts[action]=(counts[action]||0)+1;
+  const el=document.getElementById('vc-'+idx);
+  if (el) el.textContent=counts[action];
+  beep(523,'triangle',0.03,0.05);
+}
+window.castVote=function(action,idx){ _doVote(action, idx, window._voteCounts||{}); };
+
+// Update the persistent on-screen vote-mode badge.
+function _updateVoteBadge() {
+  const badge = document.getElementById('vote-mode-badge');
+  if (!badge) return;
+  if (GAME.voteMode) {
+    badge.textContent = '🗳 VOTE ON [V]';
+    badge.style.opacity='1'; badge.style.background='rgba(47,224,208,0.18)';
+    badge.style.borderColor='rgba(47,224,208,0.6)'; badge.style.color='#2fe0d0';
+  } else {
+    badge.textContent = 'VOTE OFF [V]';
+    badge.style.opacity='0.38'; badge.style.background='rgba(18,24,52,0.5)';
+    badge.style.borderColor='rgba(124,140,230,0.2)'; badge.style.color='#6b76a8';
+  }
+}
+
+// ═══════════════════════════════════════════════════════
+// BACKGROUND PARTICLE SYSTEM
+// ═══════════════════════════════════════════════════════
+const bgCanvas=document.getElementById('bg-canvas');
+const bgCtx=bgCanvas.getContext('2d');
+// A living pixel-street scene behind the board (Oravec-style): drifting glow
+// blobs for depth, then NPC pedestrians and cars walking/driving across, plus a
+// faint scrolling tile-grid "ground".
+let bgParts=[];
+let bgNPCs=[];
+
+const BG_HUES = ['139,125,255','47,224,208','255,77,157','245,183,60','120,150,255'];
+const NPC_COLORS = ['47,224,208','255,77,157','139,125,255','245,183,60','120,200,150','230,140,90'];
+const _r=(a,b)=>a+Math.random()*(b-a);
+
+function initBg() {
+  bgCanvas.width=window.innerWidth;
+  bgCanvas.height=window.innerHeight;
+  const W=bgCanvas.width, H=bgCanvas.height;
+
+  bgParts=[];
+  for (let i=0;i<5;i++) bgParts.push({
+    x:_r(0,W), y:_r(0,H), r:_r(160,320),
+    vx:_r(-0.06,0.06), vy:_r(-0.06,0.06),
+    phase:_r(0,π*2), freq:_r(0.0006,0.0016),
+    col:BG_HUES[i%BG_HUES.length], op:_r(0.04,0.08),
+  });
+
+  // NPC wanderers exploring the snowfield (spread across the viewport).
+  bgNPCs=[];
+  for (let i=0;i<12;i++) bgNPCs.push({
+    kind:'ped',
+    x:_r(0,W), y:_r(H*0.12, H*0.93),
+    dir:Math.random()<0.5?1:-1, spd:_r(0.25,0.7),
+    col:NPC_COLORS[Math.floor(_r(0,NPC_COLORS.length))],
+    ph:_r(0,π*2), s:_r(2.4,3.6),
+  });
+}
+
+function _drawPed(p,t){
+  const s=p.s, x=Math.round(p.x), y=Math.round(p.y+Math.sin(t*6+p.ph)*s*0.35);
+  bgCtx.fillStyle=`rgba(${p.col},0.5)`;
+  bgCtx.shadowColor=`rgba(${p.col},0.6)`; bgCtx.shadowBlur=6;
+  bgCtx.fillRect(x, y, s*1.4, s*1.4);            // head
+  bgCtx.fillRect(x, y+s*1.6, s*1.4, s*2.2);      // body
+  const step=Math.sin(t*6+p.ph)>0?s*0.5:-s*0.5; // walking legs
+  bgCtx.fillRect(x,        y+s*3.8, s*0.6, s*1.5);
+  bgCtx.fillRect(x+s*0.8,  y+s*3.8, s*0.6, s*1.5-Math.abs(step)*0.2);
+  bgCtx.shadowBlur=0;
+}
+
+
+function animateBg() {
+  const W=bgCanvas.width, H=bgCanvas.height;
+  bgCtx.clearRect(0,0,W,H);
+  const t=Date.now()*0.001;
+
+  // Quantum-field ambiance: a deep navy base with drifting glow blobs and a
+  // faint lattice — the atmospheric backdrop for the arena (no RPG biome art).
+  const base=bgCtx.createLinearGradient(0,0,0,H);
+  base.addColorStop(0,'#070a16'); base.addColorStop(0.5,'#0a0f22'); base.addColorStop(1,'#070a16');
+  bgCtx.fillStyle=base; bgCtx.fillRect(0,0,W,H);
+
+  // Soft drifting glow blobs for depth.
+  bgParts.forEach(p=>{
+    p.x+=p.vx+Math.sin(t*p.freq*2+p.phase)*0.15;
+    p.y+=p.vy+Math.cos(t*p.freq*1.7+p.phase)*0.15;
+    if(p.x<-p.r)p.x=W+p.r; if(p.x>W+p.r)p.x=-p.r;
+    if(p.y<-p.r)p.y=H+p.r; if(p.y>H+p.r)p.y=-p.r;
+    const g=bgCtx.createRadialGradient(p.x,p.y,0,p.x,p.y,p.r);
+    const o=p.op*(0.7+0.3*Math.sin(t*p.freq*4+p.phase));
+    g.addColorStop(0,`rgba(${p.col},${o})`); g.addColorStop(1,`rgba(${p.col},0)`);
+    bgCtx.fillStyle=g; bgCtx.beginPath(); bgCtx.arc(p.x,p.y,p.r,0,π*2); bgCtx.fill();
+  });
+
+  // Faint far lattice — a slowly drifting grid of dim nodes, evoking a qubit array.
+  const sp=64, off=(t*4)%sp;
+  bgCtx.fillStyle='rgba(124,140,230,0.05)';
+  for (let x=-sp+off; x<W+sp; x+=sp) for (let y=-sp+off; y<H+sp; y+=sp) {
+    bgCtx.fillRect(x, y, 1.4, 1.4);
+  }
+
+  requestAnimationFrame(animateBg);
+}
+
+window.addEventListener('resize',()=>{ initBg(); });
+
+// ═══════════════════════════════════════════════════════
+// ATTRACT MODE
+// ═══════════════════════════════════════════════════════
+function scheduleAttract() {
+  clearTimeout(_attractTimer);
+  _attractTimer=setTimeout(()=>{
+    if (document.getElementById('modal-overlay').classList.contains('show')) {
+      closeModal();
+    }
+    startAttractMode();
+  }, 35000);
+}
+
+function cancelAttractSchedule() {
+  clearTimeout(_attractTimer); _attractTimer=null;
+}
+
+let _savedDifficulty=1, _savedDecoRate=3;
+
+function startAttractMode() {
+  _savedDifficulty=GAME.difficulty;
+  _savedDecoRate=GAME.decoRate;
+  closeModal();
+  resetGame('attract');
+  GAME.difficulty=0;
+  GAME.decoRate=1;
+  logEv('◈ DEMO MODE: Bot vs Bot showcase. Click anywhere to take control.','system');
+  doBotMove();
+}
+
+function stopAttractMode() {
+  GAME.attractMode=false;
+  GAME.difficulty=_savedDifficulty;
+  GAME.decoRate=_savedDecoRate;
+  document.getElementById('attract-badge').style.display='none';
+  openMenu();
+}
+
+// ═══════════════════════════════════════════════════════
+// QUANTUM SAGE ADVISOR
+// ═══════════════════════════════════════════════════════
+let _advisorOpen = false;
+
+const SAGE_ICON = { danger:'⚠', warn:'◈', quantum:'⚛', gate:'✦', info:'·' };
+
+function analyzePosition() {
+  const me   = GAME.turn;
+  const mine = GAME.pieces.filter(p=>p.owner===me);
+  const foes = GAME.pieces.filter(p=>p.owner!==me);
+  const tips = [];
+  if (!mine.length || !foes.length) return [{p:1,text:'The battle is decided.',type:'info'}];
+
+  // ── Selection-aware coaching (heuristic pre-move advice) ──────────────
+  // When the player has a unit selected, lead with specific, concept-linked
+  // guidance for THAT unit — the offline counterpart to the LLM pre-move Sage.
+  const sel = GAME.selected;
+  if (sel && sel.owner === me) {
+    const c    = charge(sel);
+    const cp   = (c * 100) | 0;
+    const here = coord(sel.row, sel.col);
+    const adj  = adjacentEnemies(sel);
+    const gcrit = Math.round(QPhysics.guardCritProb(sel.state) * 100);  // X-basis crit = (1−x)/2
+
+    if (adj.length && c >= 0.6) {
+      const tgt = adj.slice().sort((a,b)=>a.hp-b.hp)[0];
+      tips.push({p:24,type:'danger',text:`${here} sits at ${cp}% charge beside ${coord(tgt.row,tgt.col)} — ATTACK now: by the Born rule your hit probability equals the charge, and a foe caught in |1⟩ takes a CRITICAL (2 dmg).`});
+    } else if (adj.length && c < 0.35) {
+      tips.push({p:23,type:'warn',text:`${here} is in range but only ${cp}% charged — apply X (→|1⟩, 100%) or H (→|+⟩, 50%) first; attacking now fires with just ${cp}% probability and then discharges to |0⟩.`});
+    } else if (!adj.length && c >= 0.6) {
+      tips.push({p:22,type:'quantum',text:`${here} is charged ${cp}% but no enemy is adjacent — close in this turn: idle charge relaxes as e^(−t/T₁), so a stored hit bleeds away while you wait.`});
+    } else if (!adj.length && c < 0.35) {
+      tips.push({p:18,type:'gate',text:`${here} is at ${cp}% — use the quiet turn to load it (X or H) and advance, so it arrives at an enemy already charged.`});
+    }
+
+    const partner = sel.entangledWith && GAME.pieces.find(p=>p.id===sel.entangledWith);
+    if (partner) {
+      tips.push({p:16,type:'quantum',text:`${here} is in a Bell pair with ${coord(partner.row,partner.col)} — a strike on either bleeds onto both, and MEASURING one collapses the partner to the correlated outcome (no faster-than-light signalling, only shared correlation).`});
+    }
+
+    if (sel.guarding) {
+      tips.push({p:15,type:gcrit>50?'warn':'gate',text:`${here} is GUARDing — it is read in the X-basis, so its crit risk is ${gcrit}% = (1−x)/2. ${gcrit>50?'It is near |−⟩ and exposed — apply Z (or two S) to flip toward |+⟩ and make it crit-immune.':'It is near |+⟩ — well braced; phase is doing real defensive work here.'}`});
+    } else if (adj.some(e=>charge(e)>0.4)) {
+      tips.push({p:14,type:'info',text:`${here} faces a live threat — GUARD braces it in the X-basis, but the phase decides the crit. Rotate toward |+⟩ (Z/S/T) first; right now a GUARD would sit at ${gcrit}% crit risk.`});
+    }
+  }
+
+  // A charged unit already adjacent to a foe → strike now.
+  const ready = mine.find(u=>charge(u)>0.6 && adjacentEnemies(u).length);
+  if (ready) {
+    const t=adjacentEnemies(ready).sort((a,b)=>a.hp-b.hp)[0];
+    tips.push({p:10,text:`${coord(ready.row,ready.col)} is charged (${(charge(ready)*100)|0}%) and beside ${coord(t.row,t.col)} — strike now for a near-certain hit.`,type:'danger'});
+  }
+  // Adjacent but uncharged → charge first.
+  const weakAdj = mine.find(u=>charge(u)<0.3 && adjacentEnemies(u).length);
+  if (weakAdj) tips.push({p:8,text:`${coord(weakAdj.row,weakAdj.col)} is in range but uncharged — apply X to load it toward |1⟩ before you strike.`,type:'warn'});
+
+  // My charged unit sitting next to a live enemy → exposed to a critical.
+  const exposed = mine.find(u=>charge(u)>0.6 && adjacentEnemies(u).some(e=>charge(e)>0.4));
+  if (exposed) tips.push({p:7,text:`${coord(exposed.row,exposed.col)} is charged beside a live enemy — a unit caught in |1⟩ takes a CRITICAL. Strike, retreat, or MEASURE to discharge.`,type:'warn'});
+
+  // Finish a low-HP enemy.
+  const low = foes.filter(f=>f.hp<=1).sort((a,b)=>a.hp-b.hp)[0];
+  if (low) tips.push({p:6,text:`Enemy ${coord(low.row,low.col)} is at ${low.hp} HP — focus it down to thin their ranks.`,type:'gate'});
+
+  // Two adjacent enemies → entangle for splash.
+  let combo=null;
+  foes.forEach(a=>foes.forEach(b=>{ if(a!==b && !combo && adjacent(a,b)) combo=[a,b]; }));
+  if (combo) tips.push({p:4,text:`Enemies at ${coord(combo[0].row,combo[0].col)} & ${coord(combo[1].row,combo[1].col)} stand adjacent — entangle them so one strike bleeds onto both.`,type:'quantum'});
+
+  tips.push({p:2,text:`Charge bleeds away each turn (T1 relaxation) — load up and strike soon. Keep idle units in |0⟩ so they're not caught exposed.`,type:'info'});
+
+  return tips.sort((a,b)=>b.p-a.p).slice(0,3);
+}
+
+// Update the Sage dialogue bar (always visible) and the optional expanded tips panel.
+function renderSage() {
+  // If the bot just explained a move, show that first (fades after one call).
+  if (GAME.botLastReason) {
+    startTypewriter('BOT: ' + GAME.botLastReason);
+    GAME.botLastReason = '';
+    const bar = document.getElementById('sage-bar');
+    if (bar) bar.classList.remove('urgent');
+    return;
+  }
+  const tips = analyzePosition();
+  const bar  = document.getElementById('sage-bar');
+  const btn  = document.querySelector('.btn-sage');
+
+  const urgent = tips.some(t => t.type === 'danger');
+  if (bar) bar.classList.toggle('urgent', urgent);
+  if (btn) btn.classList.toggle('urgent', urgent);
+
+  // Primary tip → typewriter into the dialogue bar
+  if (tips[0]) startTypewriter(tips[0].text);
+
+  // Expanded panel (if open)
+  const panel = document.getElementById('sage-tips');
+  if (!panel) return;
+  if (!_advisorOpen) { panel.classList.remove('show'); return; }
+  panel.classList.add('show');
+  panel.innerHTML = tips.map(tip => {
+    const icon = SAGE_ICON[tip.type] || '·';
+    const cls  = ['danger','warn','quantum','gate','info'].includes(tip.type) ? tip.type : 'info';
+    return `<div class="sage-tip-row"><div class="sage-tip-ic ${cls}">${icon}</div><div class="sage-tip-tx">${tip.text}</div></div>`;
+  }).join('');
+}
+
+function toggleAdvisor() {
+  _advisorOpen = !_advisorOpen;
+  if (_advisorOpen) beep(494,'triangle',0.08,0.12);
+  const moreBtn = document.getElementById('sage-bar-more');
+  if (moreBtn) moreBtn.textContent = _advisorOpen ? '▲ LESS' : '▼ MORE';
+  renderSage();
+}
+
+// ═══════════════════════════════════════════════════════
+// CLAUDE AI SAGE — LLM-powered quantum strategy oracle
+// ═══════════════════════════════════════════════════════
+let _sageAILastCall = 0;
+
+// QB-9 — the Anthropic key is NEVER collected or stored client-side. Sage AI is
+// served through a rate-limited server proxy that holds the key (see
+// sage_proxy.py, or any endpoint the deployment injects as window.QB_SAGE_PROXY,
+// e.g. the Streamlit wrapper). With no proxy configured, the AI Sage is simply
+// disabled and the heuristic Sage keeps playing — no key prompt, no exfil risk.
+const SAGE_PROXY_URL = (typeof window!=='undefined' && window.QB_SAGE_PROXY)
+  ? String(window.QB_SAGE_PROXY) : '';
+function _sageEnabled() { return !!SAGE_PROXY_URL; }
+
+function _updateClaudeBadge() {
+  const b = document.getElementById('claude-badge');
+  if (!b) return;
+  b.style.display = _sageEnabled() ? 'inline' : 'none';
+  b.textContent = '✦ Claude AI';
+}
+
+function _buildGameState(trigger) {
+  const unitDesc = u => {
+    const ch = Math.round(charge(u) * 100);
+    const flags = [
+      u.entangledWith ? 'entangled' : '',
+      u.role === 'guardian' ? 'guardian' : '',
+      u.guarding ? 'guarding' : ''
+    ].filter(Boolean).join(',');
+    return `${coord(u.row,u.col)} HP:${u.hp}/${u.maxHp} charge:${ch}%${flags ? ' ['+flags+']' : ''}`;
+  };
+  const w = GAME.pieces.filter(p=>p.owner==='white').map(unitDesc).join(' | ');
+  const b = GAME.pieces.filter(p=>p.owner==='black').map(unitDesc).join(' | ');
+  return `Turn ${GAME.turnCount}/60. ${GAME.turn.toUpperCase()} player to act.\nKNIGHTS (white): ${w||'eliminated'}\nMAGES (black): ${b||'eliminated'}\nEvent: ${trigger}`;
+}
+
+async function callSageAI(trigger) {
+  if (!_sageEnabled() || GAME.phase === 'gameover' || GAME.attractMode) return false;
+  const now = Date.now();
+  if (now - _sageAILastCall < 4000) return false; // client-side throttle (server also rate-limits)
+  _sageAILastCall = now;
+
+  const badge = document.getElementById('claude-badge');
+  if (badge) { badge.style.display = 'inline'; badge.textContent = '⟳ Claude...'; }
+  startTypewriter('⚛ Sage reads the quantum field...');
+
+  try {
+    // The proxy holds the API key and the system prompt server-side; the client
+    // only sends the game state. No key ever touches the browser (QB-9).
+    const res = await fetch(SAGE_PROXY_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ state: _buildGameState(trigger) })
+    });
+    if (badge) { badge.style.display = 'inline'; badge.textContent = '✦ Claude AI'; }
+    if (!res.ok) return false;
+    const data = await res.json();
+    const text = (data.text || data.content?.[0]?.text || '').trim();
+    if (text) { startTypewriter(text); return true; }
+  } catch(e) {
+    if (badge) { _updateClaudeBadge(); }
+  }
+  return false;
+}
+
+// ═══════════════════════════════════════════════════════
+// BOOT SEQUENCE
+// ═══════════════════════════════════════════════════════
+let _bootTimeout=null;
+let _bootFinished=false;
+
+function finishBoot() {
+  if (_bootFinished) return;
+  _bootFinished=true;
+  clearTimeout(_bootTimeout);
+  const boot=document.getElementById('boot');
+  boot.classList.add('fade-out');
+  setTimeout(()=>{ boot.style.display='none'; },700);
+  resetGame('vsBot');
+  loop();
+  _updateClaudeBadge();
+  setTimeout(openMenu, 200);
+}
+
+function runBoot() {
+  const logo =document.getElementById('boot-logo');
+  const sub  =document.getElementById('boot-sub');
+  const lines=document.getElementById('boot-lines');
+  const start=document.getElementById('boot-start');
+
+  const title='QUBLITZ';
+  let i=0;
+
+  const typeTimer=setInterval(()=>{
+    logo.textContent+=title[i];
+    sfxBootBeep(440+i*38);
+    i++;
+    if (i>=title.length) {
+      clearInterval(typeTimer);
+      setTimeout(()=>{
+        sub.textContent='Qubit Battle Arena';
+        const bootLines=[
+          '  Cooling the qubit array to millikelvin...',
+          '  Deploying quantum units to the field...',
+          '  Calibrating control pulses (H X Y Z S T)...',
+          '  Arming measurement strike systems...',
+          '  Entanglement couplers online...',
+          '  Charge. Close in. Collapse the enemy.',
+        ];
+        let li=0;
+        const lt=setInterval(()=>{
+          if (li<bootLines.length) {
+            lines.textContent+=bootLines[li]+'\n';
+            sfxBootBeep(li===bootLines.length-1?494:330);
+            li++;
+          } else {
+            clearInterval(lt);
+            start.textContent='▶ PRESS ANY KEY TO BEGIN ◀';
+            _bootTimeout=setTimeout(finishBoot,2200);
+          }
+        },180);
+      },350);
+    }
+  },110);
+
+  // Skip on any key or click
+  const skip=()=>{ finishBoot(); };
+  document.getElementById('boot').addEventListener('click',skip,{once:true});
+  document.addEventListener('keydown',skip,{once:true});
+}
+
+// ═══════════════════════════════════════════════════════
+// MENU + TUTORIAL MODALS
+// ═══════════════════════════════════════════════════════
+// ═══════════════════════════════════════════════════════
+// PHYSICS LAB — surfaces the verified QPhysics engine as a
+// first-class, inspectable feature (capability + formality).
+// ═══════════════════════════════════════════════════════
+function openPhysicsLab() {
+  const { T1, T2 } = QPhysics.timesFromRate(GAME.decoRate);
+  const sel = GAME.selected;
+  let unitBlock = `<p style="color:var(--wood);font-size:11px">Select one of your units on the board to inspect its live density matrix here.</p>`;
+  if (sel) {
+    const b = sel.bloch || QPhysics.blochFromPure(sel.state);
+    const rho = QPhysics.rhoFromBloch(b);
+    const ch = QPhysics.charge(b), pur = QPhysics.purity(b), coh = QPhysics.coherenceL1(b);
+    const fmt = z => (z>=0?' ':'') + z.toFixed(3);
+    unitBlock = `
+<p style="color:var(--teal);font-size:11px;margin:4px 0">UNIT ${coord(sel.row,sel.col)} — live state ρ</p>
+<pre style="color:var(--ink-2);font-size:11px;line-height:1.5;background:#0a0f22;border:1px solid var(--border);border-radius:4px;padding:8px;margin:4px 0;overflow:auto">ρ = [ ${fmt(rho[0][0].r)}        ${fmt(rho[0][1].r)}${rho[0][1].i<0?'−':'+'}${Math.abs(rho[0][1].i).toFixed(3)}i ]
+    [ ${fmt(rho[1][0].r)}${rho[1][0].i<0?'−':'+'}${Math.abs(rho[1][0].i).toFixed(3)}i   ${fmt(rho[1][1].r)}      ]</pre>
+<p style="color:var(--dim);font-size:11px;margin:2px 0">
+  charge P(|1⟩) = <b style="color:var(--red)">${(ch*100).toFixed(1)}%</b> ·
+  purity Tr(ρ²) = <b style="color:var(--gold)">${pur.toFixed(3)}</b> ·
+  coherence 2|ρ₀₁| = <b style="color:var(--teal)">${coh.toFixed(3)}</b>
+</p>`;
+  }
+  document.getElementById('modal-content').innerHTML = `
+<h2>🔬 PHYSICS LAB</h2>
+<p style="text-align:center;color:var(--dim);font-size:11px;margin:-8px 0 12px">Open-quantum-system engine · Lindblad master equation · unit-tested</p>
+
+<h3>THE MODEL</h3>
+<p style="color:var(--dim);font-size:11px;line-height:1.7">Every unit is a single qubit whose state ρ evolves under the <b style="color:var(--teal)">Lindblad master equation</b> for amplitude damping (T₁) plus dephasing (T₂):</p>
+<pre style="color:var(--gold);font-size:11px;line-height:1.6;text-align:center;background:#0a0f22;border:1px solid var(--border);border-radius:4px;padding:10px;margin:6px 0">dρ/dt = −(i/ℏ)[H,ρ] + Σ γₖ( Lₖ ρ Lₖ† − ½{Lₖ†Lₖ, ρ} )</pre>
+<p style="color:var(--dim);font-size:11px;line-height:1.7">Each turn we apply its <b>exact</b> solution toward |0⟩: charge relaxes as <b style="color:var(--red)">e<sup>−t/T₁</sup></b>, transverse coherence as <b style="color:var(--teal)">e<sup>−t/T₂</sup></b> (with T₂ ≤ 2T₁). At the current rate (${GAME.decoRate}/turn): <b style="color:var(--gold)">T₁ = ${T1.toFixed(1)}</b>, <b style="color:var(--gold)">T₂ = ${T2.toFixed(1)}</b> turns.</p>
+
+<h3>FALSIFIABILITY TEST</h3>
+<p style="color:var(--dim);font-size:11px;line-height:1.6">A unit prepared in |1⟩, left to decohere. Physical decay is exponential, <i>not</i> linear — the test fits both and reports R².</p>
+<canvas id="diag-canvas" width="360" height="190" style="width:100%;max-width:360px;display:block;margin:8px auto;background:#0a0f22;border:1px solid var(--border);border-radius:4px"></canvas>
+<p id="diag-readout" style="text-align:center;color:var(--dim);font-size:11px;margin:4px 0"></p>
+
+<h3>LIVE STATE INSPECTOR</h3>
+${unitBlock}
+
+<hr style="border-color:var(--border);margin:10px 0">
+<p style="color:var(--wood);font-size:11px;line-height:1.6">Verify in the browser console: <b style="color:var(--teal)">runDecoherenceDiagnostic()</b> · <b style="color:var(--teal)">QPhysics.selfTest()</b>. Physics engine has no UI dependencies — it is independently testable. Modelled after TLS-defect decoherence studied at the <b>Fitzpatrick Lab, Dartmouth College</b>.</p>
+<button class="btn" style="margin-top:8px" onclick="openMenu()">◀ BACK TO MENU</button>`;
+  document.getElementById('modal-overlay').classList.add('show');
+  drawDecoherenceDiagram(GAME.decoRate);
+}
+
+// Plots charge-vs-turn for a |1⟩ unit: the physical (exponential) decay as a
+// curve+points, the linear best-fit for contrast, and the R² of each — the
+// falsifiability argument, rendered in-game rather than only in the console.
+function drawDecoherenceDiagram(decoRate) {
+  const cv = document.getElementById('diag-canvas'); if (!cv) return;
+  const g = cv.getContext('2d'); const W = cv.width, H = cv.height;
+  const rep = QPhysics.diagnose({ decoRate, turns: 24 });
+  const data = rep.charge_by_turn, N = data.length - 1;
+  const PADL = 30, PADB = 22, PADT = 12, PADR = 8;
+  const x = t => PADL + (W - PADL - PADR) * (t / N);
+  const y = q => PADT + (H - PADT - PADB) * (1 - q);
+  g.clearRect(0, 0, W, H);
+  // axes + gridlines
+  g.strokeStyle = 'rgba(140,150,200,0.25)'; g.lineWidth = 1; g.font = "6px 'Press Start 2P',monospace";
+  g.fillStyle = 'rgba(207,214,238,0.65)';
+  for (let q = 0; q <= 1; q += 0.25) { g.beginPath(); g.moveTo(PADL, y(q)); g.lineTo(W - PADR, y(q)); g.stroke(); g.fillText((q).toFixed(2), 2, y(q) + 3); }
+  g.fillText('0', PADL - 2, H - PADB + 12); g.fillText(String(N) + ' turns', W - PADR - 42, H - PADB + 12);
+  g.fillText('charge', 2, PADT - 3);
+  // linear best-fit line (for contrast — visibly wrong)
+  const n = data.length; let mx = 0, my = 0; for (let i = 0; i < n; i++) { mx += i; my += data[i]; } mx /= n; my /= n;
+  let sxy = 0, sxx = 0; for (let i = 0; i < n; i++) { sxy += (i - mx) * (data[i] - my); sxx += (i - mx) * (i - mx); }
+  const slope = sxx ? sxy / sxx : 0, intc = my - slope * mx;
+  g.strokeStyle = '#ff5a72'; g.setLineDash([4, 3]); g.lineWidth = 1.5; g.beginPath();
+  g.moveTo(x(0), y(Math.max(0, Math.min(1, intc)))); g.lineTo(x(N), y(Math.max(0, Math.min(1, slope * N + intc)))); g.stroke(); g.setLineDash([]);
+  // exponential (physical) decay curve
+  g.strokeStyle = '#2fe0d0'; g.lineWidth = 2; g.beginPath();
+  data.forEach((q, t) => { t === 0 ? g.moveTo(x(t), y(q)) : g.lineTo(x(t), y(q)); }); g.stroke();
+  // data points
+  g.fillStyle = '#8b7dff'; data.forEach((q, t) => { g.beginPath(); g.arc(x(t), y(q), 2, 0, 2 * Math.PI); g.fill(); });
+  const ro = document.getElementById('diag-readout');
+  if (ro) ro.innerHTML = `<b style="color:#2fe0d0">exponential R² = ${rep.R2_exponential.toFixed(4)}</b> &nbsp;≫&nbsp; <b style="color:#ff5a72">linear R² = ${rep.R2_linear.toFixed(4)}</b> &nbsp;·&nbsp; fitted T₁ = ${rep.T1_recovered.toFixed(1)} (input ${rep.T1_input.toFixed(1)}) &nbsp;·&nbsp; <b style="color:var(--gold)">${rep.verdict}</b>`;
+}
+
+function openMenu() {
+  scheduleAttract();
+  const diffs=['EASY','MEDIUM','HARD'];
+  document.getElementById('modal-content').innerHTML=`
+<h2>◈ QUBLITZ ◈</h2>
+<p style="text-align:center;color:var(--dim);margin:-10px 0 10px;font-size:11px;">Qubit Battle Arena — charge, close in, collapse the enemy</p>
+
+<div style="background:linear-gradient(135deg,rgba(47,224,208,0.10),rgba(139,125,255,0.08));border:1px solid var(--border);border-radius:6px;padding:9px 11px;margin:0 0 14px">
+  <p style="color:var(--gold);font-family:var(--pixel);font-size:11px;margin:0 0 6px">⚡ PLAY IN 30 SECONDS</p>
+  <p style="color:var(--ink-2);font-size:11px;line-height:1.7;margin:0">
+    <b style="color:var(--teal)">1. CHARGE</b> — tap a unit, fire a gate (X = 100% charge, H = 50%).<br>
+    <b style="color:var(--teal)">2. STRIKE</b> — move beside a foe and ATTACK; hit chance = your charge (Born rule).<br>
+    <b style="color:var(--teal)">3. BEAT THE CLOCK</b> — charge decays exponentially each turn. Strike before it bleeds away. Last army standing wins.
+  </p>
+</div>
+
+<button class="btn" style="background:linear-gradient(135deg,rgba(47,224,208,0.18),rgba(139,125,255,0.14));border-color:var(--teal)"
+  onclick="closeModal();resetGame('vsBot');GAME.difficulty=parseInt(document.getElementById('diff-sel')?document.getElementById('diff-sel').value:1)||1">▶ PLAY vs BOT (1P)</button>
+<button class="btn" onclick="closeModal();resetGame('vs2P')">▶ LOCAL vs FRIEND (2P)</button>
+<hr style="border-color:var(--border);margin:12px 0">
+<button class="btn" onclick="openCampaign()">🎓 TRAINING PROGRAMS (3 missions)</button>
+<button class="btn" onclick="closeModal();openTutorial()">📜 BATTLE MANUAL</button>
+<button class="btn" style="border-color:var(--gold);color:var(--gold)" onclick="openPhysicsLab()">🔬 PHYSICS LAB — inspect the real engine</button>
+<hr style="border-color:var(--border);margin:12px 0">
+
+<h3>SETTINGS</h3>
+<p style="color:var(--dim);font-size:11px;margin-bottom:6px;">
+  Bot Difficulty:
+  <select id="diff-sel" onchange="GAME.difficulty=parseInt(this.value)"
+    style="background:#0c1226;border:2px solid var(--border);color:var(--gold);
+           font-family:var(--pixel);font-size:11px;margin-left:8px;padding:2px 6px;">
+    <option value="0"${GAME.difficulty===0?' selected':''}>EASY</option>
+    <option value="1"${GAME.difficulty===1?' selected':''}>MEDIUM</option>
+    <option value="2"${GAME.difficulty===2?' selected':''}>HARD</option>
+  </select>
+</p>
+<p style="color:var(--dim);font-size:11px;margin-bottom:6px;">
+  Battlefield:
+  <select id="board-sel" onchange="GAME.boardPreset=parseInt(this.value)"
+    style="background:#0c1226;border:2px solid var(--border);color:var(--teal);
+           font-family:var(--pixel);font-size:11px;margin-left:8px;padding:2px 6px;">
+    ${BOARD_PRESETS.map((p,i)=>`<option value="${i}"${GAME.boardPreset===i?' selected':''}>${p.label}</option>`).join('')}
+  </select><br>
+  <span style="color:var(--wood);font-size:11px;">Applies when you start the next battle.</span>
+</p>
+<p style="color:var(--dim);font-size:11px;margin-bottom:6px;">
+  Decoherence rate: <span id="dv" style="color:var(--green)">${GAME.decoRate}</span>/turn<br>
+  <span style="color:var(--wood);font-size:11px;">Higher = charge bleeds away faster (T1 relaxation).</span>
+</p>
+<button class="btn" onclick="GAME.decoRate=Math.max(1,GAME.decoRate-1);document.getElementById('dv').textContent=GAME.decoRate">◀ SLOWER DECO</button>
+<button class="btn" onclick="GAME.decoRate=Math.min(12,GAME.decoRate+1);document.getElementById('dv').textContent=GAME.decoRate">▶ FASTER DECO</button>
+<hr style="border-color:var(--border);margin:6px 0">
+<p style="color:var(--dim);font-size:11px;margin-bottom:6px;">
+  ⏱ Blitz Mode (30s/turn):
+  <button class="btn" style="display:inline;width:auto;padding:4px 10px;margin-left:8px;font-size:11px"
+    id="blitz-btn" onclick="GAME.blitzMode=!GAME.blitzMode;this.textContent=GAME.blitzMode?'ON ✓':'OFF'">${GAME.blitzMode?'ON ✓':'OFF'}</button>
+</p>
+<p style="color:var(--dim);font-size:11px;margin-bottom:6px;">
+  👥 Crowd Vote Mode — audience presses 1–4 to vote gates &nbsp;<span style="color:var(--teal)">[V]&nbsp;to&nbsp;toggle&nbsp;anytime</span>:
+  <button class="btn" style="display:inline;width:auto;padding:4px 10px;margin-left:8px;font-size:11px"
+    id="vote-btn" onclick="GAME.voteMode=!GAME.voteMode;this.textContent=GAME.voteMode?'ON ✓':'OFF';_updateVoteBadge();">${GAME.voteMode?'ON ✓':'OFF'}</button>
+</p>
+<hr style="border-color:var(--border);margin:6px 0">
+<p style="color:var(--dim);font-size:11px;margin-bottom:6px;">🤖 Claude AI Sage — LLM quantum insights are served through a rate-limited server proxy that holds the key. ${_sageEnabled() ? '<span style="color:var(--teal)">Connected ✓</span>' : 'Not configured for this build (the standalone file ships without a server; the heuristic Sage still plays).'}</p>
+<hr style="border-color:var(--border);margin:6px 0">
+${leaderboardHTML()}
+<p style="color:var(--wood);font-size:11px;text-align:center;margin-top:10px;">
+  Every unit is a qubit · Guardians [G] resist criticals · Charge → strike.<br>
+  Warriors attack, Guardians tank. Eliminate the enemy army.
+</p>
+<p style="color:var(--wood);font-size:11px;text-align:center;margin-top:8px;opacity:.8;line-height:1.6">
+  QUBLITZ ${QB_VERSION} · Lindblad T₁/T₂ physics engine (unit-tested)<br>
+  Built by David Mukuruva · Fitzpatrick Lab, Dartmouth College
+</p>`;
+  document.getElementById('modal-overlay').classList.add('show');
+}
+
+function closeModal() {
+  document.getElementById('modal-overlay').classList.remove('show');
+}
+
+function openTutorial() {
+  document.getElementById('modal-content').innerHTML=`
+<h2>◈ QUBLITZ — QUBIT BATTLE ARENA ◈</h2>
+
+<h3>🎯 OBJECTIVE</h3>
+<p>Two armies face off on a grid: <b style="color:#2fe0d0">Elite Knights</b> deploy at the bottom, <b style="color:#ff4d9d">Elite Mages</b> at the top. Each unit is a two-level system |ψ⟩ = α|0⟩ + β|1⟩ with <b>HP</b> and a quantum <b>charge</b>. <b>Eliminate the enemy army</b> to win (or hold the most units, then HP, at the turn limit).</p>
+
+<h3>🎮 HOW A TURN WORKS</h3>
+<p>Click one of <b>your</b> units. Green dots show where it can <b>move</b> (range ${MOVE_RANGE}, blocked by other units). Click a tile to move, or click the unit to stay put — then an <b>action menu</b> opens: Attack, a charge pulse, Entangle, Measure, or End turn. A red ring marks enemies in strike range; click one to attack directly. One unit acts per turn. Keys: [A] attack, [H/X/Y/Z/S/T] charge, [R]/[Shift+R] Ry/Rx, [M] measure, [C] entangle, [Space] end, [ESC] cancel.</p>
+
+<h3>⚔ COMBAT — CHARGE &amp; MEASURE</h3>
+<p>A unit's <b>charge</b> is its |1⟩ amplitude, P(|1⟩). To attack you must be <b>adjacent</b> to an enemy. The strike is a <b>measurement</b> of your unit (Born rule):</p>
+<table>
+  <tr><th>Your charge</th><th>Result of attacking</th></tr>
+  <tr><td>|1⟩ (100%)</td><td>Always fires — a guaranteed hit. But you discharge to |0⟩ and are left exposed.</td></tr>
+  <tr><td>|+⟩ (≈50%)</td><td>A coin-flip gamble — fire or misfire.</td></tr>
+  <tr><td>|0⟩ (0%)</td><td>Cannot strike — charge up first.</td></tr>
+</table>
+<p>When a strike fires, the <b>target is measured too</b>: if it's caught in |1⟩ it takes a <b>CRITICAL (2 dmg)</b>, otherwise 1. Either way your attacker collapses to |0⟩. <b>Defense:</b> keep idle units near |0⟩ so they're not caught charged.</p>
+
+<h3>🔋 CHARGING (control pulses)</h3>
+<table>
+  <tr><th>Pulse</th><th>Effect</th></tr>
+  <tr><td>X</td><td>|0⟩→|1⟩ — full charge, guaranteed next strike.</td></tr>
+  <tr><td>H</td><td>|0⟩→|+⟩ — ~50% charge, a flexible gamble.</td></tr>
+  <tr><td>S / T / Z</td><td>Relative-phase rotations (+π/2 · +π/4 · +π). Don't change charge or a normal strike — but a phase-loaded GUARD interferes in the X-basis: reach |+⟩ to be crit-immune, |−⟩ to be exposed.</td></tr>
+  <tr><td>Rx / Ry</td><td>±45° rotations — partial charge in one step.</td></tr>
+</table>
+<p style="opacity:.85"><b>GUARD (guardians):</b> braces in the <b>X-basis</b> instead of collapsing to |0⟩. An incoming strike measures the unit as |±⟩, so the relative phase you set with H/S/T/Z decides the crit: a |+⟩ guard is crit-immune, a |0⟩ guard is a coin flip, a |−⟩ guard is fully exposed. Phase finally pays off.</p>
+
+<h3>⚛ DECOHERENCE (Lindblad T1 / T2)</h3>
+<p>Real qubits don't bleed charge linearly — they decay <b>exponentially</b>. QuBlitz evolves every unit with the exact solution of the <b>Lindblad master equation</b>: excited charge relaxes toward |0⟩ as <b>e<sup>−t/T₁</sup></b> (amplitude damping) while superposition coherence fades as <b>e<sup>−t/T₂</sup></b> (dephasing, with T₂ ≤ 2T₁). On the Bloch sphere the state vector <b>contracts inward</b> as it mixes. So load up and strike <b>soon</b> — charge halves every couple of turns; don't charge a unit that can't reach a target. A fully decohered unit collapses to |0⟩.</p>
+<p style="opacity:.72;font-size:.92em">Verify it yourself: open the browser console and run <code>runDecoherenceDiagnostic()</code> — it fits charge-vs-turns to an exponential and a line and prints R² for each (exponential ≈ 1.000 ≫ linear), recovering the input T₁. <code>QPhysics.selfTest()</code> checks the gate &amp; decoherence math against analytic values.</p>
+
+<h3>🔗 ENTANGLEMENT &amp; 🔍 MEASURE</h3>
+<p><b>Entangle (CNOT)</b> links two <b>adjacent</b> units (friend or foe) into a Bell link — a hit on one bleeds <b>1 damage onto the other</b>. Entangle two enemies for splash value. <b>Measure</b> collapses your unit to an eigenstate and restores coherence (+12) — discharge a dangerously-exposed unit, or stabilize one.</p>
+
+<h3>🎨 READING THE BOARD</h3>
+<p>Units glow in their faction color — <b style="color:#2fe0d0">cyan</b> vs <b style="color:#ff4d9d">magenta</b>; the glow turns <b style="color:#ff5a72">hot red</b> as a unit charges toward |1⟩. <b>Green pips</b> above = HP; the bottom bar = charge. The state dot reads green |0⟩ (safe) · cyan superposition · red |1⟩ (charged). The Sage NPC beside the board calls out the best play each turn.</p>
+`;
+  document.getElementById('modal-overlay').classList.add('show');
+}
+
+// ═══════════════════════════════════════════════════════
+// INIT
+// ═══════════════════════════════════════════════════════
+window.addEventListener('load', () => {
+  document.fonts.ready.then(() => {
+    initBg();
+    animateBg();
+    runBoot();
+  });
+});
+</script>
+
+<div id="vote-overlay">
+  <div id="vote-title">◈ CROWD VOTE ◈</div>
+  <div id="vote-subtitle">Press 1–4 on any keyboard to vote! Most votes wins.</div>
+  <div id="vote-timer">12</div>
+  <div id="vote-grid"></div>
+  <div id="vote-status" style="font-size:11px;color:rgba(255,255,255,0.4);margin-top:6px;">
+    [ESC] or [Enter] to resolve immediately
+  </div>
+</div>
+
+<!-- Persistent vote-mode badge, always visible on the game screen -->
+<div id="vote-mode-badge"
+  onclick="GAME.voteMode=!GAME.voteMode;const b=document.getElementById('vote-btn');if(b)b.textContent=GAME.voteMode?'ON ✓':'OFF';_updateVoteBadge();logEv(GAME.voteMode?'Crowd Vote ENABLED — audience presses 1–4 next turn':'Crowd Vote disabled.','system');"
+  title="Toggle Crowd Vote (or press V)"
+  style="
+    position:fixed; bottom:8px; left:50%; transform:translateX(-50%);
+    font-family:var(--pixel); font-size:11px; letter-spacing:1px;
+    padding:5px 14px; border-radius:4px; cursor:pointer;
+    border:1px solid rgba(124,140,230,0.2);
+    background:rgba(18,24,52,0.5); color:#6b76a8;
+    opacity:0.38; z-index:200;
+    transition:all 0.25s ease; user-select:none;
+  ">VOTE OFF [V]</div>
+</body>
+</html>

--- a/pages/_assets/quantum_chess.html
+++ b/pages/_assets/quantum_chess.html
@@ -181,17 +181,20 @@ canvas { display: block; cursor: pointer; }
   .panel { max-width: 800px; width: 100%; order: 2; }
   #canvas-wrap { order: 1; }
 }
-/* UX-3 — tablet breakpoint. Nothing previously fired between 1100px and
-   560px, so the sage-bar footer row (hotkey legend + EXPLAIN + TEACH + MORE)
-   had no rule forcing it to wrap or shrink at ~768px and its flex children
-   overlapped into garbled text (e.g. "EXPLAIN JEACH"). Wrap the row onto
-   multiple lines and drop the long hotkey legend (least essential — the
-   actions are still reachable via click) so the action controls stay legible. */
-@media (max-width: 900px) {
-  #sage-bar-footer { flex-wrap: wrap; row-gap: 4px; }
-  #sage-bar-hotkey { display: none; }
-  #sage-bar-controls { flex: 1 1 auto; justify-content: flex-end; flex-wrap: wrap; row-gap: 4px; }
-}
+/* UX-3 — sage-bar footer row (hotkey legend + EXPLAIN + TEACH + MORE) could
+   overlap into garbled text (e.g. "EXPLAIN JEACH"). A viewport max-width media
+   query is the wrong tool here: #game-canvas is sized by
+   `width: min(800px, calc(100vh - 250px))` (see #game-canvas above), so the
+   sage-bar's actual width is driven by viewport HEIGHT, not width — on any
+   normal-height laptop screen the canvas (and this footer) is already well
+   under 900px wide even at a 1440px-wide viewport, so a width-gated rule never
+   fires when it needs to. Made unconditional instead: flex-wrap only engages
+   when content doesn't fit, so this is a no-op at any width wide enough for a
+   single line, and safely wraps otherwise, regardless of what's constraining
+   the width. */
+#sage-bar-footer { flex-wrap: wrap; row-gap: 4px; }
+#sage-bar-hotkey { display: none; }
+#sage-bar-controls { flex: 1 1 auto; justify-content: flex-end; flex-wrap: wrap; row-gap: 4px; }
 @media (max-width: 560px) {
   #ui { padding: 6px 6px 0; gap: 8px; }
   #canvas-wrap { padding-bottom: 72px; }

--- a/pages/_assets/quantum_chess.html
+++ b/pages/_assets/quantum_chess.html
@@ -720,6 +720,7 @@ body::before {
         <div class="srow">HP <span class="val" id="sel-theta">—</span></div>
         <div class="srow">Charge <span class="val" id="sel-phi">—</span></div>
         <div class="srow">Coherence <span class="val" id="sel-coh">—</span></div>
+        <div class="srow" title="Bloch x sets a GUARD's crit risk = (1−x)/2">X-basis <span class="val" id="sel-xbasis">—</span></div>
         <canvas id="bloch-canvas" width="100" height="100"
           style="display:block;margin:7px auto;border:1px solid rgba(90,80,204,0.40);border-radius:50%;background:radial-gradient(circle at 40% 35%, #1c2440, #0a0f22);box-shadow:0 4px 16px rgba(0,0,0,0.50);"></canvas>
         <div id="sel-hint"></div>
@@ -2672,6 +2673,9 @@ function drawBloch() {
 
   bx.fillStyle='rgba(207,214,238,0.85)'; bx.font="7px 'Press Start 2P',monospace";
   bx.fillText('|0⟩',cx+3,cy-R+10); bx.fillText('|1⟩',cx+3,cy+R-2);
+  // X-basis poles (|+⟩ / |−⟩) — the basis a GUARD is measured in, where phase decides the crit.
+  bx.fillStyle='rgba(123,213,196,0.9)';
+  bx.fillText('|+⟩',cx+R*0.5,cy+10); bx.fillText('|−⟩',cx-R*0.5-18,cy+10);
   // |1⟩ pole glows red — that's full charge (strongest strike).
   bx.fillStyle='#ff5a72'; bx.shadowColor='#ff5a72'; bx.shadowBlur=7;
   bx.beginPath(); bx.arc(cx,cy+R,3,0,2*π); bx.fill(); bx.shadowBlur=0;
@@ -2732,6 +2736,7 @@ function updateSelInfo(unit) {
     document.getElementById('sel-theta').textContent='—';
     document.getElementById('sel-phi').textContent='—';
     document.getElementById('sel-coh').textContent='—';
+    document.getElementById('sel-xbasis').textContent='—';
     document.getElementById('sel-hint').textContent='';
     drawBloch(); return;
   }
@@ -2741,6 +2746,9 @@ function updateSelInfo(unit) {
   document.getElementById('sel-theta').textContent=`${unit.hp}/${unit.maxHp}`;
   document.getElementById('sel-phi').textContent=`${(ch*100)|0}%`;
   document.getElementById('sel-coh').textContent=unit.coherence.toFixed(0)+'%';
+  const _b=unit.bloch || QPhysics.blochFromPure(unit.state);
+  const _gc=Math.round(QPhysics.guardCritProb(unit.state)*100);
+  document.getElementById('sel-xbasis').textContent=`x=${_b.x.toFixed(2)} · GUARD ${_gc}%`;
   document.getElementById('sel-hint').textContent=
     `Charge = strike chance (P(|1⟩)). Use X to charge toward |1⟩, H for a 50% gamble, MEASURE to discharge & stabilize. After attacking, the unit drops to |0⟩.`;
   // QB-8 — announce the selection and, on the very first selection, show a

--- a/pages/_assets/quantum_chess.html
+++ b/pages/_assets/quantum_chess.html
@@ -129,8 +129,8 @@ html, body {
 /* ── Title bar ─────────────────────────────────────── */
 #title-bar {
   width: 100%; max-width: 1350px;
-  margin-top: 8px;
-  padding: 10px 18px;
+  margin-top: 4px; /* UX-5 — trim vertical chrome so more fits in a fixed-height iframe */
+  padding: 7px 18px;
   display: flex; align-items: center; justify-content: space-between;
   border-radius: 4px;
   border: 2px solid rgba(90,80,204,0.55);
@@ -180,6 +180,17 @@ canvas { display: block; cursor: pointer; }
   #canvas-wrap { flex-shrink: 1; min-width: 0; width: 100%; max-width: 800px; }
   .panel { max-width: 800px; width: 100%; order: 2; }
   #canvas-wrap { order: 1; }
+}
+/* UX-3 — tablet breakpoint. Nothing previously fired between 1100px and
+   560px, so the sage-bar footer row (hotkey legend + EXPLAIN + TEACH + MORE)
+   had no rule forcing it to wrap or shrink at ~768px and its flex children
+   overlapped into garbled text (e.g. "EXPLAIN JEACH"). Wrap the row onto
+   multiple lines and drop the long hotkey legend (least essential — the
+   actions are still reachable via click) so the action controls stay legible. */
+@media (max-width: 900px) {
+  #sage-bar-footer { flex-wrap: wrap; row-gap: 4px; }
+  #sage-bar-hotkey { display: none; }
+  #sage-bar-controls { flex: 1 1 auto; justify-content: flex-end; flex-wrap: wrap; row-gap: 4px; }
 }
 @media (max-width: 560px) {
   #ui { padding: 6px 6px 0; gap: 8px; }
@@ -244,6 +255,22 @@ body.biome-snow {
   font-family: var(--body); font-weight: 600;
 }
 .srow .val { font-family: var(--pixel); font-size:11px; color: var(--green); }
+.srow span, .srow > * { min-width: 0; }
+.srow-label {
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  flex-shrink: 0; margin-right: 8px;
+}
+/* UX-1 — X-basis row: label + two value fields (x= and GUARD%) that must
+   never visually collide. Wraps to a second line at narrow widths instead
+   of overlapping; each field keeps its own nowrap run so digits never split. */
+.srow-xbasis {
+  flex-wrap: wrap; row-gap: 2px; column-gap: 8px;
+}
+.srow-xbasis .val {
+  display: flex; flex-wrap: wrap; justify-content: flex-end;
+  gap: 2px 10px; flex: 1 1 auto; min-width: 0;
+}
+.srow-xbasis .val span { white-space: nowrap; }
 
 /* Coherence bar */
 .cbar {
@@ -295,7 +322,7 @@ body.biome-snow {
 
 #sel-eq {
   font-size:11px; color: var(--teal);
-  word-break: break-all; min-height: 16px; margin-bottom: 4px;
+  overflow-wrap: break-word; word-break: normal; min-height: 16px; margin-bottom: 4px;
   font-family: var(--pixel); line-height: 1.7;
 }
 #sel-hint {
@@ -365,6 +392,28 @@ body.biome-snow {
 }
 #sage-bar-more.show { display: block; }
 
+/* UX-5 — Sage panel collapse toggle. Shrinks the message area (name + text)
+   while keeping the footer controls (EXPLAIN / TEACH / MORE / this toggle)
+   visible and reachable, so a fixed-height embed (e.g. an 860px iframe) can
+   reclaim vertical space without losing access to the Sage controls. */
+#sage-bar-collapse {
+  font-family: var(--pixel); font-size:11px;
+  color: rgba(139,125,255,0.85); cursor: pointer;
+}
+#sage-bar.collapsed {
+  min-height: 34px; max-height: 34px;
+}
+#sage-bar.collapsed #sage-portrait { height: 34px; }
+#sage-bar.collapsed #sage-bar-name,
+#sage-bar.collapsed #sage-bar-text { display: none; }
+#sage-bar.collapsed #sage-bar-body { padding: 6px 14px; justify-content: center; }
+/* Canvas-wrap reserves 90px of padding for the 82px sage bar + 5px timer bar
+   (see #canvas-wrap comment); when collapsed the bar only needs ~34px. */
+#canvas-wrap.sage-collapsed { padding-bottom: 42px; }
+#canvas-wrap.sage-collapsed #sage-tips { bottom: 34px; }
+#canvas-wrap.sage-collapsed #timer-bar { bottom: 37px; }
+#canvas-wrap.sage-collapsed #timer-chip { bottom: 38px; }
+
 /* Expanded tips panel — sits directly above the sage bar in the padding zone.
    max-height keeps it from ever reaching the canvas area. */
 #sage-tips {
@@ -404,13 +453,13 @@ body.biome-snow {
 /* ── Log ───────────────────────────────────────────── */
 #log {
   width: 100%; max-width: 1350px;
-  margin-top: 6px;
+  margin-top: 4px; /* UX-5 — trim vertical chrome so more fits in a fixed-height iframe */
   background: rgba(4,6,20,0.95);
   border: 1px solid rgba(90,80,204,0.40);
   border-radius: 4px;
-  padding: 7px 14px;
+  padding: 5px 14px;
   font-size: 11px; color: var(--ink-2);
-  height: 62px; overflow-y: auto;
+  height: 54px; overflow-y: auto;
   font-family: var(--body); font-weight: 500; line-height: 1.75;
 }
 #log span { display: block; animation: logIn .35s var(--ease); }
@@ -698,6 +747,7 @@ body::before {
             <span id="sage-bar-controls" style="display:flex;gap:10px;align-items:center">
               <span id="sage-bar-explain" onclick="event.stopPropagation(); explainSelected();" title="Explain the selected qubit's state (E)" style="cursor:pointer;font-family:var(--pixel);font-size:11px;color:rgba(139,125,255,0.85)">✦ EXPLAIN</span>
               <span id="sage-bar-coach" onclick="event.stopPropagation(); toggleCoach();" title="Toggle teaching depth (verbose ↔ terse)" style="cursor:pointer;font-family:var(--pixel);font-size:11px;color:rgba(139,125,255,0.85)">◆ TEACH</span>
+              <span id="sage-bar-collapse" onclick="event.stopPropagation(); toggleSagePanel();" title="Collapse/expand the Sage panel to reclaim vertical space">▾ HIDE</span>
               <span id="sage-bar-more">▼ MORE</span>
             </span>
           </div>
@@ -723,7 +773,10 @@ body::before {
         <div class="srow">HP <span class="val" id="sel-theta">—</span></div>
         <div class="srow">Charge <span class="val" id="sel-phi">—</span></div>
         <div class="srow">Coherence <span class="val" id="sel-coh">—</span></div>
-        <div class="srow" title="Bloch x sets a GUARD's crit risk = (1−x)/2">X-basis <span class="val" id="sel-xbasis">—</span></div>
+        <div class="srow srow-xbasis" title="Bloch x sets a GUARD's crit risk = (1−x)/2">
+          <span class="srow-label">X-basis</span>
+          <span class="val" id="sel-xbasis">—</span>
+        </div>
         <canvas id="bloch-canvas" width="100" height="100"
           style="display:block;margin:7px auto;border:1px solid rgba(90,80,204,0.40);border-radius:50%;background:radial-gradient(circle at 40% 35%, #1c2440, #0a0f22);box-shadow:0 4px 16px rgba(0,0,0,0.50);"></canvas>
         <div id="sel-hint"></div>
@@ -994,7 +1047,7 @@ const GATES = {
 
 const GATE_INFO = {
   H: {label:'Hadamard',short:'|0⟩↔|+⟩ superposition',ctrl:'π rotation around (X+Z)/√2. Creates maximum superposition — equal |0⟩/|1⟩ amplitude. Drives qubit to Bloch equator.'},
-  X: {label:'Pauli-X',short:'|0⟩↔|1⟩ bit-flip NOT',ctrl:'π rotation around X-axis. Full population inversion. The quantum NOT gate — foundational to error correction.'},
+  X: {label:'Pauli-X',short:'|0⟩↔|1⟩ bit-flip NOT',ctrl:'π rotation around X-axis. Full population inversion. The quantum NOT gate — foundational to error correction. In-game this is "full charge," but |1⟩ is the excited state — in a real lab it\'s fragile, which is exactly why it decays.'},
   Y: {label:'Pauli-Y',short:'bit-flip + phase flip',ctrl:'π rotation around Y-axis. Applies both bit-flip and phase-flip: α↦−iβ, β↦iα.'},
   Z: {label:'Pauli-Z',short:'phase flip |+⟩↔|−⟩',ctrl:'π rotation around Z-axis. Flips the sign of the |1⟩ amplitude (φ→φ+π), which swaps |+⟩↔|−⟩. Phase is invisible to charge and a Z-basis strike, but flips a safe X-basis GUARD into an exposed one.'},
   S: {label:'S Phase',short:'+π/2 relative phase',ctrl:'90° Z-axis rotation. Multiplies |1⟩ by i (φ→φ+π/2). Chain two S gates to get Z. Sets up the relative phase that decides a GUARD\'s X-basis crit odds.'},
@@ -1002,7 +1055,7 @@ const GATE_INFO = {
   Rx:{label:'Rx(π/4)',short:'π/4 X-axis tilt',ctrl:'π/4 X-axis rotation, modelling Larmor spin precession. Tilts the qubit toward the equator, adjusting both charge and the X-basis phase.'},
   Ry:{label:'Ry(π/4)',short:'π/4 Y-axis tilt',ctrl:'π/4 Y-axis rotation, modelling Rabi oscillation — the cleanest coherent qubit drive. Nudges charge without adding a complex phase.'},
   CNOT:   {label:'CNOT',short:'entangle two qubits',ctrl:'Conditional X: flips target if control |1⟩. Forms a correlated Bell pair — a strike on one bleeds onto the other (no faster-than-light control; only the correlation is shared).'},
-  MEASURE:{label:'Measure',short:'collapse to eigenstate',ctrl:'Projective Z-basis measurement. Collapses |ψ⟩ to |0⟩ or |1⟩ and stabilizes the unit (coherence +12).'},
+  MEASURE:{label:'Measure',short:'collapse to eigenstate',ctrl:'Projective Z-basis measurement. Collapses |ψ⟩ to |0⟩ or |1⟩ and stabilizes the unit (coherence +12). "Discharging" to |0⟩ is a game-mechanic reward, not a physical one — |0⟩ is simply the low-energy ground state a real qubit relaxes to anyway; |1⟩ is high-energy and short-lived by nature.'},
 };
 
 // ═══════════════════════════════════════════════════════
@@ -1231,6 +1284,163 @@ if (typeof window !== 'undefined') {
   window.runDecoherenceDiagnostic = o => QPhysics.diagnose(o);
   try { QPhysics.selfTest(); } catch (e) { console.error('QPhysics self-test threw', e); }
 }
+
+// ═══════════════════════════════════════════════════════
+// BotAI — pure, DOM-free bot decision + combat-resolution engine (GD-1).
+// Mirrors doBotMove()'s move/action-selection logic and attack()'s combat
+// math exactly, but takes plain data in and returns a plain decision/result
+// out — no document.*, no canvas, no GAME global, no animation/sfx calls.
+// The in-browser doBotMove()/attack() call into this module so there is a
+// single source of truth for "what does the bot do" and "who gets crit".
+// This is what tests/bot_guard_harness.test.js extracts and drives headlessly.
+// ═══════════════════════════════════════════════════════
+const BotAI = (() => {
+  // A unit only needs: {row,col,owner,role,hp,state,bloch,guarding,
+  // inSuperpos,entangledWith,coherence,maxCoh,id} — the same shape createUnit()
+  // produces. charge()/QPhysics work off .state/.bloch, so this module doesn't
+  // need its own copy of qubit math.
+  const charge = u => QPhysics.charge(u.bloch || QPhysics.blochFromPure(u.state));
+
+  // ── Move-target scoring (mirrors the mine.forEach(u=>{...}) block in
+  // doBotMove): for one unit, score each reachable tile by proximity to the
+  // nearest foe and, if a foe would be adjacent from there, by charge/kill
+  // potential. Pure function of (unit, spots, foes, rndSpread, rng). ──
+  function scoreMoveSpots(unit, spots, foes, rndSpread, rng = Math.random) {
+    const pAtt = charge(unit);
+    let best = null, bestScore = -Infinity;
+    spots.forEach(s => {
+      let nearest = 99, adj = null;
+      foes.forEach(f => {
+        const d = Math.abs(f.row - s.row) + Math.abs(f.col - s.col);
+        if (d < nearest) nearest = d;
+        if (d === 1 && (!adj || f.hp < adj.hp)) adj = f;
+      });
+      let score = -nearest;
+      if (adj) {
+        score += 6 + pAtt * 9;
+        if (adj.hp <= 1 && pAtt > 0.5) score += 6;
+        if (pAtt < 0.2) score -= 3;
+      }
+      score += rng() * rndSpread;
+      if (score > bestScore) { bestScore = score; best = { spot: s, score }; }
+    });
+    return best;
+  }
+
+  // ── Target selection among adjacent enemies (GD-1). doBotMove() used to
+  // sort purely by lowest HP. A non-guarding target's crit chance on a hit
+  // is exactly its own charge (Z-basis measurement), so an X-only opponent —
+  // who is at high charge every time it's adjacent, about to take its own
+  // shot — is a free crit if struck first. On medium/hard, prefer a
+  // low-HP-and-highly-charged-and-not-guarding kill/crit over a merely
+  // low-HP one; this is what actually punishes "press X, walk over, attack"
+  // instead of relying solely on the 1-in-army guardian's GUARD. Falls back
+  // to plain lowest-HP on easy (diff 0) or when no target is more exposed. ──
+  function pickTarget(adjFoes, diff) {
+    if (!adjFoes.length) return undefined;
+    const byHp = adjFoes.slice().sort((a, b) => a.hp - b.hp);
+    if (diff < 1) return byHp[0];
+    const exposed = adjFoes.filter(f => !f.guarding && charge(f) > 0.6);
+    if (exposed.length) return exposed.slice().sort((a, b) => a.hp - b.hp)[0];
+    return byHp[0];
+  }
+
+  // ── Action-selection decision tree — mirrors doBotMove()'s numbered
+  // 1)-6) cascade exactly, PLUS the GD-1 policy addition: on medium/hard,
+  // a guardian facing a threat that is already phase-favorable (or for whom
+  // GUARD is simply the best available move) prefers GUARD over passively
+  // charging or taking a weak/no action. Returns a decision descriptor;
+  // never mutates its inputs. `advanced` = chance to reach for a smart play,
+  // same [0, 0.45, 0.8][diff] table as doBotMove(). `rng` is injectable for
+  // deterministic tests.
+  function chooseAction({ unit, target, threat, diff, rng = Math.random }) {
+    const myChg = charge(unit);
+    const advanced = [0, 0.45, 0.8][diff];
+    const gcrit = QPhysics.guardCritProb(unit.bloch || QPhysics.blochFromPure(unit.state));
+
+    // GD-1 — guard-preference gate: on medium/hard, a guardian under threat
+    // that is NOT about to land a strong hit itself, and whose current phase
+    // already makes GUARD cheap (crit risk <= 50%, i.e. at worst a coin flip
+    // — X-only opponents sit at exactly 50%, phase-managed ones sit near 0%),
+    // takes GUARD in preference to passively charging (step 5) or a no-op.
+    // This is inserted between the existing steps 4 and 5 so a genuine kill
+    // shot (step 1), an already-scheduled guard (step 2), a defensive MEASURE
+    // (step 3) and CNOT setup (step 4) all still take priority — GD-1 only
+    // fires when the bot would otherwise have fallen through to "charge up".
+    // `nearFoe` is broader than `threat`: any adjacent enemy can reach full
+    // charge and strike next turn (an X-only opponent goes from 0% to 100%
+    // in one gate), so a guardian standing next to ANY enemy — not only one
+    // already above 50% charge — has a live reason to brace rather than
+    // wait for the threat to fully materialize first.
+    const nearFoe = !!target;
+    const guardIsCheap = gcrit <= 0.5;
+    const preferGuard = unit.role === 'guardian' && (threat || nearFoe) && diff >= 1 &&
+      !unit.guarding && !(target && myChg > 0.6) && guardIsCheap;
+
+    if (target && myChg > 0.6) {
+      return { action: 'ATTACK', target, reason: 'strong-shot' };
+    } else if (unit.role === 'guardian' && (threat || nearFoe) && diff >= 1 && rng() < advanced) {
+      return { action: 'GUARD', reason: 'scheduled-guard' };
+    } else if (unit.role === 'guardian' && diff >= 1 && threat && myChg > 0.4 && myChg <= 0.6 && rng() < advanced) {
+      // GD-1 — bugfix + scope-narrow of the original "defensive MEASURE" step:
+      // (a) it was gated on `!target`, but `threat` already implies an
+      // adjacent enemy, which means `target` is (almost) always truthy too —
+      // so the branch was structurally near-dead. Gating on `myChg <= 0.6`
+      // instead (i.e. "not already taking the strong-shot at step 1") makes
+      // it reachable. (b) scoped to guardians: a warrior has no GUARD to
+      // fall back on, so discharging away its own charge purely because it's
+      // threatened is a pure tempo loss for it (the same trap a "camp in
+      // |+⟩ forever" policy falls into) — only a guardian, who can follow up
+      // with a cheap GUARD, comes out ahead by playing defensively here.
+      return { action: 'MEASURE', reason: 'defensive-measure' };
+    } else if (diff >= 2 && !unit.entangledWith && target && myChg < 0.6 && !threat && rng() < 0.4) {
+      return { action: 'CNOT', target, reason: 'setup-splash' };
+    } else if (preferGuard) {
+      return { action: 'GUARD', reason: 'guard-preferred (GD-1: cheap crit risk, no better play)' };
+    } else if (myChg < 0.6) {
+      // GD-1 — phase play (H) only pays for itself on a guardian, since
+      // GUARD is the only thing that turns phase into a defensive benefit;
+      // for a warrior, a coin-flip charge is a strictly worse choice than
+      // going straight for a guaranteed X charge, so restrict the "fast
+      // gamble" branch to guardians and always charge-up with X otherwise.
+      // For guardians specifically this is no longer a random "maybe" — a
+      // guardian with no adjacent target has nothing to lose by prepping
+      // |+⟩ now (deterministic on medium/hard), since it's directly setting
+      // up the GUARD counter-play rather than gambling on a faster strike.
+      const gate = unit.role === 'guardian'
+        ? ((diff >= 1 && !target) ? 'H' : 'X')
+        : 'X';
+      return { action: 'GATE', gate, reason: gate === 'H' ? 'fast-gamble' : 'charge-up' };
+    } else if (target) {
+      return { action: 'ATTACK', target, reason: 'take-the-shot' };
+    }
+    return { action: 'GATE', gate: 'X', reason: 'build-charge' };
+  }
+
+  // ── Combat resolution — pure port of attack()'s math (Born-rule fire roll,
+  // GUARD X-basis measurement, crit, damage, entangled-partner splash). Takes
+  // plain state, mutates nothing; returns a result descriptor the caller
+  // applies to its own unit objects (browser: real GAME.pieces; harness: a
+  // headless sim state). `rng()` drives the fire roll; `measureRng()` drives
+  // the target's collapse (both injectable for deterministic tests). ──
+  function resolveAttack(attacker, target, rng = Math.random) {
+    const pAtt = charge(attacker);
+    const fired = rng() < pAtt;
+    if (!fired) return { fired: false, pAtt };
+
+    // GUARD reads the target in the X-basis (apply H, then a Z-basis
+    // projective measurement) — exactly QB-5's defensive-interference rule.
+    const src = target.guarding ? GATES.H(target.state) : target.state;
+    const p1 = C.norm2(src.beta);
+    const collapsed = rng() < p1 ? 1 : 0;
+    const crit = collapsed === 1;
+    const dmg = crit ? 2 : 1;
+    return { fired: true, pAtt, crit, dmg, collapsed };
+  }
+
+  return { charge, scoreMoveSpots, pickTarget, chooseAction, resolveAttack };
+})();
+if (typeof window !== 'undefined') { window.BotAI = BotAI; }
 
 // ═══════════════════════════════════════════════════════
 // PIXEL ART SPRITES  (7 cols × 9 rows bitmaps)
@@ -1801,8 +2011,13 @@ function damageUnit(u, dmg) {
 // If it fired, the target is measured too — an excited target is caught exposed
 // and takes a critical hit. Entangled targets bleed 1 onto their Bell partner.
 function attack(attacker, target) {
-  const pAtt  = charge(attacker);
-  const fired = Math.random() < pAtt;
+  // Fire roll + GUARD-aware target collapse are delegated to
+  // BotAI.resolveAttack (GD-1) — the same pure combat-resolution function
+  // tests/bot_guard_harness.test.js drives headlessly, so the in-browser
+  // game and the harness can never disagree about who gets crit.
+  const res  = BotAI.resolveAttack(attacker, target);
+  const pAtt = res.pAtt;
+  const fired = res.fired;
   // Face the target and swing/cast (the attack animation plays regardless).
   const fdx = target.col - attacker.col;
   if (fdx) attacker.facing = fdx<0 ? -1 : 1;
@@ -1824,9 +2039,10 @@ function attack(attacker, target) {
   // QB-5 — a GUARDing unit is measured in the X-basis (apply H, then a Z-basis
   // measurement): whether it is caught excited (a CRITICAL) depends on the
   // relative phase φ it set up. |+⟩ is crit-immune, |−⟩ is fully exposed.
-  // Non-guarding units take the ordinary Z-basis measurement.
-  const tm = target.guarding ? measureState(GATES.H(target.state))
-                             : measureState(target.state);
+  // Non-guarding units take the ordinary Z-basis measurement. The collapse
+  // outcome itself already happened inside BotAI.resolveAttack (res.collapsed)
+  // — apply the resulting eigenstate to the real target object here.
+  const tm = { collapsed: res.collapsed, state: _EIGEN(res.collapsed) };
   target.state = tm.state; refreshSuperpos(target);
   const crit = tm.collapsed===1;
   // QB-6 — measuring an entangled target collapses its partner with a
@@ -1849,7 +2065,7 @@ function attack(attacker, target) {
     GAME.shake = Math.max(GAME.shake, 8);
   }
   logEv(`STRIKE: ${coord(attacker.row,attacker.col)} → ${coord(target.row,target.col)} for ${dmg}`+
-    `${crit?' (CRITICAL — target caught in |1⟩!)':''}.`,'capture');
+    `${crit?' (CRITICAL — target caught in |1⟩, the fragile excited state!)':''}.`,'capture');
   spawn(attacker.px, attacker.py, FACTION[attacker.owner].col, 8);
   const partner = target.entangledWith && GAME.pieces.find(p=>p.id===target.entangledWith);
   // Flash the entanglement beam when a hit propagates.
@@ -1948,25 +2164,13 @@ async function doBotMove() {
   const rnd = [6, 3, 1][GAME.difficulty];
   let best=null, bestScore=-Infinity;
 
+  // Move-target scoring is delegated to BotAI.scoreMoveSpots (GD-1) — a pure
+  // function of (unit, spots, foes, rndSpread) so it can run headlessly in
+  // tests/bot_guard_harness.test.js with no duplicated logic.
   mine.forEach(u=>{
     const spots = [{row:u.row,col:u.col}, ...reachableTiles(u)];
-    const pAtt  = charge(u);
-    spots.forEach(s=>{
-      let nearest=99, adj=null;
-      foes.forEach(f=>{
-        const d=Math.abs(f.row-s.row)+Math.abs(f.col-s.col);
-        if (d<nearest) nearest=d;
-        if (d===1 && (!adj || f.hp<adj.hp)) adj=f;
-      });
-      let score = -nearest;
-      if (adj) {
-        score += 6 + pAtt*9;
-        if (adj.hp<=1 && pAtt>0.5) score += 6;
-        if (pAtt < 0.2) score -= 3;
-      }
-      score += Math.random()*rnd;
-      if (score>bestScore) { bestScore=score; best={u, s}; }
-    });
+    const picked = BotAI.scoreMoveSpots(u, spots, foes, rnd);
+    if (picked && picked.score>bestScore) { bestScore=picked.score; best={u, s:picked.spot}; }
   });
 
   if (!best) { endTurn(); return; }
@@ -1985,56 +2189,52 @@ async function doBotMove() {
   updateSelInfo(u);
 
   // ── Action selection — uses the full action set, scaled by difficulty so
-  //    players see (and get punished by) MEASURE, CNOT, GUARD and phase. ──
+  //    players see (and get punished by) MEASURE, CNOT, GUARD and phase.
+  //    The decision itself is delegated to BotAI.chooseAction (GD-1) — a
+  //    pure function of (unit, target, threat, diff) — so the exact same
+  //    policy runs headlessly in tests/bot_guard_harness.test.js. ──
   const diff   = GAME.difficulty;                 // 0 easy · 1 medium · 2 hard
   const myChg  = charge(u);
   const adjFoes = adjacentEnemies(u);
-  const target = adjFoes.sort((a,b)=>a.hp-b.hp)[0];
+  // GD-1 — BotAI.pickTarget prefers a low-HP, highly-charged, non-guarding
+  // foe (a free crit) over plain lowest-HP on medium/hard, so a bot that
+  // gets the chance to strike first actually punishes X-spam.
+  const target = BotAI.pickTarget(adjFoes, diff);
   // An adjacent enemy that is itself charged can crit u next turn.
   const threat = adjFoes.some(f => charge(f) > 0.5);
-  const advanced = [0, 0.45, 0.8][diff];          // chance to reach for a smart play
 
-  // 1) Take a strong shot if we have one.
-  if (target && myChg > 0.6) {
-    GAME.botLastReason = `Bot strikes ${coord(target.row,target.col)} — charge ${(myChg*100)|0}%, Born rule: P(hit) = |β|².`;
-    attack(u, target);
+  const decision = BotAI.chooseAction({ unit: u, target, threat, diff });
 
-  // 2) Guardian under threat → brace in the X-basis. Hard bots set up |+⟩ with H
-  //    first (next turn) but a bare guard already halves the crit risk.
-  } else if (u.role==='guardian' && threat && diff>=1 && Math.random()<advanced) {
+  if (decision.action === 'ATTACK') {
+    GAME.botLastReason = decision.reason === 'strong-shot'
+      ? `Bot strikes ${coord(target.row,target.col)} — charge ${(myChg*100)|0}%, Born rule: P(hit) = |β|².`
+      : `Bot strikes ${coord(target.row,target.col)} — measuring the enemy at ${(myChg*100)|0}% charge.`;
+    attack(u, decision.target);
+
+  } else if (decision.action === 'GUARD') {
     u.guarding = true; refreshSuperpos(u);
     u.coherence = Math.min(u.maxCoh, u.coherence+8);
-    GAME.botLastReason = `Bot GUARDS ${coord(u.row,u.col)} — bracing in the X-basis (${(QPhysics.guardCritProb(u.state)*100)|0}% crit risk) against the adjacent threat.`;
+    GAME.botLastReason = decision.reason.startsWith('guard-preferred')
+      ? `Bot GUARDS ${coord(u.row,u.col)} — its phase already keeps X-basis crit risk low (${(QPhysics.guardCritProb(u.state)*100)|0}%), so bracing beats a passive charge.`
+      : `Bot GUARDS ${coord(u.row,u.col)} — bracing in the X-basis (${(QPhysics.guardCritProb(u.state)*100)|0}% crit risk) against the adjacent threat.`;
     sfxGate('Z');
 
-  // 3) MEASURE-discharge a dangerously exposed unit: in superposition, charged,
-  //    and threatened — collapse now to (maybe) drop to a safe |0⟩.
-  } else if (diff>=1 && threat && u.inSuperpos && myChg>0.4 && !target && Math.random()<advanced) {
-    GAME.botLastReason = `Bot MEASURES ${coord(u.row,u.col)} — discharging a unit about to be crit (collapse to an eigenstate).`;
+  } else if (decision.action === 'MEASURE') {
+    GAME.botLastReason = `Bot MEASURES ${coord(u.row,u.col)} — discharging out of the fragile |1⟩ excited state before it gets crit (collapse to an eigenstate).`;
     applyMeasure(u);
 
-  // 4) CNOT-link an adjacent enemy into a Bell pair so the bot's next strike
-  //    splashes — hard bots only, and only when not about to be self-splashed.
-  } else if (diff>=2 && !u.entangledWith && target && myChg < 0.6 && !threat && Math.random()<0.4) {
-    GAME.botLastReason = `Bot uses CNOT on ${coord(target.row,target.col)} — forming a Bell pair so a later strike bleeds onto its partner.`;
-    applyCNOT(u, target);
+  } else if (decision.action === 'CNOT') {
+    GAME.botLastReason = `Bot uses CNOT on ${coord(decision.target.row,decision.target.col)} — forming a Bell pair so a later strike bleeds onto its partner.`;
+    applyCNOT(u, decision.target);
 
-  // 5) Can't finish a kill — charge up. X for a sure |1⟩, or gamble on H
-  //    (superposition) when the bot wants to act fast.
-  } else if (myChg < 0.6) {
-    const gate = (diff>=1 && !target && Math.random()<advanced) ? 'H' : 'X';
-    GAME.botLastReason = gate==='H'
-      ? `Bot applies H to ${coord(u.row,u.col)} — entering |+⟩ superposition (~50% charge). A fast gamble.`
-      : `Bot charges ${coord(u.row,u.col)} with X — flipping to |1⟩ for a guaranteed strike next turn.`;
-    applyGate(u, gate);
+  } else if (decision.action === 'GATE' && decision.gate === 'H') {
+    GAME.botLastReason = `Bot applies H to ${coord(u.row,u.col)} — entering |+⟩ superposition (~50% charge). A fast gamble.`;
+    applyGate(u, 'H');
 
-  // 6) Charged and adjacent — take the shot.
-  } else if (target) {
-    GAME.botLastReason = `Bot strikes ${coord(target.row,target.col)} — measuring the enemy at ${(myChg*100)|0}% charge.`;
-    attack(u, target);
-
-  } else {
-    GAME.botLastReason = `Bot charges ${coord(u.row,u.col)} with X — no enemy in reach yet, building toward |1⟩.`;
+  } else { // decision.action === 'GATE', gate 'X' (charge-up or build-charge)
+    GAME.botLastReason = target
+      ? `Bot charges ${coord(u.row,u.col)} with X — flipping to |1⟩ for a guaranteed strike next turn (it won't stay there long — |1⟩ decays fast).`
+      : `Bot charges ${coord(u.row,u.col)} with X — no enemy in reach yet, building toward |1⟩.`;
     applyGate(u, 'X');
   }
 
@@ -2586,18 +2786,33 @@ function roundRect(x,y,w,h,r){
 function drawTurnBanner() {
   const isW=GAME.turn==='white';
   const col=isW?'47,224,208':'255,77,157';
-  const g=ctx.createLinearGradient(0,0,BOARD,0);
+  const text=`${FACTION[GAME.turn].name} TO MOVE  |  KNIGHTS ${aliveCount('white')} – ${aliveCount('black')} MAGES  |  TURN ${GAME.turnCount+1}/${GAME.turnCap}`;
+  ctx.font="bold 6px 'Press Start 2P',monospace";
+
+  // UX-4 — the banner sits in the row-0 strip and previously only had a
+  // low-alpha (0.18) gradient wash behind it, so it visibly overprinted
+  // row-0 unit sprites instead of occluding them. Measure the text and draw
+  // an opaque backing plate sized to it (not the full board width) before
+  // the text, so it reads cleanly without blanking out the whole top row.
+  const textW = ctx.measureText(text).width;
+  const padX = 14, bandH = 18;
+  const bandW = Math.min(BOARD, textW + padX*2);
+  const bandX = (BOARD - bandW) / 2;
+  ctx.fillStyle = 'rgba(4,6,20,0.86)';
+  ctx.fillRect(bandX, 0, bandW, bandH);
+
+  // Subtle faction-colored wash + hairline, kept inside the opaque plate.
+  const g=ctx.createLinearGradient(bandX,0,bandX+bandW,0);
   g.addColorStop(0,'transparent');
-  g.addColorStop(0.5,`rgba(${col},0.18)`);
+  g.addColorStop(0.5,`rgba(${col},0.28)`);
   g.addColorStop(1,'transparent');
-  ctx.fillStyle=g; ctx.fillRect(0,0,BOARD,18);
+  ctx.fillStyle=g; ctx.fillRect(bandX,0,bandW,bandH);
+  ctx.strokeStyle=`rgba(${col},0.35)`; ctx.lineWidth=1;
+  ctx.beginPath(); ctx.moveTo(bandX,bandH-0.5); ctx.lineTo(bandX+bandW,bandH-0.5); ctx.stroke();
+
   ctx.textAlign='center';
   ctx.fillStyle=`rgb(${col})`;
-  ctx.font="bold 6px 'Press Start 2P',monospace";
-    ctx.fillText(
-    `${FACTION[GAME.turn].name} TO MOVE  |  KNIGHTS ${aliveCount('white')} – ${aliveCount('black')} MAGES  |  TURN ${GAME.turnCount+1}/${GAME.turnCap}`,
-    BOARD/2,12
-  );
+  ctx.fillText(text, BOARD/2, 12);
   ctx.textAlign='left';
 }
 
@@ -2740,20 +2955,27 @@ function updateSelInfo(unit) {
     document.getElementById('sel-phi').textContent='—';
     document.getElementById('sel-coh').textContent='—';
     document.getElementById('sel-xbasis').textContent='—';
+    document.getElementById('sel-eq').removeAttribute('title');
     document.getElementById('sel-hint').textContent='';
     drawBloch(); return;
   }
   const ch=charge(unit);
   document.getElementById('sel-name').textContent=`${coord(unit.row,unit.col)} · ${FACTION[unit.owner].name}`;
-  document.getElementById('sel-eq').textContent=fmtState(unit.state);
+  const _eqText=fmtState(unit.state);
+  const _eqEl=document.getElementById('sel-eq');
+  _eqEl.textContent=_eqText;
+  _eqEl.title=_eqText; // UX-1 — full ψ readable via tooltip if it ever needs to truncate at narrow widths
   document.getElementById('sel-theta').textContent=`${unit.hp}/${unit.maxHp}`;
   document.getElementById('sel-phi').textContent=`${(ch*100)|0}%`;
   document.getElementById('sel-coh').textContent=unit.coherence.toFixed(0)+'%';
   const _b=unit.bloch || QPhysics.blochFromPure(unit.state);
   const _gc=Math.round(QPhysics.guardCritProb(unit.state)*100);
-  document.getElementById('sel-xbasis').textContent=`x=${_b.x.toFixed(2)} · GUARD ${_gc}%`;
+  // UX-1 — x= and GUARD% are separate nowrap spans (not one crammed string) so
+  // they can wrap onto their own line at narrow widths instead of colliding.
+  document.getElementById('sel-xbasis').innerHTML=
+    `<span>x=${_b.x.toFixed(2)}</span><span>GUARD ${_gc}%</span>`;
   document.getElementById('sel-hint').textContent=
-    `Charge = strike chance (P(|1⟩)). Use X to charge toward |1⟩, H for a 50% gamble, MEASURE to discharge & stabilize. After attacking, the unit drops to |0⟩.`;
+    `Charge = strike chance (P(|1⟩)). Use X to charge toward |1⟩, H for a 50% gamble, MEASURE to discharge & stabilize. Note: |1⟩ is the excited state — being IN it is what makes a unit fragile (it decays and can crit), not a state you'd want to sit in. After attacking, the unit drops to |0⟩, the ground state.`;
   // QB-8 — announce the selection and, on the very first selection, show a
   // one-time "click again for actions" onboarding hint.
   const st = document.getElementById('a11y-status');
@@ -3549,7 +3771,7 @@ function analyzePosition() {
 
     if (adj.length && c >= 0.6) {
       const tgt = adj.slice().sort((a,b)=>a.hp-b.hp)[0];
-      tips.push({p:24,type:'danger',short:`${here} → ATTACK ${coord(tgt.row,tgt.col)} (${cp}% charge).`,text:`${here} sits at ${cp}% charge beside ${coord(tgt.row,tgt.col)} — ATTACK now: by the Born rule your hit probability equals the charge, and a foe caught in |1⟩ takes a CRITICAL (2 dmg).`});
+      tips.push({p:24,type:'danger',short:`${here} → ATTACK ${coord(tgt.row,tgt.col)} (${cp}% charge).`,text:`${here} sits at ${cp}% charge beside ${coord(tgt.row,tgt.col)} — ATTACK now: by the Born rule your hit probability equals the charge, and a foe caught in |1⟩ — the fragile excited state — takes a CRITICAL (2 dmg).`});
     } else if (adj.length && c < 0.35) {
       tips.push({p:23,type:'warn',short:`${here} → charge first (X/H), only ${cp}%.`,text:`${here} is in range but only ${cp}% charged — apply X (→|1⟩, 100%) or H (→|+⟩, 50%) first; attacking now fires with just ${cp}% probability and then discharges to |0⟩.`});
     } else if (!adj.length && c >= 0.6) {
@@ -3578,11 +3800,11 @@ function analyzePosition() {
   }
   // Adjacent but uncharged → charge first.
   const weakAdj = mine.find(u=>charge(u)<0.3 && adjacentEnemies(u).length);
-  if (weakAdj) tips.push({p:8,text:`${coord(weakAdj.row,weakAdj.col)} is in range but uncharged — apply X to load it toward |1⟩ before you strike.`,type:'warn'});
+  if (weakAdj) tips.push({p:8,text:`${coord(weakAdj.row,weakAdj.col)} is in range but uncharged — apply X to load it toward |1⟩ (the excited state) before you strike; it won't stay charged long once there.`,type:'warn'});
 
   // My charged unit sitting next to a live enemy → exposed to a critical.
   const exposed = mine.find(u=>charge(u)>0.6 && adjacentEnemies(u).some(e=>charge(e)>0.4));
-  if (exposed) tips.push({p:7,text:`${coord(exposed.row,exposed.col)} is charged beside a live enemy — a unit caught in |1⟩ takes a CRITICAL. Strike, retreat, or MEASURE to discharge.`,type:'warn'});
+  if (exposed) tips.push({p:7,text:`${coord(exposed.row,exposed.col)} is charged beside a live enemy — a unit caught in |1⟩ (the fragile excited state) takes a CRITICAL. Strike, retreat, or MEASURE to discharge.`,type:'warn'});
 
   // Finish a low-HP enemy.
   const low = foes.filter(f=>f.hp<=1).sort((a,b)=>a.hp-b.hp)[0];
@@ -3593,21 +3815,40 @@ function analyzePosition() {
   foes.forEach(a=>foes.forEach(b=>{ if(a!==b && !combo && adjacent(a,b)) combo=[a,b]; }));
   if (combo) tips.push({p:4,text:`Enemies at ${coord(combo[0].row,combo[0].col)} & ${coord(combo[1].row,combo[1].col)} stand adjacent — entangle them so one strike bleeds onto both.`,type:'quantum'});
 
-  tips.push({p:2,text:`Charge bleeds away each turn (T1 relaxation) — load up and strike soon. Keep idle units in |0⟩ so they're not caught exposed.`,type:'info'});
+  tips.push({p:2,text:`Charge bleeds away each turn (T1 relaxation) — that's |1⟩ being the fragile excited state, not a bug. Load up and strike soon. Keep idle units in |0⟩ (the stable ground state) so they're not caught exposed.`,type:'info'});
 
   return tips.sort((a,b)=>b.p-a.p).slice(0,3);
+}
+
+// UX-2 — speaker label for the Sage dialogue bar. Bot commentary gets its own
+// "BOT (difficulty)" speaker, distinct from the player-facing SAGE label, so
+// it never reads as the redundant/wrong "BOT: Bot ...".
+const SAGE_SPEAKER_DEFAULT = '⬟ THE SAGE · QUANTUM ADVISOR';
+const DIFF_LABEL = ['EASY','MEDIUM','HARD'];
+function setSageSpeaker(label) {
+  const nameEl = document.getElementById('sage-bar-name');
+  if (!nameEl) return;
+  // Preserve the Claude badge child element (appended inside sage-bar-name).
+  const badge = document.getElementById('claude-badge');
+  nameEl.textContent = label;
+  if (badge) nameEl.appendChild(badge);
 }
 
 // Update the Sage dialogue bar (always visible) and the optional expanded tips panel.
 function renderSage() {
   // If the bot just explained a move, show that first (fades after one call).
   if (GAME.botLastReason) {
-    startTypewriter('BOT: ' + GAME.botLastReason);
+    const diffLabel = DIFF_LABEL[GAME.difficulty] || DIFF_LABEL[1];
+    setSageSpeaker(`◆ BOT (${diffLabel})`);
+    // Reason text already reads naturally on its own (e.g. "Bot strikes E4…");
+    // the speaker label above now carries "BOT", so don't prefix it again.
+    startTypewriter(GAME.botLastReason);
     GAME.botLastReason = '';
     const bar = document.getElementById('sage-bar');
     if (bar) bar.classList.remove('urgent');
     return;
   }
+  setSageSpeaker(SAGE_SPEAKER_DEFAULT);
   const tips = analyzePosition();
   const bar  = document.getElementById('sage-bar');
   const btn  = document.querySelector('.btn-sage');
@@ -3656,6 +3897,27 @@ function toggleCoach() {
   renderSage();
 }
 
+// UX-5 — Sage panel collapse toggle. Shrinks the message area (name + text)
+// so more of a fixed-height embed (e.g. an 860px iframe) fits on screen,
+// while the footer controls (EXPLAIN / TEACH / MORE / this toggle) stay
+// visible and reachable. Persisted like the coaching-depth preference.
+let _sageCollapsed = false;
+try { _sageCollapsed = localStorage.getItem('qb_sage_collapsed') === '1'; } catch (e) {}
+function _applySageCollapsed() {
+  const bar = document.getElementById('sage-bar');
+  const wrap = document.getElementById('canvas-wrap');
+  const btn = document.getElementById('sage-bar-collapse');
+  if (bar) bar.classList.toggle('collapsed', _sageCollapsed);
+  if (wrap) wrap.classList.toggle('sage-collapsed', _sageCollapsed);
+  if (btn) btn.textContent = _sageCollapsed ? '▸ SHOW' : '▾ HIDE';
+}
+function toggleSagePanel() {
+  _sageCollapsed = !_sageCollapsed;
+  try { localStorage.setItem('qb_sage_collapsed', _sageCollapsed ? '1' : '0'); } catch (e) {}
+  _applySageCollapsed();
+  beep(_sageCollapsed ? 392 : 523, 'triangle', 0.06, 0.1);
+}
+
 // "Explain this" — read the selected qubit's quantum state in plain language.
 function explainSelected() {
   _advisorOpen = false;
@@ -3669,14 +3931,14 @@ function explainSelected() {
   const gc = Math.round(QPhysics.guardCritProb(u.state) * 100);
   const here = coord(u.row, u.col);
   let basis;
-  if (ch >= 95)      basis = '|1⟩ (excited — fully charged)';
-  else if (ch <= 5)  basis = '|0⟩ (ground — discharged)';
+  if (ch >= 95)      basis = '|1⟩ (excited — fully charged, but fragile: it decays and can be caught in a critical)';
+  else if (ch <= 5)  basis = '|0⟩ (ground — discharged and stable)';
   else if (b.x >  0.85) basis = '|+⟩ (equal superposition along +X)';
   else if (b.x < -0.85) basis = '|−⟩ (equal superposition along −X)';
   else               basis = 'a superposition of |0⟩ and |1⟩';
   const advice = ch < 50
-    ? 'Apply X to drive it toward |1⟩, or H for a |+⟩ guard.'
-    : 'Well charged — close in and strike before T₁ relaxation bleeds it away.';
+    ? 'Apply X to drive it toward |1⟩ for a guaranteed strike (remember: |1⟩ is high-energy and short-lived), or H for a |+⟩ guard.'
+    : 'Well charged — close in and strike before T₁ relaxation bleeds it away; the excited state doesn\'t last.';
   startTypewriter(`${here} is in ${basis}: charge P(|1⟩)=${ch}% (your hit chance), Bloch x=${b.x.toFixed(2)} so a GUARD here would sit at ${gc}% crit. ${advice}`);
 }
 
@@ -3762,6 +4024,7 @@ function finishBoot() {
   loop();
   _updateClaudeBadge();
   _updateCoachLabel();
+  _applySageCollapsed();
   setTimeout(openMenu, 200);
 }
 
@@ -3847,8 +4110,9 @@ function openPhysicsLab() {
 <pre style="color:var(--gold);font-size:11px;line-height:1.6;text-align:center;background:#0a0f22;border:1px solid var(--border);border-radius:4px;padding:10px;margin:6px 0">dρ/dt = −(i/ℏ)[H,ρ] + Σ γₖ( Lₖ ρ Lₖ† − ½{Lₖ†Lₖ, ρ} )</pre>
 <p style="color:var(--dim);font-size:11px;line-height:1.7">Each turn we apply its <b>exact</b> solution toward |0⟩: charge relaxes as <b style="color:var(--red)">e<sup>−t/T₁</sup></b>, transverse coherence as <b style="color:var(--teal)">e<sup>−t/T₂</sup></b> (with T₂ ≤ 2T₁). At the current rate (${GAME.decoRate}/turn): <b style="color:var(--gold)">T₁ = ${T1.toFixed(1)}</b>, <b style="color:var(--gold)">T₂ = ${T2.toFixed(1)}</b> turns.</p>
 
-<h3>FALSIFIABILITY TEST</h3>
-<p style="color:var(--dim);font-size:11px;line-height:1.6">A unit prepared in |1⟩, left to decohere. Physical decay is exponential, <i>not</i> linear — the test fits both and reports R².</p>
+<h3>ENGINE SELF-TEST: DECAY IS EXPONENTIAL, NOT LINEAR</h3>
+<p style="color:var(--dim);font-size:11px;line-height:1.6">A unit prepared in |1⟩, left to decohere. The engine's own generated data is fit against an exponential model and a linear model to confirm the <i>implementation</i> matches the exponential decay the Lindblad equation prescribes.</p>
+<p style="color:var(--wood);font-size:10px;line-height:1.6;margin:2px 0 6px">This validates the implementation against the model; the model itself is standard open-quantum-systems physics (the Lindblad master equation) — it is not an empirical measurement against a real physical qubit.</p>
 <canvas id="diag-canvas" width="360" height="190" style="width:100%;max-width:360px;display:block;margin:8px auto;background:#0a0f22;border:1px solid var(--border);border-radius:4px"></canvas>
 <p id="diag-readout" style="text-align:center;color:var(--dim);font-size:11px;margin:4px 0"></p>
 
@@ -3907,7 +4171,7 @@ function openMenu() {
   <p style="color:var(--ink-2);font-size:11px;line-height:1.7;margin:0">
     <b style="color:var(--teal)">1. CHARGE</b> — tap a unit, fire a gate (X = 100% charge, H = 50%).<br>
     <b style="color:var(--teal)">2. STRIKE</b> — move beside a foe and ATTACK; hit chance = your charge (Born rule).<br>
-    <b style="color:var(--teal)">3. BEAT THE CLOCK</b> — charge decays exponentially each turn. Strike before it bleeds away. Last army standing wins.
+    <b style="color:var(--teal)">3. BEAT THE CLOCK</b> — charge decays exponentially each turn, because |1⟩ is the fragile, high-energy excited state — that's why it decays, not a game penalty. Strike before it bleeds away. Last army standing wins.
   </p>
 </div>
 
@@ -3987,19 +4251,19 @@ function openTutorial() {
 <p>Click one of <b>your</b> units. Green dots show where it can <b>move</b> (range ${MOVE_RANGE}, blocked by other units). Click a tile to move, or click the unit to stay put — then an <b>action menu</b> opens: Attack, a charge pulse, Entangle, Measure, or End turn. A red ring marks enemies in strike range; click one to attack directly. One unit acts per turn. Keys: [A] attack, [H/X/Y/Z/S/T] charge, [R]/[Shift+R] Ry/Rx, [M] measure, [C] entangle, [Space] end, [ESC] cancel.</p>
 
 <h3>▸ COMBAT — CHARGE &amp; MEASURE</h3>
-<p>A unit's <b>charge</b> is its |1⟩ amplitude, P(|1⟩). To attack you must be <b>adjacent</b> to an enemy. The strike is a <b>measurement</b> of your unit (Born rule):</p>
+<p>A unit's <b>charge</b> is its |1⟩ amplitude, P(|1⟩). To attack you must be <b>adjacent</b> to an enemy. The strike is a <b>measurement</b> of your unit (Born rule). Note on the physics: |1⟩ is the <i>excited</i> state — in a real lab it's fragile, which is exactly why it decays (that's the in-game "charge bleeds away" clock); |0⟩ is simply the ground state a real qubit relaxes to. "Charge" is a game-mechanic reward for being excited, not a claim that the excited state is physically special or safe.</p>
 <table>
   <tr><th>Your charge</th><th>Result of attacking</th></tr>
   <tr><td>|1⟩ (100%)</td><td>Always fires — a guaranteed hit. But you discharge to |0⟩ and are left exposed.</td></tr>
   <tr><td>|+⟩ (≈50%)</td><td>A coin-flip gamble — fire or misfire.</td></tr>
   <tr><td>|0⟩ (0%)</td><td>Cannot strike — charge up first.</td></tr>
 </table>
-<p>When a strike fires, the <b>target is measured too</b>: if it's caught in |1⟩ it takes a <b>CRITICAL (2 dmg)</b>, otherwise 1. Either way your attacker collapses to |0⟩. <b>Defense:</b> keep idle units near |0⟩ so they're not caught charged.</p>
+<p>When a strike fires, the <b>target is measured too</b>: if it's caught in |1⟩ — the fragile excited state — it takes a <b>CRITICAL (2 dmg)</b>, otherwise 1. Either way your attacker collapses to |0⟩. <b>Defense:</b> keep idle units near |0⟩ so they're not caught charged and exposed — sitting in |1⟩ is inherently risky, not a state to camp in.</p>
 
 <h3>▸ CHARGING (control pulses)</h3>
 <table>
   <tr><th>Pulse</th><th>Effect</th></tr>
-  <tr><td>X</td><td>|0⟩→|1⟩ — full charge, guaranteed next strike.</td></tr>
+  <tr><td>X</td><td>|0⟩→|1⟩ — full charge, guaranteed next strike. |1⟩ is the excited state: high-energy and short-lived, which is why it decays fast.</td></tr>
   <tr><td>H</td><td>|0⟩→|+⟩ — ~50% charge, a flexible gamble.</td></tr>
   <tr><td>S / T / Z</td><td>Relative-phase rotations (+π/2 · +π/4 · +π). Don't change charge or a normal strike — but a phase-loaded GUARD interferes in the X-basis: reach |+⟩ to be crit-immune, |−⟩ to be exposed.</td></tr>
   <tr><td>Rx / Ry</td><td>±45° rotations — partial charge in one step.</td></tr>
@@ -4014,7 +4278,7 @@ function openTutorial() {
 <p><b>Entangle (CNOT)</b> links two <b>adjacent</b> units (friend or foe) into a Bell link — a hit on one bleeds <b>1 damage onto the other</b>. Entangle two enemies for splash value. <b>Measure</b> collapses your unit to an eigenstate and restores coherence (+12) — discharge a dangerously-exposed unit, or stabilize one.</p>
 
 <h3>🎨 READING THE BOARD</h3>
-<p>Units glow in their faction color — <b style="color:#2fe0d0">cyan</b> vs <b style="color:#ff4d9d">magenta</b>; the glow turns <b style="color:#ff5a72">hot red</b> as a unit charges toward |1⟩. <b>Green pips</b> above = HP; the bottom bar = charge. The state dot reads green |0⟩ (safe) · cyan superposition · red |1⟩ (charged). The Sage NPC beside the board calls out the best play each turn.</p>
+<p>Units glow in their faction color — <b style="color:#2fe0d0">cyan</b> vs <b style="color:#ff4d9d">magenta</b>; the glow turns <b style="color:#ff5a72">hot red</b> as a unit charges toward |1⟩ — physically, the fragile excited state, not a "power level." <b>Green pips</b> above = HP; the bottom bar = charge. The state dot reads green |0⟩ (safe, ground state) · cyan superposition · red |1⟩ (charged, but short-lived). The Sage NPC beside the board calls out the best play each turn.</p>
 `;
   document.getElementById('modal-overlay').classList.add('show');
 }

--- a/pages/_assets/quantum_chess.html
+++ b/pages/_assets/quantum_chess.html
@@ -692,7 +692,11 @@ body::before {
           <div id="sage-bar-text">Greetings, controller. Charge a qubit, close in, and strike.</div>
           <div id="sage-bar-footer">
             <span id="sage-bar-hotkey">[?] · A=ATK H/X/Y/Z=CHARGE M=MEASURE C=CNOT SPC=END</span>
-            <span id="sage-bar-more">▼ MORE</span>
+            <span id="sage-bar-controls" style="display:flex;gap:10px;align-items:center">
+              <span id="sage-bar-explain" onclick="event.stopPropagation(); explainSelected();" title="Explain the selected qubit's state (E)" style="cursor:pointer;font-family:var(--pixel);font-size:11px;color:rgba(139,125,255,0.85)">✦ EXPLAIN</span>
+              <span id="sage-bar-coach" onclick="event.stopPropagation(); toggleCoach();" title="Toggle teaching depth (verbose ↔ terse)" style="cursor:pointer;font-family:var(--pixel);font-size:11px;color:rgba(139,125,255,0.85)">🎓 TEACH</span>
+              <span id="sage-bar-more">▼ MORE</span>
+            </span>
           </div>
         </div>
       </div>
@@ -2944,6 +2948,8 @@ document.addEventListener('keydown', e => {
 
   // ? toggles Sage advisor
   if (e.key==='?') { toggleAdvisor(); return; }
+  // E asks the Sage to explain the selected qubit's state
+  if (key==='e' && GAME.phase!=='gameover') { explainSelected(); return; }
   // V toggles Crowd Vote mode without opening the Settings menu
   if (e.key.toLowerCase()==='v' && GAME.phase!=='gameover') {
     GAME.voteMode = !GAME.voteMode;
@@ -3532,13 +3538,13 @@ function analyzePosition() {
 
     if (adj.length && c >= 0.6) {
       const tgt = adj.slice().sort((a,b)=>a.hp-b.hp)[0];
-      tips.push({p:24,type:'danger',text:`${here} sits at ${cp}% charge beside ${coord(tgt.row,tgt.col)} — ATTACK now: by the Born rule your hit probability equals the charge, and a foe caught in |1⟩ takes a CRITICAL (2 dmg).`});
+      tips.push({p:24,type:'danger',short:`${here} → ATTACK ${coord(tgt.row,tgt.col)} (${cp}% charge).`,text:`${here} sits at ${cp}% charge beside ${coord(tgt.row,tgt.col)} — ATTACK now: by the Born rule your hit probability equals the charge, and a foe caught in |1⟩ takes a CRITICAL (2 dmg).`});
     } else if (adj.length && c < 0.35) {
-      tips.push({p:23,type:'warn',text:`${here} is in range but only ${cp}% charged — apply X (→|1⟩, 100%) or H (→|+⟩, 50%) first; attacking now fires with just ${cp}% probability and then discharges to |0⟩.`});
+      tips.push({p:23,type:'warn',short:`${here} → charge first (X/H), only ${cp}%.`,text:`${here} is in range but only ${cp}% charged — apply X (→|1⟩, 100%) or H (→|+⟩, 50%) first; attacking now fires with just ${cp}% probability and then discharges to |0⟩.`});
     } else if (!adj.length && c >= 0.6) {
-      tips.push({p:22,type:'quantum',text:`${here} is charged ${cp}% but no enemy is adjacent — close in this turn: idle charge relaxes as e^(−t/T₁), so a stored hit bleeds away while you wait.`});
+      tips.push({p:22,type:'quantum',short:`${here} → close in (${cp}% charge bleeding).`,text:`${here} is charged ${cp}% but no enemy is adjacent — close in this turn: idle charge relaxes as e^(−t/T₁), so a stored hit bleeds away while you wait.`});
     } else if (!adj.length && c < 0.35) {
-      tips.push({p:18,type:'gate',text:`${here} is at ${cp}% — use the quiet turn to load it (X or H) and advance, so it arrives at an enemy already charged.`});
+      tips.push({p:18,type:'gate',short:`${here} → load it (X/H) and advance.`,text:`${here} is at ${cp}% — use the quiet turn to load it (X or H) and advance, so it arrives at an enemy already charged.`});
     }
 
     const partner = sel.entangledWith && GAME.pieces.find(p=>p.id===sel.entangledWith);
@@ -3599,8 +3605,9 @@ function renderSage() {
   if (bar) bar.classList.toggle('urgent', urgent);
   if (btn) btn.classList.toggle('urgent', urgent);
 
-  // Primary tip → typewriter into the dialogue bar
-  if (tips[0]) startTypewriter(tips[0].text);
+  // Primary tip → typewriter into the dialogue bar. In TERSE coaching mode show
+  // the short form (just the move); in TEACH mode the full concept-linked line.
+  if (tips[0]) startTypewriter(_coachTerse ? (tips[0].short || tips[0].text) : tips[0].text);
 
   // Expanded panel (if open)
   const panel = document.getElementById('sage-tips');
@@ -3620,6 +3627,46 @@ function toggleAdvisor() {
   const moreBtn = document.getElementById('sage-bar-more');
   if (moreBtn) moreBtn.textContent = _advisorOpen ? '▲ LESS' : '▼ MORE';
   renderSage();
+}
+
+// Coaching depth: TEACH (verbose, concept-linked) ↔ TERSE (just the move).
+// Persisted so a learner's preference survives reloads.
+let _coachTerse = false;
+try { _coachTerse = localStorage.getItem('qb_coach') === 'terse'; } catch (e) {}
+function _updateCoachLabel() {
+  const el = document.getElementById('sage-bar-coach');
+  if (el) el.textContent = _coachTerse ? '🎓 TERSE' : '🎓 TEACH';
+}
+function toggleCoach() {
+  _coachTerse = !_coachTerse;
+  try { localStorage.setItem('qb_coach', _coachTerse ? 'terse' : 'teach'); } catch (e) {}
+  _updateCoachLabel();
+  beep(_coachTerse ? 392 : 523, 'triangle', 0.06, 0.1);
+  renderSage();
+}
+
+// "Explain this" — read the selected qubit's quantum state in plain language.
+function explainSelected() {
+  _advisorOpen = false;
+  const u = GAME.selected;
+  if (!u || u.owner !== GAME.turn) {
+    startTypewriter('Select one of your units, then press E — I will read its quantum state for you.');
+    return;
+  }
+  const b  = u.bloch || QPhysics.blochFromPure(u.state);
+  const ch = Math.round(charge(u) * 100);
+  const gc = Math.round(QPhysics.guardCritProb(u.state) * 100);
+  const here = coord(u.row, u.col);
+  let basis;
+  if (ch >= 95)      basis = '|1⟩ (excited — fully charged)';
+  else if (ch <= 5)  basis = '|0⟩ (ground — discharged)';
+  else if (b.x >  0.85) basis = '|+⟩ (equal superposition along +X)';
+  else if (b.x < -0.85) basis = '|−⟩ (equal superposition along −X)';
+  else               basis = 'a superposition of |0⟩ and |1⟩';
+  const advice = ch < 50
+    ? 'Apply X to drive it toward |1⟩, or H for a |+⟩ guard.'
+    : 'Well charged — close in and strike before T₁ relaxation bleeds it away.';
+  startTypewriter(`${here} is in ${basis}: charge P(|1⟩)=${ch}% (your hit chance), Bloch x=${b.x.toFixed(2)} so a GUARD here would sit at ${gc}% crit. ${advice}`);
 }
 
 // ═══════════════════════════════════════════════════════
@@ -3703,6 +3750,7 @@ function finishBoot() {
   resetGame('vsBot');
   loop();
   _updateClaudeBadge();
+  _updateCoachLabel();
   setTimeout(openMenu, 200);
 }
 

--- a/pages/_assets/quantum_chess.html
+++ b/pages/_assets/quantum_chess.html
@@ -196,10 +196,13 @@ canvas { display: block; cursor: pointer; }
   image-rendering: crisp-edges;
   /* QB-4 — display-scale to the viewport without touching the internal 800px
      resolution (kept crisp). The click handler scales via getBoundingClientRect,
-     so input math still lands on the right cells at any size. */
-  width: 100%;
+     so input math still lands on the right cells at any size.
+     Cap by viewport HEIGHT too (not just width) so the whole board + sage bar +
+     title + log fit on one screen: ~210px reserves the title bar, sage-bar
+     padding and the event log. */
+  width: min(800px, calc(100vh - 250px));
   height: auto;
-  max-width: 800px;
+  max-width: 100%;
   aspect-ratio: 1 / 1;
 }
 
@@ -668,7 +671,7 @@ body::before {
           <div>M: <span id="cnt-MEASURE">0</span></div>
         </div>
       </div>
-      <button class="btn" onclick="openTutorial()">📜 TOME</button>
+      <button class="btn" onclick="openTutorial()">▸ TOME</button>
       <button class="btn" onclick="openMenu()">⚙ MENU</button>
     </div>
 
@@ -694,7 +697,7 @@ body::before {
             <span id="sage-bar-hotkey">[?] · A=ATK H/X/Y/Z=CHARGE M=MEASURE C=CNOT SPC=END</span>
             <span id="sage-bar-controls" style="display:flex;gap:10px;align-items:center">
               <span id="sage-bar-explain" onclick="event.stopPropagation(); explainSelected();" title="Explain the selected qubit's state (E)" style="cursor:pointer;font-family:var(--pixel);font-size:11px;color:rgba(139,125,255,0.85)">✦ EXPLAIN</span>
-              <span id="sage-bar-coach" onclick="event.stopPropagation(); toggleCoach();" title="Toggle teaching depth (verbose ↔ terse)" style="cursor:pointer;font-family:var(--pixel);font-size:11px;color:rgba(139,125,255,0.85)">🎓 TEACH</span>
+              <span id="sage-bar-coach" onclick="event.stopPropagation(); toggleCoach();" title="Toggle teaching depth (verbose ↔ terse)" style="cursor:pointer;font-family:var(--pixel);font-size:11px;color:rgba(139,125,255,0.85)">◆ TEACH</span>
               <span id="sage-bar-more">▼ MORE</span>
             </span>
           </div>
@@ -3195,11 +3198,11 @@ function checkLeaderboard() {
 function leaderboardHTML() {
   const lb = loadLeaderboard();
   if (!lb.fastestWin && !lb.mostCrits && !lb.mostEntangl) return '';
-  return `<h3>🏆 HALL OF FAME</h3>
+  return `<h3>◈ HALL OF FAME</h3>
 <div class="lb-wrap">
-  ${lb.fastestWin  ? `<div class="lb-row"><span class="lb-icon">⚡</span>Fastest win<span class="lb-val">${lb.fastestWin} turns</span></div>` : ''}
-  ${lb.mostCrits   ? `<div class="lb-row"><span class="lb-icon">💥</span>Most criticals<span class="lb-val">${lb.mostCrits}</span></div>`    : ''}
-  ${lb.mostEntangl ? `<div class="lb-row"><span class="lb-icon">🔗</span>Most entanglements<span class="lb-val">${lb.mostEntangl}</span></div>` : ''}
+  ${lb.fastestWin  ? `<div class="lb-row"><span class="lb-icon">▸</span>Fastest win<span class="lb-val">${lb.fastestWin} turns</span></div>` : ''}
+  ${lb.mostCrits   ? `<div class="lb-row"><span class="lb-icon">▸</span>Most criticals<span class="lb-val">${lb.mostCrits}</span></div>`    : ''}
+  ${lb.mostEntangl ? `<div class="lb-row"><span class="lb-icon">▸</span>Most entanglements<span class="lb-val">${lb.mostEntangl}</span></div>` : ''}
 </div>`;
 }
 
@@ -3643,7 +3646,7 @@ let _coachTerse = false;
 try { _coachTerse = localStorage.getItem('qb_coach') === 'terse'; } catch (e) {}
 function _updateCoachLabel() {
   const el = document.getElementById('sage-bar-coach');
-  if (el) el.textContent = _coachTerse ? '🎓 TERSE' : '🎓 TEACH';
+  if (el) el.textContent = _coachTerse ? '◆ TERSE' : '◆ TEACH';
 }
 function toggleCoach() {
   _coachTerse = !_coachTerse;
@@ -3836,7 +3839,7 @@ function openPhysicsLab() {
 </p>`;
   }
   document.getElementById('modal-content').innerHTML = `
-<h2>🔬 PHYSICS LAB</h2>
+<h2>✦ PHYSICS LAB</h2>
 <p style="text-align:center;color:var(--dim);font-size:11px;margin:-8px 0 12px">Open-quantum-system engine · Lindblad master equation · unit-tested</p>
 
 <h3>THE MODEL</h3>
@@ -3900,7 +3903,7 @@ function openMenu() {
 <p style="text-align:center;color:var(--dim);margin:-10px 0 10px;font-size:11px;">Qubit Battle Arena — charge, close in, collapse the enemy</p>
 
 <div style="background:linear-gradient(135deg,rgba(47,224,208,0.10),rgba(139,125,255,0.08));border:1px solid var(--border);border-radius:6px;padding:9px 11px;margin:0 0 14px">
-  <p style="color:var(--gold);font-family:var(--pixel);font-size:11px;margin:0 0 6px">⚡ PLAY IN 30 SECONDS</p>
+  <p style="color:var(--gold);font-family:var(--pixel);font-size:11px;margin:0 0 6px">▸ PLAY IN 30 SECONDS</p>
   <p style="color:var(--ink-2);font-size:11px;line-height:1.7;margin:0">
     <b style="color:var(--teal)">1. CHARGE</b> — tap a unit, fire a gate (X = 100% charge, H = 50%).<br>
     <b style="color:var(--teal)">2. STRIKE</b> — move beside a foe and ATTACK; hit chance = your charge (Born rule).<br>
@@ -3912,9 +3915,9 @@ function openMenu() {
   onclick="closeModal();resetGame('vsBot');GAME.difficulty=parseInt(document.getElementById('diff-sel')?document.getElementById('diff-sel').value:1)||1">▶ PLAY vs BOT (1P)</button>
 <button class="btn" onclick="closeModal();resetGame('vs2P')">▶ LOCAL vs FRIEND (2P)</button>
 <hr style="border-color:var(--border);margin:12px 0">
-<button class="btn" onclick="openCampaign()">🎓 TRAINING PROGRAMS (3 missions)</button>
-<button class="btn" onclick="closeModal();openTutorial()">📜 BATTLE MANUAL</button>
-<button class="btn" style="border-color:var(--gold);color:var(--gold)" onclick="openPhysicsLab()">🔬 PHYSICS LAB — inspect the real engine</button>
+<button class="btn" onclick="openCampaign()">◈ TRAINING PROGRAMS (3 missions)</button>
+<button class="btn" onclick="closeModal();openTutorial()">▸ BATTLE MANUAL</button>
+<button class="btn" style="border-color:var(--gold);color:var(--gold)" onclick="openPhysicsLab()">✦ PHYSICS LAB — inspect the real engine</button>
 <hr style="border-color:var(--border);margin:12px 0">
 
 <h3>SETTINGS</h3>
@@ -3977,13 +3980,13 @@ function openTutorial() {
   document.getElementById('modal-content').innerHTML=`
 <h2>◈ QUBLITZ — QUBIT BATTLE ARENA ◈</h2>
 
-<h3>🎯 OBJECTIVE</h3>
+<h3>▸ OBJECTIVE</h3>
 <p>Two armies face off on a grid: <b style="color:#2fe0d0">Elite Knights</b> deploy at the bottom, <b style="color:#ff4d9d">Elite Mages</b> at the top. Each unit is a two-level system |ψ⟩ = α|0⟩ + β|1⟩ with <b>HP</b> and a quantum <b>charge</b>. <b>Eliminate the enemy army</b> to win (or hold the most units, then HP, at the turn limit).</p>
 
-<h3>🎮 HOW A TURN WORKS</h3>
+<h3>▸ HOW A TURN WORKS</h3>
 <p>Click one of <b>your</b> units. Green dots show where it can <b>move</b> (range ${MOVE_RANGE}, blocked by other units). Click a tile to move, or click the unit to stay put — then an <b>action menu</b> opens: Attack, a charge pulse, Entangle, Measure, or End turn. A red ring marks enemies in strike range; click one to attack directly. One unit acts per turn. Keys: [A] attack, [H/X/Y/Z/S/T] charge, [R]/[Shift+R] Ry/Rx, [M] measure, [C] entangle, [Space] end, [ESC] cancel.</p>
 
-<h3>⚔ COMBAT — CHARGE &amp; MEASURE</h3>
+<h3>▸ COMBAT — CHARGE &amp; MEASURE</h3>
 <p>A unit's <b>charge</b> is its |1⟩ amplitude, P(|1⟩). To attack you must be <b>adjacent</b> to an enemy. The strike is a <b>measurement</b> of your unit (Born rule):</p>
 <table>
   <tr><th>Your charge</th><th>Result of attacking</th></tr>
@@ -3993,7 +3996,7 @@ function openTutorial() {
 </table>
 <p>When a strike fires, the <b>target is measured too</b>: if it's caught in |1⟩ it takes a <b>CRITICAL (2 dmg)</b>, otherwise 1. Either way your attacker collapses to |0⟩. <b>Defense:</b> keep idle units near |0⟩ so they're not caught charged.</p>
 
-<h3>🔋 CHARGING (control pulses)</h3>
+<h3>▸ CHARGING (control pulses)</h3>
 <table>
   <tr><th>Pulse</th><th>Effect</th></tr>
   <tr><td>X</td><td>|0⟩→|1⟩ — full charge, guaranteed next strike.</td></tr>
@@ -4003,11 +4006,11 @@ function openTutorial() {
 </table>
 <p style="opacity:.85"><b>GUARD (guardians):</b> braces in the <b>X-basis</b> instead of collapsing to |0⟩. An incoming strike measures the unit as |±⟩, so the relative phase you set with H/S/T/Z decides the crit: a |+⟩ guard is crit-immune, a |0⟩ guard is a coin flip, a |−⟩ guard is fully exposed. Phase finally pays off.</p>
 
-<h3>⚛ DECOHERENCE (Lindblad T1 / T2)</h3>
+<h3>▸ DECOHERENCE (Lindblad T1 / T2)</h3>
 <p>Real qubits don't bleed charge linearly — they decay <b>exponentially</b>. QuBlitz evolves every unit with the exact solution of the <b>Lindblad master equation</b>: excited charge relaxes toward |0⟩ as <b>e<sup>−t/T₁</sup></b> (amplitude damping) while superposition coherence fades as <b>e<sup>−t/T₂</sup></b> (dephasing, with T₂ ≤ 2T₁). On the Bloch sphere the state vector <b>contracts inward</b> as it mixes. So load up and strike <b>soon</b> — charge halves every couple of turns; don't charge a unit that can't reach a target. A fully decohered unit collapses to |0⟩.</p>
 <p style="opacity:.72;font-size:.92em">Verify it yourself: open the browser console and run <code>runDecoherenceDiagnostic()</code> — it fits charge-vs-turns to an exponential and a line and prints R² for each (exponential ≈ 1.000 ≫ linear), recovering the input T₁. <code>QPhysics.selfTest()</code> checks the gate &amp; decoherence math against analytic values.</p>
 
-<h3>🔗 ENTANGLEMENT &amp; 🔍 MEASURE</h3>
+<h3>▸ ENTANGLEMENT &amp; MEASURE</h3>
 <p><b>Entangle (CNOT)</b> links two <b>adjacent</b> units (friend or foe) into a Bell link — a hit on one bleeds <b>1 damage onto the other</b>. Entangle two enemies for splash value. <b>Measure</b> collapses your unit to an eigenstate and restores coherence (+12) — discharge a dangerously-exposed unit, or stabilize one.</p>
 
 <h3>🎨 READING THE BOARD</h3>

--- a/pages/_assets/tests/qphysics.test.js
+++ b/pages/_assets/tests/qphysics.test.js
@@ -1,0 +1,103 @@
+// Regression test for the QPhysics engine. Extracts the REAL C / GATES /
+// QPhysics blocks from quantum_chess.html (no copy) and asserts the critique's
+// physics success criteria. Run: node tests/qphysics.test.js
+const fs = require('fs');
+const path = require('path');
+const htmlPath = process.argv[2] || path.join(__dirname, '..', 'quantum_chess.html');
+const src = fs.readFileSync(htmlPath, 'utf8').split('\n');
+// Find a block by a start-anchor regex, reading until the first line that
+// matches the close regex (robust to line-number drift as the file changes).
+function findBlock(startRe, closeRe) {
+  const start = src.findIndex(l => startRe.test(l));
+  if (start < 0) throw new Error('start not found: ' + startRe);
+  for (let i = start; i < src.length; i++) {
+    if (closeRe.test(src[i])) return src.slice(start, i + 1).join('\n');
+  }
+  throw new Error('close not found for: ' + startRe);
+}
+const piSrc    = src.find(l => /^const π\s*=/.test(l));        // const π = Math.PI;
+const cSrc     = findBlock(/^const C = \{/,        /^};$/);
+const gatesSrc = findBlock(/^const GATES = \{/,    /^};$/);
+const qSrc     = findBlock(/^const QPhysics = \(\(\) => \{/, /^\}\)\(\);$/);
+
+const code = [piSrc, cSrc, gatesSrc, qSrc,
+  'module.exports = QPhysics;'].join('\n');
+const QPhysics = eval('(function(){' + code + '\nreturn module.exports;})()');
+
+let fail = 0;
+const st = QPhysics.selfTest();
+if (!st.pass) { console.error('SELF-TEST FAILED'); fail++; }
+
+console.log('\n--- Falsifiability diagnostic (decoRate=2, 20 turns) ---');
+const d = QPhysics.diagnose({ decoRate: 2, turns: 20 });
+console.log('R²(exponential) =', d.R2_exponential, ' R²(linear) =', d.R2_linear);
+console.log('verdict         =', d.verdict);
+console.log('T1 input/fit    =', d.T1_input, '/', d.T1_recovered);
+console.log('charge by turn  =', d.charge_by_turn.slice(0, 8).join(', '), '...');
+
+// Hard assertions for the critique's success criteria.
+function assert(name, ok) { console.log((ok ? '  ✓ ' : '  ✗ ') + name); if (!ok) fail++; }
+assert('R²(exp) > 0.99 (critique success criterion)', d.R2_exponential > 0.99);
+assert('R²(exp) > R²(lin) — model is exponential, not linear', d.R2_exponential > d.R2_linear);
+assert('fitted T1 recovers input T1 within 1%', Math.abs(d.T1_recovered - d.T1_input) / d.T1_input < 0.01);
+
+// Charge must be monotonically non-increasing for a unit left in |1⟩.
+let mono = true;
+for (let i = 1; i < d.charge_by_turn.length; i++)
+  if (d.charge_by_turn[i] > d.charge_by_turn[i - 1] + 1e-9) mono = false;
+assert('charge decays monotonically toward 0', mono && d.charge_by_turn[20] < 0.05);
+
+// Round-trip: pure→bloch→pure preserves charge for a few states.
+const C0 = QPhysics; const approx = (a, b) => Math.abs(a - b) < 1e-9;
+[[0, 0, 1], [0, 0, -1], [1, 0, 0], [0.3, -0.4, 0.5]].forEach(([x, y, z]) => {
+  const p = C0.pureFromBloch({ x, y, z });
+  const r = C0.blochFromPure(p);
+  assert(`pure↔bloch preserves charge for z=${z}`, approx(C0.charge(r), C0.charge({ x, y, z })));
+});
+
+// ── QB-5: defensive interference makes relative phase mechanically real ──
+// A GUARDing unit is measured in the X-basis, so its crit risk is (1−x)/2.
+console.log('\n--- QB-5 defensive interference (guardCritProb) ---');
+const gcp = QPhysics.guardCritProb;
+const approxP = (a, b) => Math.abs(a - b) < 1e-9;
+assert('|+⟩ (x=+1) guard is crit-immune  → 0%', approxP(gcp({ x: 1, y: 0, z: 0 }), 0));
+assert('|−⟩ (x=−1) guard is fully exposed → 100%', approxP(gcp({ x: -1, y: 0, z: 0 }), 1));
+assert('|0⟩ guard is a coin flip           → 50%', approxP(gcp({ x: 0, y: 0, z: 1 }), 0.5));
+assert('|1⟩ guard is a coin flip           → 50%', approxP(gcp({ x: 0, y: 0, z: -1 }), 0.5));
+// Using phase (reaching |+⟩) must be strictly safer than ignoring it (|0⟩):
+assert('phase-aware |+⟩ guard beats naive |0⟩ guard',
+  gcp({ x: 1, y: 0, z: 0 }) < gcp({ x: 0, y: 0, z: 1 }));
+
+// ── QB-6: real 2-qubit Bell pair (correlated collapse + no-communication) ──
+console.log('\n--- QB-6 Bell pair (entanglement) ---');
+const Bell = QPhysics.Bell;
+
+// |Φ+⟩ marginals are 50/50 on each qubit.
+assert('Bell |Φ+⟩ marginal P1(q0) = 0.5', approx(Bell.marginalP1(Bell.phiPlus(), 0), 0.5));
+assert('Bell |Φ+⟩ marginal P1(q1) = 0.5', approx(Bell.marginalP1(Bell.phiPlus(), 1), 0.5));
+
+// Measuring one half forces the partner to the SAME outcome (perfect correlation).
+{
+  let correlated = true;
+  for (const r of [0.1, 0.9, 0.49, 0.51, 0.0, 0.999]) {
+    const res = Bell.measure(Bell.phiPlus(), 0, () => r);
+    if (res.outcome !== res.partnerOutcome) correlated = false;
+  }
+  assert('measuring q0 collapses q1 to the correlated outcome', correlated);
+}
+
+// No-communication: a LOCAL gate on q0 must not change q1's marginal.
+{
+  const X = QPhysics.gateMatrix('X');
+  const H = QPhysics.gateMatrix('H');
+  const Z = QPhysics.gateMatrix('Z');
+  let invariant = true;
+  for (const U of [X, H, Z]) {
+    const after = Bell.applyLocal(Bell.phiPlus(), 0, U);
+    if (!approx(Bell.marginalP1(after, 1), 0.5)) invariant = false;
+  }
+  assert('local gate on q0 leaves q1 marginal unchanged (no-communication)', invariant);
+}
+
+console.log(fail === 0 ? '\nALL CHECKS PASSED ✓' : `\n${fail} CHECK(S) FAILED ✗`);
+process.exit(fail === 0 ? 0 : 1);

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -q

--- a/quantum_simulator.py
+++ b/quantum_simulator.py
@@ -1,4 +1,5 @@
 import numpy as np
+import streamlit as st
 from qutip import basis, sigmaz, sigmax, sigmay, mesolve, sigmam, Options
 
 
@@ -44,13 +45,22 @@ def run_frequency_sweep(start_freq, stop_freq, num_points, t_final, n_steps,
     }
 
 
-def run_quantum_simulation(omega_q, omega_rabi, t_final, n_steps, omega_d,
-                           user_vector_I, user_vector_Q, num_shots, T1, T2):
-    tlist = np.linspace(0.0, t_final, n_steps)
+@st.cache_data(show_spinner=False)
+def _solve_mesolve(omega_q, omega_rabi, t_final, n_steps, omega_d,
+                   user_vector_I, user_vector_Q, T1, T2):
+    """Deterministic, expensive part: the Lindblad ODE solve.
 
+    Cached so that an identical re-run (the common case on every Streamlit
+    rerun where only an unrelated widget moved) returns instantly instead of
+    re-integrating ``mesolve``. Returns ``(expect, probabilities)`` where
+    ``expect`` is [<sigma_x>, <sigma_y>, <sigma_z>] over time and
+    ``probabilities`` is P(|1>) per time step. The stochastic shot sampling is
+    kept OUT of the cache (see ``run_quantum_simulation``) so it stays random.
+    """
     H0 = 2.0 * np.pi * omega_q * sigmaz() / 2.0
     H1 = 2.0 * np.pi * omega_rabi * sigmax()
     H2 = 2.0 * np.pi * omega_rabi * sigmay()
+    tlist = np.linspace(0.0, t_final, n_steps)
 
     def _coeff(env):
         return lambda t, args: float(env[min(int(t / t_final * n_steps), n_steps - 1)]) * np.cos(args['w'] * t)
@@ -85,15 +95,27 @@ def run_quantum_simulation(omega_q, omega_rabi, t_final, n_steps, omega_d,
         args={'w': 2.0 * np.pi * omega_d}, options=options
     )
 
-    probabilities = []
-    sampled_probabilities = []
+    probabilities = [
+        float(np.clip(_state_excited_population(state), 0.0, 1.0))
+        for state in result.states
+    ]
+    return result.expect, probabilities
 
-    for state in result.states:
-        prob_1 = np.clip(_state_excited_population(state), 0.0, 1.0)
-        prob_0 = 1.0 - prob_1
-        probabilities.append(prob_1)
 
-        samples = np.random.choice([0, 1], size=num_shots, p=[prob_0, prob_1])
-        sampled_probabilities.append(float(np.mean(samples == 1)))
+def run_quantum_simulation(omega_q, omega_rabi, t_final, n_steps, omega_d,
+                           user_vector_I, user_vector_Q, num_shots, T1, T2):
+    expect, probabilities = _solve_mesolve(
+        omega_q, omega_rabi, t_final, n_steps, omega_d,
+        user_vector_I, user_vector_Q, T1, T2
+    )
 
-    return result.expect, probabilities, sampled_probabilities
+    # Vectorized shot sampling: one np.random.binomial over all time steps at
+    # once (was a per-time-step np.random.choice loop drawing num_shots samples
+    # each). Statistically identical: the sampled |1> fraction per step.
+    probs = np.asarray(probabilities, dtype=float)
+    if num_shots and num_shots > 0:
+        sampled_probabilities = (np.random.binomial(num_shots, probs) / num_shots).tolist()
+    else:
+        sampled_probabilities = probs.tolist()
+
+    return expect, probabilities, sampled_probabilities

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Development / CI tooling (not needed to run the app).
+-r requirements.txt
+pytest==8.3.4
+ruff==0.8.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -5,6 +5,11 @@
 line-length = 120
 target-version = "py312"
 
+# extra_pages/ holds incomplete challenge scaffolding (Gates / Step-Pulse) slated
+# for completion in a later cycle (roadmap C06). It is not wired into the app's
+# sidebar; exclude it from the gate until it is finished rather than churn WIP code.
+extend-exclude = ["extra_pages"]
+
 [lint]
 select = ["E9", "F"]
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,14 @@
+# Correctness-focused lint config. We gate on pyflakes (real bugs: undefined
+# names, unused/duplicate imports, wildcard imports) plus syntax errors, and
+# deliberately do NOT enforce whole-repo style (E501 line length, etc.) so the
+# gate stays meaningful without churning the lab's existing pages.
+line-length = 120
+target-version = "py312"
+
+[lint]
+select = ["E9", "F"]
+
+# Streamlit pages are executed top-to-bottom by the framework with __name__ set
+# to "__main__"; module-level "unused" names are sometimes the rendered output.
+[lint.per-file-ignores]
+"tests/*" = ["F401"]

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Local debugging gate for the Qublitz fork. Runs the same checks as CI:
+# ruff lint + pytest smoke tests + (when vendored) the game physics test.
+# Prints a single PASS/FAIL and exits non-zero if anything fails.
+#
+#   bash scripts/verify.sh
+#
+# Run this GREEN before any push or pull request.
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 2
+
+# Prefer the local venv interpreter if present, else fall back to python3.
+PY=".venv/bin/python"
+[ -x "$PY" ] || PY="$(command -v python3)"
+
+fail=0
+run() {
+  local name="$1"; shift
+  echo "── $name ──────────────────────────────────────────────"
+  if "$@"; then
+    echo "  ✓ $name"
+  else
+    echo "  ✗ $name"
+    fail=1
+  fi
+  echo
+}
+
+run "ruff (lint)"          "$PY" -m ruff check .
+run "pytest (smoke tests)" "$PY" -m pytest -q
+
+# Game physics regression test — only once the game is vendored (C02-T4).
+GAME_TEST="pages/_assets/tests/qphysics.test.js"
+GAME_HTML="pages/_assets/quantum_chess.html"
+if [ -f "$GAME_TEST" ]; then
+  if command -v node >/dev/null 2>&1; then
+    run "node (game physics)" node "$GAME_TEST" "$GAME_HTML"
+  else
+    echo "── node (game physics) ── SKIPPED: node not installed"; echo
+  fi
+fi
+
+echo "════════════════════════════════════════════════════════"
+if [ "$fail" -eq 0 ]; then
+  echo "VERIFY: PASS ✓  — safe to push / open a PR"
+else
+  echo "VERIFY: FAIL ✗  — fix the above before pushing"
+fi
+exit "$fail"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Shared test setup for the Qublitz smoke suite.
+
+Run everything from the repo root so that (a) pages loading relative assets
+(``images/...``) resolve them, and (b) pages doing ``from quantum_simulator
+import ...`` can find the top-level module.
+"""
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+os.chdir(ROOT)
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/tests/test_pages_smoke.py
+++ b/tests/test_pages_smoke.py
@@ -1,0 +1,46 @@
+"""Smoke tests: every Streamlit page must load without raising.
+
+Most pages are rendered headless with ``streamlit.testing.v1.AppTest`` and
+asserted to raise no exception. Two pages cannot run headless in CI — they
+either talk to a lab backend or auto-run a full ``mesolve`` on load — so they
+are syntax/compile-checked instead. After C02-T12 removes the auto-simulation,
+``Qubit_Simulator.py`` can graduate to the rendered list.
+"""
+import os
+import py_compile
+
+import pytest
+from streamlit.testing.v1 import AppTest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Pages safe to fully render headless (no external backend, no minutes-long solve).
+RENDER_PAGES = [
+    "home.py",
+    "pages/QuBlitz_Arena.py",
+    "pages/Laser_Heating_Calculator.py",
+    "pages/Quantum_Measurement_Tutorial.py",
+    "pages/IQ_mixer.py",
+    "pages/Dilution_Refrigerator_Noise_Explorer.py",
+    "pages/EP_TPD_exploration.py",
+    "pages/Sonify.py",
+]
+
+# Pages that hit a lab API or auto-run a full mesolve on load: compile-check only.
+COMPILE_ONLY = [
+    "quantum_simulator.py",
+    "pages/Custom_Qubit_Query.py",
+    "pages/Qubit_Simulator.py",
+]
+
+
+@pytest.mark.parametrize("page", RENDER_PAGES)
+def test_page_renders_without_exception(page):
+    at = AppTest.from_file(os.path.join(ROOT, page), default_timeout=90)
+    at.run()
+    assert not at.exception, f"{page} raised on load: {at.exception}"
+
+
+@pytest.mark.parametrize("page", COMPILE_ONLY)
+def test_page_compiles(page):
+    py_compile.compile(os.path.join(ROOT, page), doraise=True)

--- a/tests/test_pages_smoke.py
+++ b/tests/test_pages_smoke.py
@@ -1,10 +1,10 @@
 """Smoke tests: every Streamlit page must load without raising.
 
-Most pages are rendered headless with ``streamlit.testing.v1.AppTest`` and
-asserted to raise no exception. Two pages cannot run headless in CI — they
-either talk to a lab backend or auto-run a full ``mesolve`` on load — so they
-are syntax/compile-checked instead. After C02-T12 removes the auto-simulation,
-``Qubit_Simulator.py`` can graduate to the rendered list.
+Every page is rendered headless with ``streamlit.testing.v1.AppTest`` and
+asserted to raise no exception. Since C02-T12 gated the time-domain ``mesolve``
+behind a Run button, the two simulator pages no longer auto-solve on load and
+render headless too (the lab-API page short-circuits at its login prompt).
+``quantum_simulator.py`` is a library, not a page, so it is compile-checked.
 """
 import os
 import py_compile
@@ -14,7 +14,7 @@ from streamlit.testing.v1 import AppTest
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-# Pages safe to fully render headless (no external backend, no minutes-long solve).
+# Pages safe to fully render headless (no external backend call, no auto-solve).
 RENDER_PAGES = [
     "home.py",
     "pages/QuBlitz_Arena.py",
@@ -24,13 +24,13 @@ RENDER_PAGES = [
     "pages/Dilution_Refrigerator_Noise_Explorer.py",
     "pages/EP_TPD_exploration.py",
     "pages/Sonify.py",
+    "pages/Qubit_Simulator.py",
+    "pages/Custom_Qubit_Query.py",
 ]
 
-# Pages that hit a lab API or auto-run a full mesolve on load: compile-check only.
+# Library modules (not Streamlit pages): syntax/compile-check only.
 COMPILE_ONLY = [
     "quantum_simulator.py",
-    "pages/Custom_Qubit_Query.py",
-    "pages/Qubit_Simulator.py",
 ]
 
 

--- a/tests/test_qublitz_arena.py
+++ b/tests/test_qublitz_arena.py
@@ -1,7 +1,8 @@
-"""Focused test for the QuBlitz Arena page (David's contribution).
+"""Focused tests for the QuBlitz Arena page (David's contribution).
 
-Asserts the page renders without error and shows its title. The embed marker
-assertion is tightened in C02-T4 once the live game is embedded.
+Asserts the page renders, shows its title, carries the academic framing
+(the concept map / objectives), and that the live game is actually vendored
+for the embed.
 """
 import os
 
@@ -9,10 +10,11 @@ from streamlit.testing.v1 import AppTest
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ARENA = os.path.join(ROOT, "pages", "QuBlitz_Arena.py")
+GAME_ASSET = os.path.join(ROOT, "pages", "_assets", "quantum_chess.html")
 
 
 def _run():
-    at = AppTest.from_file(ARENA, default_timeout=60)
+    at = AppTest.from_file(ARENA, default_timeout=90)
     at.run()
     return at
 
@@ -26,3 +28,16 @@ def test_arena_shows_title():
     at = _run()
     titles = [t.value for t in at.title]
     assert any("QuBlitz Arena" in t for t in titles), f"title not found in {titles}"
+
+
+def test_arena_has_academic_framing():
+    at = _run()
+    blob = " ".join(m.value for m in at.markdown)
+    assert "Born rule" in blob, "expected the concept map / Born-rule framing to render"
+    assert "Learning objectives" in blob or "learning" in blob.lower()
+
+
+def test_game_is_vendored_for_embed():
+    # The embed reads this file; it must exist and be the real (large) game.
+    assert os.path.exists(GAME_ASSET), "vendored quantum_chess.html missing"
+    assert os.path.getsize(GAME_ASSET) > 100_000, "vendored game looks truncated"

--- a/tests/test_qublitz_arena.py
+++ b/tests/test_qublitz_arena.py
@@ -1,0 +1,28 @@
+"""Focused test for the QuBlitz Arena page (David's contribution).
+
+Asserts the page renders without error and shows its title. The embed marker
+assertion is tightened in C02-T4 once the live game is embedded.
+"""
+import os
+
+from streamlit.testing.v1 import AppTest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ARENA = os.path.join(ROOT, "pages", "QuBlitz_Arena.py")
+
+
+def _run():
+    at = AppTest.from_file(ARENA, default_timeout=60)
+    at.run()
+    return at
+
+
+def test_arena_renders_without_exception():
+    at = _run()
+    assert not at.exception, f"Arena raised on load: {at.exception}"
+
+
+def test_arena_shows_title():
+    at = _run()
+    titles = [t.value for t in at.title]
+    assert any("QuBlitz Arena" in t for t in titles), f"title not found in {titles}"

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,0 +1,41 @@
+"""Regression tests for the cached simulator hot path (C02-T10).
+
+Guards the @st.cache_data refactor of ``run_quantum_simulation``: the
+deterministic Lindblad solve must be stable across identical calls, while the
+vectorized shot sampling stays stochastic and tracks P(|1>).
+"""
+import numpy as np
+
+import quantum_simulator as qs
+
+N = 24
+COMMON = dict(
+    omega_q=5.0, omega_rabi=0.05, t_final=20.0, n_steps=N, omega_d=5.0,
+    user_vector_I=np.ones(N), user_vector_Q=np.zeros(N), T1=0.0, T2=0.0,
+)
+
+
+def test_solve_is_cached():
+    assert hasattr(qs._solve_mesolve, "clear"), "expected an @st.cache_data function"
+
+
+def test_shapes_and_bounds():
+    expect, probs, sampled = qs.run_quantum_simulation(num_shots=256, **COMMON)
+    assert len(expect) == 3 and all(len(e) == N for e in expect)
+    assert len(probs) == N and all(0.0 <= p <= 1.0 for p in probs)
+    assert len(sampled) == N and all(0.0 <= s <= 1.0 for s in sampled)
+
+
+def test_solve_deterministic_but_sampling_stochastic():
+    _, p1, s1 = qs.run_quantum_simulation(num_shots=256, **COMMON)
+    _, p2, s2 = qs.run_quantum_simulation(num_shots=256, **COMMON)
+    # The expensive solve is deterministic (and cache-stable)…
+    assert np.allclose(p1, p2)
+    # …but the shot sampling is fresh each call.
+    assert not np.allclose(s1, s2)
+
+
+def test_sampling_tracks_probabilities():
+    _, probs, sampled = qs.run_quantum_simulation(num_shots=4000, **COMMON)
+    # With many shots the sampled |1> fraction is close to the true probability.
+    assert float(np.mean(np.abs(np.array(sampled) - np.array(probs)))) < 0.05

--- a/utils/branding.py
+++ b/utils/branding.py
@@ -1,0 +1,14 @@
+"""Shared, cached loaders for the static sidebar branding images.
+
+Every page used to call ``Image.open("images/qublitz.png")`` and
+``Image.open("images/logo.png")`` in its sidebar on *every* Streamlit rerun,
+re-decoding the PNGs from disk each time. ``@st.cache_resource`` decodes them
+once per process and hands back the same object thereafter.
+"""
+import streamlit as st
+from PIL import Image
+
+
+@st.cache_resource(show_spinner=False)
+def load_logo(path: str) -> Image.Image:
+    return Image.open(path)

--- a/utils/sonify.py
+++ b/utils/sonify.py
@@ -1,5 +1,4 @@
 import numpy as np
-from PIL import Image
 import soundfile as sf
 import tempfile
 


### PR DESCRIPTION
## Summary

Adds **QuBlitz Arena** (`pages/QuBlitz_Arena.py`), David's contribution page: a self-contained, single-file HTML5 quantum-tactics game (`pages/_assets/quantum_chess.html`) embedded in the Streamlit platform, backed by a unit-tested open-quantum-systems physics engine (`QPhysics` — exact Lindblad T1/T2 decoherence, Born-rule measurement, Bell-pair entanglement).

This bundles the full cycle of work on this feature: initial embed + academic framing, CI/lint/test scaffolding, several performance passes (cached `mesolve` solves, cached field computations, dead-import cleanup), an in-game visual/pedagogy pass (Bloch-sphere X-basis labels, Sage AI advisor UX), and — most recently — a full remediation pass driven by an independent LLM-council review of the game's UI and teaching effectiveness:

- **UI defect fixes**: side-panel text collisions, a mislabeled bot speaker line, a button-row overlap bug (turned out to be caused by the canvas being sized off viewport *height*, not width — fixed properly, not just at the originally-suspected breakpoint), a turn-banner/sprite overlap, and Sage-panel vertical-space trimming for the embed height.
- **Honest framing**: the Physics Lab's "falsifiability" screen was retitled — it validates the *implementation* against the model, not physical reality — and page copy overclaims about proven learning outcomes were softened to state what's demonstrated vs. what's a design goal under future evaluation.
- **Misconception fix**: every `|1⟩`/charge/MEASURE string a player sees now pairs the game mechanic with the physical truth (the excited state is fragile and decays for a real physical reason, not "ammo").
- **Incentive tuning**: the bot AI now uses the existing GUARD mechanic (X-basis crit rule) so relative-phase play has a real payoff — validated with a new headless bot-vs-bot harness (`tests/bot_guard_harness.test.js`). One target from that harness (X-only play losing ≥65% of games) is **not yet met** — it currently sits at 38.5%, because the default army's warrior units have no GUARD lever at all, so warrior-vs-warrior combat is an inherent ~50/50 no bot policy can move. The mixed/phase-aware policy does clear its target (55.5% ≥ 50%). This is called out explicitly in the test file and is a known follow-up (likely needs an army-composition or warrior-defense change, tracked for a later iteration).

## Review guide

This is a large diff (`quantum_chess.html` alone is ~4,300 lines) and not realistically reviewable line-by-line. **`docs/PR_REVIEW_GUIDE.md`** (included in this PR) maps the 10 structural anchor points (physics engine, Born-rule/GUARD/Lindblad logic, Bell-pair state, bot AI, Sage proxy security boundary, renderer, UI panels), the in-browser console self-tests, and how to run the verification gates — aimed at getting a reviewer from clone to informed approve in ~20 minutes.

## How to test locally
- `bash scripts/verify.sh` — runs ruff, pytest smoke tests (incl. a Streamlit AppTest render of the Arena page), and the vendored game's physics regression test. Confirmed green locally (ruff clean, pytest passing incl. qutip-dependent simulator tests, `node` physics test all-green).
- Game physics engine directly: `node pages/_assets/tests/qphysics.test.js pages/_assets/quantum_chess.html`.
- Bot-incentive harness (canonical repo, not yet vendored into this fork): `node tests/bot_guard_harness.test.js` — see the shortfall note above.
- Standalone: open `pages/_assets/quantum_chess.html` directly in Chrome (self-contained, no server needed); open the browser console and run `QPhysics.selfTest()` / `QPhysics.diagnose({decoRate:2, turns:20})`.

## Screenshots

Screenshots (menu, board play, selected-unit panel, GUARD state, Sage panel, Physics Lab, and a 768px tablet capture) were captured against this branch and reviewed for the UI fixes above, but aren't attached to this PR body directly (avoiding binary bloat in the diff) — happy to attach them here or in a comment if useful for review.

## Note

An accidentally-committed `venv_qublitz/` virtualenv on `main` is being removed in a separate, smaller PR (#27) so it doesn't bury this diff in ~185k unrelated deleted lines.